### PR TITLE
fix: apply naming rules

### DIFF
--- a/.github/AUTHORS.txt
+++ b/.github/AUTHORS.txt
@@ -1,4 +1,4 @@
-# This is the official list of ods-ios authors for copyright purposes.
+# This is the official list of ouds-ios authors for copyright purposes.
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 #
-# Software Name: Orange Unified Design System
+# Software Name: OUDS iOS
 # SPDX-FileCopyrightText: Copyright (c) Orange SA
 # SPDX-License-Identifier: MIT
 #

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Orange Unified Design System iOS
+# Contributing to OUDS iOS
 
-Looking to contribute something to Orange Unified Design System iOS? **Here's how you can help.**
+Looking to contribute something OUDS iOS? **Here's how you can help.**
 
 Please take a moment to review this document in order to make the contribution process easy for everyone involved.
 
@@ -8,9 +8,9 @@ Following these guidelines helps to communicate that you respect the time of the
 
 ## Using the Issue Tracker
 
-The [issue tracker](https://github.com/uds-sandbox/uds-ios/issues) is the preferred channel for [bug reports](#bug-reports), [feature requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
+The [issue tracker](https://github.com/ouds-sandbox/ouds-ios/issues) is the preferred channel for [bug reports](#bug-reports), [feature requests](#feature-requests) and [submitting pull requests](#pull-requests), but please respect the following restrictions:
 
-- Please **do not** use the issue tracker for personal support requests. [GitHub Discussions](https://github.com/uds-sandbox/uds-ios/discussions/categories/q-a) or our internal Orange communication tools are better places to get help.
+- Please **do not** use the issue tracker for personal support requests. [GitHub Discussions](https://github.com/ouds-sandbox/ouds-ios/discussions/categories/q-a) or our internal Orange communication tools are better places to get help.
 
 - Please **do not** derail or troll issues. Keep the discussion on topic and respect the opinions of others.
 
@@ -23,7 +23,7 @@ Our bug tracker utilizes several labels to help organize and identify issues. He
 - `feature` - Issues asking for a new feature to be added, or an existing one to be extended or modified. New features require a minor version bump (e.g., `v1.0.0` to `v1.1.0`).
 - `help wanted` - Issues we need or would love help from the community to resolve.
 
-For a complete look at our labels, see the [project labels page](https://github.com/uds-sandbox/uds-ios/labels).
+For a complete look at our labels, see the [project labels page](https://github.com/ouds-sandbox/ouds-ios/labels).
 
 ## Bug Reports
 
@@ -75,11 +75,11 @@ Adhering to the following process is the best way to get your work included in t
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/uds-ios.git
+   git clone https://github.com/<your-username>/ouds-ios.git
    # Navigate to the newly cloned directory
-   cd uds-ios
+   cd ouds-ios
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/Orange-OpenSource/uds-ios.git
+   git remote add upstream https://github.com/Orange-OpenSource/ouds-ios.git
    ```
 
 2. If you cloned a while ago, get the latest changes from upstream:

--- a/.github/CONTRIBUTORS.txt
+++ b/.github/CONTRIBUTORS.txt
@@ -1,5 +1,5 @@
 # This is the official list of people have contributed code to the
-# uds-ios repository.
+# ouds-ios repository.
 #
 # The AUTHORS file lists the copyright holders; this file
 # lists people.  For example, Orange employees are listed here

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Report a bug
-description: Tell us about a bug or issue you may have identified in UDS iOS.
+description: Tell us about a bug or issue you may have identified in OUDS iOS.
 title: "[Bug]: Bug Summary"
 labels: ["🐞 bug", "🔍 triage"]
 assignees: ["ludovic35", "pylapp"]
@@ -9,7 +9,7 @@ body:
       label: Prerequisites
       description: Take a couple minutes to help our maintainers work faster.
       options:
-        - label: I have [searched the backlog](https://github.com/uds-sandbox/uds-ios/issues) for duplicate or closed feature requests
+        - label: I have [searched the backlog](https://github.com/ouds-sandbox/ouds-ios/issues) for duplicate or closed feature requests
           required: true
   - type: input
     id: device

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -9,7 +9,7 @@ body:
       label: Prerequisites
       description: Take a couple minutes to help our maintainers work faster.
       options:
-        - label: I have [searched the backlog](https://github.com/uds-sandbox/uds-ios/issues) for duplicate or closed feature requests
+        - label: I have [searched the backlog](https://github.com/ouds-sandbox/ouds-ios/issues) for duplicate or closed feature requests
           required: true
   - type: markdown
     attributes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# UDS iOS library changelog
+# OUDS iOS library changelog
 
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-<h1 align="center">Orange Unified Design System iOS</h1>
+<h1 align="center">OUDS iOS</h1>
 
 <p align="center">
-  Orange Unified Design System iOS provides Orange iOS components to developers and a demo application.
+  OUDS iOS provides Orange iOS components to developers and a demo application.
   <br>
-  <a href="https://github.com/uds-sandbox/uds-ios/issues/new?assignees=pylapp&labels=%F0%9F%90%9E%20bug%2C%F0%9F%94%8D+triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
+  <a href="https://github.com/ouds-sandbox/ouds-ios/issues/new?assignees=pylapp&labels=%F0%9F%90%9E%20bug%2C%F0%9F%94%8D+triage&template=bug_report.yml&title=[Bug]%3A+Bug+Summary">Report bug</a>
   ·
-  <a href="https://github.com/uds-sandbox/uds-ios/issues/new?assignees=pylapp&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+">Request feature</a>
+  <a href="https://github.com/ouds-sandbox/ouds-ios/issues/new?assignees=pylapp&labels=feature%2C%F0%9F%94%8D%20triage&template=feature_request.yml&title=[feature]%3A+">Request feature</a>
 </p>
 
 ## Table of contents
@@ -18,23 +18,23 @@
 
 ## Status
 
-[![MIT license](https://img.shields.io/github/license/uds-sandbox/uds-ios)](https://github.com/uds-sandbox/uds-ios/blob/main/LICENSE)
+[![MIT license](https://img.shields.io/github/license/ouds-sandbox/ouds-ios)](https://github.com/ouds-sandbox/ouds-ios/blob/main/LICENSE)
 [![iOS 15.0](https://img.shields.io/badge/iOS-15.0-informational.svg)](https://developer.apple.com/support/app-store "iOS 15 supports")
-[![Still maintained](https://img.shields.io/maintenance/yes/2024)](https://github.com/uds-sandbox/uds-ios/issues?q=is%3Aissue+is%3Aclosed)
-[![Code size](https://img.shields.io/github/languages/code-size/uds-sandbox/uds-ios)](https://github.com/uds-sandbox/uds-ios)
+[![Still maintained](https://img.shields.io/maintenance/yes/2024)](https://github.com/ouds-sandbox/ouds-ios/issues?q=is%3Aissue+is%3Aclosed)
+[![Code size](https://img.shields.io/github/languages/code-size/ouds-sandbox/ouds-ios)](https://github.com/ouds-sandbox/ouds-ios)
 
 ## Content
 
-This repository contains the Orange Unified Design System iOS library that provides Orange iOS components, but also a demo application showcasing these different components.
+This repository contains the OUDS iOS library that provides Orange iOS components, but also a demo application showcasing these different components.
 
 ## Bugs and feature requests
 
-Have a bug or a feature request? Please first search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/uds-sandbox/uds-ios/issues/new/choose).
+Have a bug or a feature request? Please first search for existing and closed issues. If your problem or idea is not addressed yet, [please open a new issue](https://github.com/ouds-sandbox/ouds-ios/issues/new/choose).
 
 ## Contributing
 
-Please read through our [contributing guidelines](https://github.com/uds-sandbox/uds-ios/blob/main/.github/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
+Please read through our [contributing guidelines](https://github.com/ouds-sandbox/ouds-ios/blob/main/.github/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
 
 ## Copyright and license
 
-Code released under the [MIT License](https://github.com/uds-sandbox/uds-ios/blob/main/LICENSE).
+Code released under the [MIT License](https://github.com/ouds-sandbox/ouds-ios/blob/main/LICENSE).


### PR DESCRIPTION
### Description

This PR applies the naming rules for OUDS iOS.

I searched for the following patterns:
* "Orange D"
* "ODS"
* "UDS"
* "uds-"
* "ods-"

Hope that I haven't forgotten anything 😇 
Feel free to override my modifications or close the PR if you want to do it differently :)