### PR TITLE
[#29] Add raw tokens and semantic tokens for opacity 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Library] Add raw tokens and semantic tokens for opacity ([#29](https://github.com/Orange-OpenSource/ouds-ios/issues/29))
 - [Showcase] Publication of comment on issues about new alpha build upload on TestFlight ([#56](https://github.com/Orange-OpenSource/ouds-ios/issues/56))
 - [Library] Add raw tokens and semantic tokens for border ([#30](https://github.com/Orange-OpenSource/ouds-ios/issues/30))
 - [Library] Define Swift Package architecture of library and tokens (raw and semantic) ([#33](https://github.com/Orange-OpenSource/ouds-ios/issues/33))

--- a/OUDS/Core/Themes/Sources/Shared/OUDSTheme+SemanticTokens/OUDSTheme+OpacitySemanticTokens.swift
+++ b/OUDS/Core/Themes/Sources/Shared/OUDSTheme+SemanticTokens/OUDSTheme+OpacitySemanticTokens.swift
@@ -22,7 +22,7 @@ extension OUDSTheme: OpacitySemanticTokens {
     @objc open var opacityTransparent: OpacitySemanticToken { OpacityRawTokens.opacity0 }
     @objc open var opacityWeaker: OpacitySemanticToken { OpacityRawTokens.opacity100 }
     @objc open var opacityWeak: OpacitySemanticToken { OpacityRawTokens.opacity300 }
-    @objc open var opacityMedum: OpacitySemanticToken { OpacityRawTokens.opacity500 }
+    @objc open var opacityMedium: OpacitySemanticToken { OpacityRawTokens.opacity500 }
     @objc open var opacityEmphasis: OpacitySemanticToken { OpacityRawTokens.opacity700 }
     @objc open var opacityOpaque: OpacitySemanticToken { OpacityRawTokens.opacity900 }
 }

--- a/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfOpacitySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfOpacitySemanticTokens.swift
@@ -1,0 +1,51 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import XCTest
+@testable import OUDSThemesShared
+
+/// The architecture of _OUDS iOS_ _Swift package_ library is based on _object oriented paradigm_ and overriding of classes.
+/// In factn the `OUDSTheme` object is a class, which can be seens as an _asbtract class_, exposing through its extensions and protocols _opacity semantic tokens_.
+/// These semantic tokens should be overriden by subclass like the `OrangeTheme` default theme.
+/// **These tests checks if any _opacity semantic tokens_ can be surcharged by a child theme**
+final class ThemeOverrideOfOpacitySemanticTokens: XCTestCase {
+
+    private var abstractTheme: OUDSTheme!
+    private var inheritedTheme: OUDSTheme!
+
+    override func setUp() async throws {
+        abstractTheme = OUDSTheme()
+        inheritedTheme = MockTheme()
+    }
+
+    /// Test overriding of opacity width semantic tokens
+    func testInheritedThemeCanOverrideOpacitySemanticTokens() throws {
+        XCTAssertNotEqual(inheritedTheme.opacityTransparent, abstractTheme.opacityTransparent)
+        XCTAssertTrue(inheritedTheme.opacityTransparent == MockTheme.mockThemeOpacityRawToken)
+
+        XCTAssertNotEqual(inheritedTheme.opacityWeaker, abstractTheme.opacityWeaker)
+        XCTAssertTrue(inheritedTheme.opacityWeaker == MockTheme.mockThemeOpacityRawToken)
+
+        XCTAssertNotEqual(inheritedTheme.opacityWeak, abstractTheme.opacityWeak)
+        XCTAssertTrue(inheritedTheme.opacityWeak == MockTheme.mockThemeOpacityRawToken)
+
+        XCTAssertNotEqual(inheritedTheme.opacityMedum, abstractTheme.opacityMedum)
+        XCTAssertTrue(inheritedTheme.opacityMedum == MockTheme.mockThemeOpacityRawToken)
+
+        XCTAssertNotEqual(inheritedTheme.opacityEmphasis, abstractTheme.opacityEmphasis)
+        XCTAssertTrue(inheritedTheme.opacityEmphasis == MockTheme.mockThemeOpacityRawToken)
+
+        XCTAssertNotEqual(inheritedTheme.opacityOpaque, abstractTheme.opacityOpaque)
+        XCTAssertTrue(inheritedTheme.opacityOpaque == MockTheme.mockThemeOpacityRawToken)
+    }
+}

--- a/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfOpacitySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfOpacitySemanticTokens.swift
@@ -28,23 +28,32 @@ final class ThemeOverrideOfOpacitySemanticTokens: XCTestCase {
         inheritedTheme = MockTheme()
     }
 
-    /// Test overriding of opacity width semantic tokens
-    func testInheritedThemeCanOverrideOpacitySemanticTokens() throws {
+    func testInheritedThemeCanOverrideSemanticTokenOpacityTransparent() throws {
         XCTAssertNotEqual(inheritedTheme.opacityTransparent, abstractTheme.opacityTransparent)
         XCTAssertTrue(inheritedTheme.opacityTransparent == MockTheme.mockThemeOpacityRawToken)
+    }
 
+    func testInheritedThemeCanOverrideSemanticTokenOpacityWeaker() throws {
         XCTAssertNotEqual(inheritedTheme.opacityWeaker, abstractTheme.opacityWeaker)
         XCTAssertTrue(inheritedTheme.opacityWeaker == MockTheme.mockThemeOpacityRawToken)
+    }
 
+    func testInheritedThemeCanOverrideSemanticTokenOpacityWeak() throws {
         XCTAssertNotEqual(inheritedTheme.opacityWeak, abstractTheme.opacityWeak)
         XCTAssertTrue(inheritedTheme.opacityWeak == MockTheme.mockThemeOpacityRawToken)
+    }
 
-        XCTAssertNotEqual(inheritedTheme.opacityMedum, abstractTheme.opacityMedum)
-        XCTAssertTrue(inheritedTheme.opacityMedum == MockTheme.mockThemeOpacityRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenOpacityMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.opacityMedium, abstractTheme.opacityMedium)
+        XCTAssertTrue(inheritedTheme.opacityMedium == MockTheme.mockThemeOpacityRawToken)
+    }
 
+    func testInheritedThemeCanOverrideSemanticTokenOpacityEmphasis() throws {
         XCTAssertNotEqual(inheritedTheme.opacityEmphasis, abstractTheme.opacityEmphasis)
         XCTAssertTrue(inheritedTheme.opacityEmphasis == MockTheme.mockThemeOpacityRawToken)
+    }
 
+    func testInheritedThemeCanOverrideSemanticTokenOpacityOpaque() throws {
         XCTAssertNotEqual(inheritedTheme.opacityOpaque, abstractTheme.opacityOpaque)
         XCTAssertTrue(inheritedTheme.opacityOpaque == MockTheme.mockThemeOpacityRawToken)
     }

--- a/OUDS/Core/Themes/Tests/Shared/_/MockTheme+OpacitySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/_/MockTheme+OpacitySemanticTokens.swift
@@ -22,7 +22,7 @@ extension MockTheme {
     override var opacityTransparent: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
     override var opacityWeaker: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
     override var opacityWeak: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
-    override var opacityMedum: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityMedium: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
     override var opacityEmphasis: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
     override var opacityOpaque: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
 }

--- a/OUDS/Core/Themes/Tests/Shared/_/MockTheme+OpacitySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/_/MockTheme+OpacitySemanticTokens.swift
@@ -1,0 +1,28 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensRaw
+import OUDSTokensSemantic
+
+extension MockTheme {
+
+    static let mockThemeOpacityRawToken: OpacityRawToken = 713
+
+    override var opacityTransparent: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityWeaker: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityWeak: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityMedum: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityEmphasis: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+    override var opacityOpaque: OpacitySemanticToken { Self.mockThemeOpacityRawToken }
+}

--- a/OUDS/Core/Tokens/RawTokens/Tests/OpacityRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/OpacityRawTokensTests.swift
@@ -1,0 +1,36 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import XCTest
+import OUDSTokensRaw
+
+/// The aim of this tests class is to look for regressions in **opacity raw tokens**.
+/// Because these values will be at least generated through an external tool, is it not relevant to test each token values.
+/// Indeed, each future generation of Swift code may break theses tests because there are new values.
+/// However, in the semantics of border raw tokens, there will be some unchanged things like relationships between tokens.
+/// Thus this tests class just checks if such relationships are still here whatever the values at the end.
+final class OpacityRawTokensTests: XCTestCase {
+
+    /// Whathever the values are, opacity raw tokens must keep their order relationships
+    func testOrderRelationshipForWidths() throws {
+        XCTAssertLessThan(OpacityRawTokens.opacity0, OpacityRawTokens.opacity100)
+        XCTAssertLessThan(OpacityRawTokens.opacity100, OpacityRawTokens.opacity200)
+        XCTAssertLessThan(OpacityRawTokens.opacity200, OpacityRawTokens.opacity300)
+        XCTAssertLessThan(OpacityRawTokens.opacity300, OpacityRawTokens.opacity400)
+        XCTAssertLessThan(OpacityRawTokens.opacity400, OpacityRawTokens.opacity500)
+        XCTAssertLessThan(OpacityRawTokens.opacity500, OpacityRawTokens.opacity600)
+        XCTAssertLessThan(OpacityRawTokens.opacity600, OpacityRawTokens.opacity700)
+        XCTAssertLessThan(OpacityRawTokens.opacity700, OpacityRawTokens.opacity800)
+        XCTAssertLessThan(OpacityRawTokens.opacity800, OpacityRawTokens.opacity900)
+    }
+}

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/OpacitySemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/OpacitySemanticTokens.swift
@@ -29,7 +29,7 @@ public protocol OpacitySemanticTokens {
     var opacityTransparent: OpacitySemanticToken { get }
     var opacityWeaker: OpacitySemanticToken { get }
     var opacityWeak: OpacitySemanticToken { get }
-    var opacityMedum: OpacitySemanticToken { get }
+    var opacityMedium: OpacitySemanticToken { get }
     var opacityEmphasis: OpacitySemanticToken { get }
     var opacityOpaque: OpacitySemanticToken { get }
 }


### PR DESCRIPTION
THis commit updates when needed the values of raw tokens and semenatic tokens for opacity. It brings also unit tests for theme overriding and raw tokens relationships.

_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#29

### Description

Update raw and semantic tokens for opacity

### Motivation & Context

See #29

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- (NA) The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
