### PR TITLE
[#51] Add raw and semantic tokens for typography

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [Library] Add raw tokens and semantic tokens for opacity ([#29](https://github.com/Orange-OpenSource/ouds-ios/issues/29))
+- [Library] Add raw tokens and semantic tokens for typography ([#51](https://github.com/Orange-OpenSource/ouds-ios/issues/51))
 - [Showcase] Publication of comment on issues about new alpha build upload on TestFlight ([#56](https://github.com/Orange-OpenSource/ouds-ios/issues/56))
 - [Library] Add raw tokens and semantic tokens for elevation ([#32](https://github.com/Orange-OpenSource/ouds-ios/issues/32))
 - [Library] Add raw tokens and semantic tokens for border ([#30](https://github.com/Orange-OpenSource/ouds-ios/issues/30))

--- a/OUDS/Core/Themes/Sources/Shared/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/Themes/Sources/Shared/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
@@ -21,6 +21,7 @@ extension OUDSTheme: TypographySemanticTokens {
 
     // MARK: Semantic token - Typography - Font - Family
 
+    @objc open var fontFamily: TypographyFontFamilySemanticToken { TypographyRawTokens.fontFamilySystem }
     @objc open var fontFamilyDisplay: TypographyFontFamilySemanticToken { TypographyRawTokens.fontFamilySystem }
     @objc open var fontFamilyHeading: TypographyFontFamilySemanticToken { TypographyRawTokens.fontFamilySystem }
     @objc open var fontFamilyBody: TypographyFontFamilySemanticToken { TypographyRawTokens.fontFamilySystem }
@@ -35,11 +36,11 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontWeightBodyStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
     @objc open var fontWeightLabelDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
     @objc open var fontWeightLabelStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightWeightCode: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
+    @objc open var fontWeightCode: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
 
     // MARK: Semantic token - Typography - Font - Size - Mobile
 
-    @objc open var fontSizeMobileDislayLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize850 }
+    @objc open var fontSizeMobileDisplayLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize850 }
     @objc open var fontSizeMobileDisplayMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize750 }
     @objc open var fontSizeMobileDisplaySmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize650 }
     @objc open var fontSizeMobileHeadingXLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize550 }
@@ -49,10 +50,12 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontSizeMobileBodyLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize250 }
     @objc open var fontSizeMobileBodyMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
     @objc open var fontSizeMobileBodySmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize100 }
+    @objc open var fontSizeMobileCodeMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
+    @objc open var fontSizeMobileCodeSmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize100 }
 
     // MARK: Semantic token - Typography - Font - Size - Tablet
 
-    @objc open var fontSizeTabletDislayLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize1450 }
+    @objc open var fontSizeTabletDisplayLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize1450 }
     @objc open var fontSizeTabletDisplayMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize1050 }
     @objc open var fontSizeTabletDisplaySmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize850 }
     @objc open var fontSizeTabletHeadingXLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize750 }
@@ -62,19 +65,21 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontSizeTabletBodyLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize250 }
     @objc open var fontSizeTabletBodyMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
     @objc open var fontSizeTabletBodySmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize150 }
+    @objc open var fontSizeTabletCodeMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
+    @objc open var fontSizeTabletCodeSmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize150 }
 
     // MARK: Semantic token - Typography - Font - Size - Others
 
     @objc open var fontSizeLabelXLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize300 }
     @objc open var fontSizeLabelLarge: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize250 }
     @objc open var fontSizeLabelMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
-    @objc open var fontSizeLabelSmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize100 }
+    @objc open var fontSizeLabelSmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize150 }
     @objc open var fontSizeCodeMedium: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize200 }
     @objc open var fontSizeCodeSmall: TypographyFontSizeSemanticToken { TypographyRawTokens.fontSize150 }
 
     // MARK: Semantic token - Typography - Font - Light height - Mobile
 
-    @objc open var fontLineHeightMobileDislayLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1050 }
+    @objc open var fontLineHeightMobileDisplayLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1050 }
     @objc open var fontLineHeightMobileDisplayMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight950 }
     @objc open var fontLineHeightMobileDisplaySmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight850 }
     @objc open var fontLineHeightMobileHeadingXLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight750 }
@@ -84,10 +89,12 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLineHeightMobileBodyLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight450 }
     @objc open var fontLineHeightMobileBodyMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight350 }
     @objc open var fontLineHeightMobileBodySmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
+    @objc open var fontLineHeightMobileCodeMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight350 }
+    @objc open var fontLineHeightMobileCodeSmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
 
     // MARK: Semantic token - Typography - Font - Light height - Tablet
 
-    @objc open var fontLineHeightTabletDislayLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1850 }
+    @objc open var fontLineHeightTabletDisplayLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1850 }
     @objc open var fontLineHeightTabletDisplayMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1250 }
     @objc open var fontLineHeightTabletDisplaySmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight1050 }
     @objc open var fontLineHeightTabletHeadingXLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight950 }
@@ -97,6 +104,8 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLineHeightTabletBodyLarge: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight450 }
     @objc open var fontLineHeightTabletBodyMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight350 }
     @objc open var fontLineHeightTabletBodySmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
+    @objc open var fontLineHeightTabletCodeMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight350 }
+    @objc open var fontLineHeightTabletCodeSmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
 
     // MARK: Semantic token - Typography - Font - Light height - Others
 
@@ -109,7 +118,7 @@ extension OUDSTheme: TypographySemanticTokens {
 
     // MARK: Semantic token - Typography - Font - Paragraph spacing - Mobile
 
-    @objc open var fontParagraphSpacingMobileDislayLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingMobileDisplayLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingMobileDisplayMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingMobileDisplaySmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingMobileHeadingXLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
@@ -119,10 +128,12 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontParagraphSpacingMobileBodyLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingMobileBodyMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingMobileBodySmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingMobileCodeMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingMobileCodeSmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
 
     // MARK: Semantic token - Typography - Font - Paragraph spacing - Tablet
 
-    @objc open var fontParagraphSpacingTabletDislayLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingTabletDisplayLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingTabletDisplayMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingTabletDisplaySmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingTabletHeadingXLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
@@ -132,6 +143,8 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontParagraphSpacingTabletBodyLarge: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingTabletBodyMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingTabletBodySmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingTabletCodeMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
+    @objc open var fontParagraphSpacingTabletCodeSmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
 
     // MARK: Semantic token - Typography - Font - Paragraph spacing - Others
 
@@ -141,5 +154,4 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontParagraphSpacingLabelSmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingCodeMedium: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
     @objc open var fontParagraphSpacingCodeSmall: TypographyFontParagraphSpacingRawToken { TypographyRawTokens.fontParagraphSpacing100 }
-
 }

--- a/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfTypographySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/ThemeOverrideOfTypographySemanticTokens.swift
@@ -1,0 +1,571 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import XCTest
+import OUDSThemesShared
+
+// swiftlint:disable type_body_length
+
+/// The architecture of _OUDS iOS_ _Swift package_ library is based on _object oriented paradigm_ and overriding of classes.
+/// In fact the `OUDSTheme` object is a class, which can be seen as an _asbtract class_, exposing through its extensions and protocols _typography semantic tokens_.
+/// These semantic tokens should be overriden by subclass like the `OrangeTheme` default theme.
+/// **These tests checks if any _typography semantic tokens_ can be surcharged by a child theme**
+final class ThemeOverrideOfTypographySemanticTokens: XCTestCase {
+
+    private var abstractTheme: OUDSTheme!
+    private var inheritedTheme: OUDSTheme!
+
+    override func setUp() async throws {
+        abstractTheme = OUDSTheme()
+        inheritedTheme = MockTheme()
+    }
+
+    // MARK: - Semantic token - Typography - Font - Family
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamily() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamily, abstractTheme.fontFamily)
+        XCTAssertTrue(inheritedTheme.fontFamily == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamilyDisplay() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamilyDisplay, abstractTheme.fontFamilyDisplay)
+        XCTAssertTrue(inheritedTheme.fontFamilyDisplay == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamilyHeading() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamilyHeading, abstractTheme.fontFamilyHeading)
+        XCTAssertTrue(inheritedTheme.fontFamilyHeading == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamilyBody() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamilyBody, abstractTheme.fontFamilyBody)
+        XCTAssertTrue(inheritedTheme.fontFamilyBody == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamilyLabel() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamilyLabel, abstractTheme.fontFamilyLabel)
+        XCTAssertTrue(inheritedTheme.fontFamilyLabel == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontFamilyCode() throws {
+        XCTAssertNotEqual(inheritedTheme.fontFamilyCode, abstractTheme.fontFamilyCode)
+        XCTAssertTrue(inheritedTheme.fontFamilyCode == MockTheme.mockThemeFontFamilyRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Weight
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightDisplay() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightDisplay, abstractTheme.fontWeightDisplay)
+        XCTAssertTrue(inheritedTheme.fontWeightDisplay == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightHeading() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightHeading, abstractTheme.fontWeightHeading)
+        XCTAssertTrue(inheritedTheme.fontWeightHeading == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightBodyDefault() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightBodyDefault, abstractTheme.fontWeightBodyDefault)
+        XCTAssertTrue(inheritedTheme.fontWeightBodyDefault == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightBodyStrong() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightBodyStrong, abstractTheme.fontWeightBodyStrong)
+        XCTAssertTrue(inheritedTheme.fontWeightBodyStrong == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightLabelDefault() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightLabelDefault, abstractTheme.fontWeightLabelDefault)
+        XCTAssertTrue(inheritedTheme.fontWeightLabelDefault == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightLabelStrong() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightLabelStrong, abstractTheme.fontWeightLabelStrong)
+        XCTAssertTrue(inheritedTheme.fontWeightLabelStrong == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontWeightCode() throws {
+        XCTAssertNotEqual(inheritedTheme.fontWeightCode, abstractTheme.fontWeightCode)
+        XCTAssertTrue(inheritedTheme.fontWeightCode == MockTheme.mockThemeFontWeightRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Size - Mobile
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileDisplayLarge, abstractTheme.fontSizeMobileDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileDisplayLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileDisplayMedium, abstractTheme.fontSizeMobileDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileDisplayMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileDisplaySmall, abstractTheme.fontSizeMobileDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileDisplaySmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileHeadingXLarge, abstractTheme.fontSizeMobileHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileHeadingXLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileHeadingLarge, abstractTheme.fontSizeMobileHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileHeadingLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileHeadingMedium, abstractTheme.fontSizeMobileHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileHeadingMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileHeadingSmall, abstractTheme.fontSizeMobileHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileHeadingSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileBodyLarge, abstractTheme.fontSizeMobileBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileBodyLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileBodyMedium, abstractTheme.fontSizeMobileBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileBodyMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileBodySmall, abstractTheme.fontSizeMobileBodySmall)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileBodySmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileCodeMedium, abstractTheme.fontSizeMobileCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileCodeMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeMobileCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeMobileCodeSmall, abstractTheme.fontSizeMobileCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeMobileCodeSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Size - Tablet
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletDisplayLarge, abstractTheme.fontSizeTabletDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletDisplayLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletDisplayMedium, abstractTheme.fontSizeTabletDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletDisplayMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletDisplaySmall, abstractTheme.fontSizeTabletDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletDisplaySmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletHeadingXLarge, abstractTheme.fontSizeTabletHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletHeadingXLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletHeadingLarge, abstractTheme.fontSizeTabletHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletHeadingLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletHeadingMedium, abstractTheme.fontSizeTabletHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletHeadingMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletHeadingSmall, abstractTheme.fontSizeTabletHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletHeadingSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletBodyLarge, abstractTheme.fontSizeTabletBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletBodyLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletBodyMedium, abstractTheme.fontSizeTabletBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletBodyMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletBodySmall, abstractTheme.fontSizeTabletBodySmall)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletBodySmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletCodeMedium, abstractTheme.fontSizeTabletCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletCodeMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeTabletCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeTabletCodeSmall, abstractTheme.fontSizeTabletCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeTabletCodeSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Size - Others
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeLabelXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeLabelXLarge, abstractTheme.fontSizeLabelXLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeLabelXLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeLabelLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeLabelLarge, abstractTheme.fontSizeLabelLarge)
+        XCTAssertTrue(inheritedTheme.fontSizeLabelLarge == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeLabelMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeLabelMedium, abstractTheme.fontSizeLabelMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeLabelMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeLabelSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeLabelSmall, abstractTheme.fontSizeLabelSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeLabelSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeCodeMedium, abstractTheme.fontSizeCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontSizeCodeMedium == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontSizeCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontSizeCodeSmall, abstractTheme.fontSizeCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontSizeCodeSmall == MockTheme.mockThemeFontSizeRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Line height - Mobile
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileDisplayLarge, abstractTheme.fontLineHeightMobileDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileDisplayLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileDisplayMedium, abstractTheme.fontLineHeightMobileDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileDisplayMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileDisplaySmall, abstractTheme.fontLineHeightMobileDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileDisplaySmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileHeadingXLarge, abstractTheme.fontLineHeightMobileHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileHeadingXLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileHeadingLarge, abstractTheme.fontLineHeightMobileHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileHeadingLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileHeadingMedium, abstractTheme.fontLineHeightMobileHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileHeadingMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileHeadingSmall, abstractTheme.fontLineHeightMobileHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileHeadingSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileBodyLarge, abstractTheme.fontLineHeightMobileBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileBodyLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileBodyMedium, abstractTheme.fontLineHeightMobileBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileBodyMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileBodySmall, abstractTheme.fontLineHeightMobileBodySmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileBodySmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileCodeMedium, abstractTheme.fontLineHeightMobileCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileCodeMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightMobileCodeSmall, abstractTheme.fontLineHeightMobileCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightMobileCodeSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Line height - Tablet
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletDisplayLarge, abstractTheme.fontLineHeightTabletDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletDisplayLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletDisplayMedium, abstractTheme.fontLineHeightTabletDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletDisplayMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletDisplaySmall, abstractTheme.fontLineHeightTabletDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletDisplaySmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletHeadingXLarge, abstractTheme.fontLineHeightTabletHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletHeadingXLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletHeadingLarge, abstractTheme.fontLineHeightTabletHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletHeadingLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletHeadingMedium, abstractTheme.fontLineHeightTabletHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletHeadingMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletHeadingSmall, abstractTheme.fontLineHeightTabletHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletHeadingSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletBodyLarge, abstractTheme.fontLineHeightTabletBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletBodyLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletBodyMedium, abstractTheme.fontLineHeightTabletBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletBodyMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletBodySmall, abstractTheme.fontLineHeightTabletBodySmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletBodySmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletCodeMedium, abstractTheme.fontLineHeightTabletCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletCodeMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightTabletCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightTabletCodeSmall, abstractTheme.fontLineHeightTabletCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightTabletCodeSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Line height - Others
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightLabelXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightLabelXLarge, abstractTheme.fontLineHeightLabelXLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightLabelXLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightLabelLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightLabelLarge, abstractTheme.fontLineHeightLabelLarge)
+        XCTAssertTrue(inheritedTheme.fontLineHeightLabelLarge == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightLabelMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightLabelMedium, abstractTheme.fontLineHeightLabelMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightLabelMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightLabelSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightLabelSmall, abstractTheme.fontLineHeightLabelSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightLabelSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightCodeMedium, abstractTheme.fontLineHeightCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontLineHeightCodeMedium == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLineHeightCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLineHeightCodeSmall, abstractTheme.fontLineHeightCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontLineHeightCodeSmall == MockTheme.mockThemeFontLineHeightRawToken)
+    }
+
+    // MARK: Semantic token - Typography - Font - Paragraph spacing - Mobile
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileDisplayLarge, abstractTheme.fontParagraphSpacingMobileDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileDisplayLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileDisplayMedium, abstractTheme.fontParagraphSpacingMobileDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileDisplayMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileDisplaySmall, abstractTheme.fontParagraphSpacingMobileDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileDisplaySmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileHeadingXLarge, abstractTheme.fontParagraphSpacingMobileHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileHeadingXLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileHeadingLarge, abstractTheme.fontParagraphSpacingMobileHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileHeadingLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileHeadingMedium, abstractTheme.fontParagraphSpacingMobileHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileHeadingMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileHeadingSmall, abstractTheme.fontParagraphSpacingMobileHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileHeadingSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileBodyLarge, abstractTheme.fontParagraphSpacingMobileBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileBodyLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileBodyMedium, abstractTheme.fontParagraphSpacingMobileBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileBodyMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileBodySmall, abstractTheme.fontParagraphSpacingMobileBodySmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileBodySmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileCodeMedium, abstractTheme.fontParagraphSpacingMobileCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileCodeMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingMobileCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingMobileCodeSmall, abstractTheme.fontParagraphSpacingMobileCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingMobileCodeSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Paragraph spacing - Tablet
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletDisplayLarge, abstractTheme.fontParagraphSpacingTabletDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletDisplayLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletDisplayMedium, abstractTheme.fontParagraphSpacingTabletDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletDisplayMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletDisplaySmall, abstractTheme.fontParagraphSpacingTabletDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletDisplaySmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletHeadingXLarge, abstractTheme.fontParagraphSpacingTabletHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletHeadingXLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletHeadingLarge, abstractTheme.fontParagraphSpacingTabletHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletHeadingLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletHeadingMedium, abstractTheme.fontParagraphSpacingTabletHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletHeadingMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletHeadingSmall, abstractTheme.fontParagraphSpacingTabletHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletHeadingSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletBodyLarge, abstractTheme.fontParagraphSpacingTabletBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletBodyLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletBodyMedium, abstractTheme.fontParagraphSpacingTabletBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletBodyMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletBodySmall, abstractTheme.fontParagraphSpacingTabletBodySmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletBodySmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletCodeMedium, abstractTheme.fontParagraphSpacingTabletCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletCodeMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingTabletCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingTabletCodeSmall, abstractTheme.fontParagraphSpacingTabletCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingTabletCodeSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Paragraph spacing - Others
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingLabelXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingLabelXLarge, abstractTheme.fontParagraphSpacingLabelXLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingLabelXLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingLabelLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingLabelLarge, abstractTheme.fontParagraphSpacingLabelLarge)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingLabelLarge == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingLabelMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingLabelMedium, abstractTheme.fontParagraphSpacingLabelMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingLabelMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingLabelSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingLabelSmall, abstractTheme.fontParagraphSpacingLabelSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingLabelSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingCodeMedium, abstractTheme.fontParagraphSpacingCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingCodeMedium == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontParagraphSpacingCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontParagraphSpacingCodeSmall, abstractTheme.fontParagraphSpacingCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontParagraphSpacingCodeSmall == MockTheme.mockThemeFontParagraphSpacingRawToken)
+    }
+}
+
+// swiftlint:enable type_body_length

--- a/OUDS/Core/Themes/Tests/Shared/_/MockTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/Themes/Tests/Shared/_/MockTheme+TypographySemanticTokens.swift
@@ -1,0 +1,161 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensRaw
+import OUDSTokensSemantic
+
+extension MockTheme {
+
+    static let mockThemeFontFamilyRawToken: TypographyFontFamilyRawToken = "o°xXSkyBl0GF0ntxXx°o"
+    static let mockThemeFontWeightRawToken: TypographyFontWeightRawToken = "stiicckkyyyy"
+    static let mockThemeFontSizeRawToken: TypographyFontSizeRawToken = 666
+    static let mockThemeFontLineHeightRawToken: TypographyFontLineHeightRawToken = 321
+    static let mockThemeFontParagraphSpacingRawToken: TypographyFontParagraphSpacingRawToken = 0x911
+
+    // MARK: Semantic token - Typography - Font - Family
+
+    override var fontFamily: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+    override var fontFamilyDisplay: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+    override var fontFamilyHeading: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+    override var fontFamilyBody: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+    override var fontFamilyLabel: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+    override var fontFamilyCode: TypographyFontFamilySemanticToken { Self.mockThemeFontFamilyRawToken }
+
+    // MARK: Semantic token - Typography - Font - Weight
+
+    override var fontWeightDisplay: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightHeading: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightBodyDefault: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightBodyStrong: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightLabelDefault: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightLabelStrong: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+    override var fontWeightCode: TypographyFontWeightSemanticToken { Self.mockThemeFontWeightRawToken }
+
+    // MARK: Semantic token - Typography - Font - Size - Mobile
+
+    override var fontSizeMobileDisplayLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileDisplayMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileDisplaySmall: TypographyFontSizeSemanticToken  { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileHeadingXLarge: TypographyFontSizeSemanticToken  { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileHeadingLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileHeadingMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileHeadingSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileBodyLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileBodyMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileBodySmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileCodeMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeMobileCodeSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+
+    // MARK: Semantic token - Typography - Font - Size - Tablet
+
+    override var fontSizeTabletDisplayLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletDisplayMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletDisplaySmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletHeadingXLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletHeadingLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletHeadingMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletHeadingSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletBodyLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletBodyMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletBodySmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletCodeMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeTabletCodeSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+
+    // MARK: Semantic token - Typography - Font - Size - Others
+
+    override var fontSizeLabelXLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeLabelLarge: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeLabelMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeLabelSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeCodeMedium: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+    override var fontSizeCodeSmall: TypographyFontSizeSemanticToken { Self.mockThemeFontSizeRawToken }
+
+    // MARK: Semantic token - Typography - Font - Line height - Mobile
+
+    override var fontLineHeightMobileDisplayLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileDisplayMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileDisplaySmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileHeadingXLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileHeadingLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileHeadingMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileHeadingSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileBodyLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileBodyMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileBodySmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileCodeMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightMobileCodeSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+
+    // MARK: Semantic token - Typography - Font - Line height - Tablet
+
+    override var fontLineHeightTabletDisplayLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletDisplayMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletDisplaySmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletHeadingXLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletHeadingLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletHeadingMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletHeadingSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletBodyLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletBodyMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletBodySmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletCodeMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightTabletCodeSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+
+    // MARK: Semantic token - Typography - Font - Light height - Others
+
+    override var fontLineHeightLabelXLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightLabelLarge: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightLabelMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightLabelSmall: TypographyFontLineHeightSemanticToken  { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightCodeMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+    override var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeFontLineHeightRawToken }
+
+    // MARK: Semantic token - Typography - Font - Paragraph spacing - Mobile
+
+    override var fontParagraphSpacingMobileDisplayLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileDisplayMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileDisplaySmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileHeadingXLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileHeadingLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileHeadingMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileHeadingSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileBodyLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileBodyMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileBodySmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileCodeMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingMobileCodeSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+
+    // MARK: Semantic token - Typography - Font - Paragraph spacing - Tablet
+
+    override var fontParagraphSpacingTabletDisplayLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletDisplayMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletDisplaySmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletHeadingXLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletHeadingLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletHeadingMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletHeadingSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletBodyLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletBodyMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletBodySmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletCodeMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingTabletCodeSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+
+    // MARK: Semantic token - Typography - Font - Paragraph spacing - Others
+
+    override var fontParagraphSpacingLabelXLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingLabelLarge: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingLabelMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingLabelSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingCodeMedium: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+    override var fontParagraphSpacingCodeSmall: TypographyFontParagraphSpacingRawToken { Self.mockThemeFontParagraphSpacingRawToken }
+}

--- a/OUDS/Core/Tokens/RawTokens/Sources/TypographyRawTokens.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/TypographyRawTokens.swift
@@ -28,12 +28,12 @@ public typealias TypographyFontParagraphSpacingRawToken = Int
 
 public struct TypographyCompositeRawToken {
 
-    let family: TypographyFontFamilyRawToken
-    let size: TypographyFontSizeRawToken
-    let lineHeight: TypographyFontLineHeightRawToken
-    let weight: TypographyFontWeightRawToken
+    public let family: TypographyFontFamilyRawToken
+    public let size: TypographyFontSizeRawToken
+    public let lineHeight: TypographyFontLineHeightRawToken
+    public let weight: TypographyFontWeightRawToken
     // TODO: How to deal "letter spacing"?
-    let paragraphSpacing: TypographyFontParagraphSpacingRawToken
+    public let paragraphSpacing: TypographyFontParagraphSpacingRawToken
 }
 
 // MARK: - Raw tokens
@@ -74,7 +74,7 @@ public enum TypographyRawTokens {
     public static let fontLineHeight550: TypographyFontLineHeightRawToken = 28
     public static let fontLineHeight650: TypographyFontLineHeightRawToken = 32
     public static let fontLineHeight750: TypographyFontLineHeightRawToken = 36
-    public static let fontLineHeight850: TypographyFontLineHeightRawToken = 10
+    public static let fontLineHeight850: TypographyFontLineHeightRawToken = 40
     public static let fontLineHeight950: TypographyFontLineHeightRawToken = 44
     public static let fontLineHeight1050: TypographyFontLineHeightRawToken = 48
     public static let fontLineHeight1150: TypographyFontLineHeightRawToken = 52

--- a/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
@@ -1,0 +1,92 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import XCTest
+import OUDSTokensRaw
+
+/// The aim of this tests class is to look for regressions in **typography raw tokens**.
+/// Because these values will be at least generated through an external tool, is it not relevant to test each token values.
+/// Indeed, each future generation of Swift code may break theses tests because there are new values.
+/// However, in the semantics of typography raw tokens, there will be some unchanged things like relationships between tokens.
+/// Thus this tests class just checks if such relationships are still here whatever the values at the end.
+final class TypographyRawTokensTests: XCTestCase {
+
+    /// Whatever the values are, font sizes raw tokens must keep their order relationships
+    func testOrderRelationshipFontSizes() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontSize100, TypographyRawTokens.fontSize150)
+        XCTAssertLessThan(TypographyRawTokens.fontSize150, TypographyRawTokens.fontSize175)
+        XCTAssertLessThan(TypographyRawTokens.fontSize175, TypographyRawTokens.fontSize200)
+        XCTAssertLessThan(TypographyRawTokens.fontSize200, TypographyRawTokens.fontSize250)
+        XCTAssertLessThan(TypographyRawTokens.fontSize250, TypographyRawTokens.fontSize300)
+        XCTAssertLessThan(TypographyRawTokens.fontSize300, TypographyRawTokens.fontSize350)
+        XCTAssertLessThan(TypographyRawTokens.fontSize350, TypographyRawTokens.fontSize450)
+        XCTAssertLessThan(TypographyRawTokens.fontSize450, TypographyRawTokens.fontSize550)
+        XCTAssertLessThan(TypographyRawTokens.fontSize550, TypographyRawTokens.fontSize650)
+        XCTAssertLessThan(TypographyRawTokens.fontSize650, TypographyRawTokens.fontSize750)
+        XCTAssertLessThan(TypographyRawTokens.fontSize750, TypographyRawTokens.fontSize850)
+        XCTAssertLessThan(TypographyRawTokens.fontSize850, TypographyRawTokens.fontSize950)
+        XCTAssertLessThan(TypographyRawTokens.fontSize950, TypographyRawTokens.fontSize1050)
+        XCTAssertLessThan(TypographyRawTokens.fontSize1050, TypographyRawTokens.fontSize1150)
+        XCTAssertLessThan(TypographyRawTokens.fontSize1150, TypographyRawTokens.fontSize1250)
+        XCTAssertLessThan(TypographyRawTokens.fontSize1250, TypographyRawTokens.fontSize1450)
+        XCTAssertLessThan(TypographyRawTokens.fontSize1450, TypographyRawTokens.fontSize1850)
+    }
+
+    /// Whatever the values are, font line heights raw tokens must keep their order relationships
+    func testOrderRelationshipFontLineHeights() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight250, TypographyRawTokens.fontLineHeight350)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight350, TypographyRawTokens.fontLineHeight450)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight450, TypographyRawTokens.fontLineHeight550)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight550, TypographyRawTokens.fontLineHeight650)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight650, TypographyRawTokens.fontLineHeight750)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight750, TypographyRawTokens.fontLineHeight850)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight850, TypographyRawTokens.fontLineHeight950)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight950, TypographyRawTokens.fontLineHeight1050)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1050, TypographyRawTokens.fontLineHeight1150)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1150, TypographyRawTokens.fontLineHeight1250)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1250, TypographyRawTokens.fontLineHeight1350)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1350, TypographyRawTokens.fontLineHeight1450)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1450, TypographyRawTokens.fontLineHeight1850)
+        XCTAssertLessThan(TypographyRawTokens.fontLineHeight1850, TypographyRawTokens.fontLineHeight2050)
+    }
+
+    /// Whatever the values are, font paragraph spacings raw tokens must keep their order relationships
+    func testOrderRelationshipFontParagraphSpacings() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontParagraphSpacing100, TypographyRawTokens.fontParagraphSpacing200)
+        XCTAssertLessThan(TypographyRawTokens.fontParagraphSpacing200, TypographyRawTokens.fontParagraphSpacing300)
+        XCTAssertLessThan(TypographyRawTokens.fontParagraphSpacing300, TypographyRawTokens.fontParagraphSpacing400)
+    }
+
+    /// Whatever the values are, typographies must keep their order relationships
+    func testOrderRelationshipComposites() throws {
+        XCTAssertLessThan(TypographyRawTokens.typeRegular150.size, TypographyRawTokens.typeRegular175.size)
+        XCTAssertLessThan(TypographyRawTokens.typeRegular175.size, TypographyRawTokens.typeRegular200.size)
+        XCTAssertLessThan(TypographyRawTokens.typeRegular200.size, TypographyRawTokens.typeRegular250.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold150.size, TypographyRawTokens.typeBold175.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold175.size, TypographyRawTokens.typeBold200.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold200.size, TypographyRawTokens.typeBold250.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold250.size, TypographyRawTokens.typeBold300.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold300.size, TypographyRawTokens.typeBold350.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold350.size, TypographyRawTokens.typeBold450.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold450.size, TypographyRawTokens.typeBold550.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold550.size, TypographyRawTokens.typeBold650.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold650.size, TypographyRawTokens.typeBold750.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold750.size, TypographyRawTokens.typeBold850.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold850.size, TypographyRawTokens.typeBold950.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold950.size, TypographyRawTokens.typeBold1050.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold1050.size, TypographyRawTokens.typeBold1150.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold1150.size, TypographyRawTokens.typeBold1250.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold1250.size, TypographyRawTokens.typeBold1450.size)
+        XCTAssertLessThan(TypographyRawTokens.typeBold1450.size, TypographyRawTokens.typeBold1850.size)
+    }
+}

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/TypographySemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/TypographySemanticTokens.swift
@@ -27,15 +27,16 @@ public typealias TypographyFontLineHeightSemanticToken = TypographyFontLineHeigh
 /// It defines all `TypographySemanticToken` a theme must have.
 public protocol TypographySemanticTokens {
 
-    // MARK: Semantic token - Typography - Font - Family
+    // MARK: - Semantic token - Typography - Font - Family
 
+    var fontFamily: TypographyFontFamilyRawToken { get }
     var fontFamilyDisplay: TypographyFontFamilySemanticToken { get }
     var fontFamilyHeading: TypographyFontFamilySemanticToken { get }
     var fontFamilyBody: TypographyFontFamilySemanticToken { get }
     var fontFamilyLabel: TypographyFontFamilySemanticToken { get }
     var fontFamilyCode: TypographyFontFamilySemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Weight
+    // MARK: - Semantic token - Typography - Font - Weight
 
     var fontWeightDisplay: TypographyFontWeightSemanticToken { get }
     var fontWeightHeading: TypographyFontWeightSemanticToken { get }
@@ -43,11 +44,11 @@ public protocol TypographySemanticTokens {
     var fontWeightBodyStrong: TypographyFontWeightSemanticToken { get }
     var fontWeightLabelDefault: TypographyFontWeightSemanticToken { get }
     var fontWeightLabelStrong: TypographyFontWeightSemanticToken { get }
-    var fontWeightWeightCode: TypographyFontWeightSemanticToken { get }
+    var fontWeightCode: TypographyFontWeightSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Size - Mobile
+    // MARK: - Semantic token - Typography - Font - Size - Mobile
 
-    var fontSizeMobileDislayLarge: TypographyFontSizeSemanticToken { get }
+    var fontSizeMobileDisplayLarge: TypographyFontSizeSemanticToken { get }
     var fontSizeMobileDisplayMedium: TypographyFontSizeSemanticToken { get }
     var fontSizeMobileDisplaySmall: TypographyFontSizeSemanticToken { get }
     var fontSizeMobileHeadingXLarge: TypographyFontSizeSemanticToken { get }
@@ -57,10 +58,12 @@ public protocol TypographySemanticTokens {
     var fontSizeMobileBodyLarge: TypographyFontSizeSemanticToken { get }
     var fontSizeMobileBodyMedium: TypographyFontSizeSemanticToken { get }
     var fontSizeMobileBodySmall: TypographyFontSizeSemanticToken { get }
+    var fontSizeMobileCodeMedium: TypographyFontSizeSemanticToken { get }
+    var fontSizeMobileCodeSmall: TypographyFontSizeSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Size - Tablet
+    // MARK: - Semantic token - Typography - Font - Size - Tablet
 
-    var fontSizeTabletDislayLarge: TypographyFontSizeSemanticToken { get }
+    var fontSizeTabletDisplayLarge: TypographyFontSizeSemanticToken { get }
     var fontSizeTabletDisplayMedium: TypographyFontSizeSemanticToken { get }
     var fontSizeTabletDisplaySmall: TypographyFontSizeSemanticToken { get }
     var fontSizeTabletHeadingXLarge: TypographyFontSizeSemanticToken { get }
@@ -70,8 +73,10 @@ public protocol TypographySemanticTokens {
     var fontSizeTabletBodyLarge: TypographyFontSizeSemanticToken { get }
     var fontSizeTabletBodyMedium: TypographyFontSizeSemanticToken { get }
     var fontSizeTabletBodySmall: TypographyFontSizeSemanticToken { get }
+    var fontSizeTabletCodeMedium: TypographyFontSizeSemanticToken { get }
+    var fontSizeTabletCodeSmall: TypographyFontSizeSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Size - Others
+    // MARK: - Semantic token - Typography - Font - Size - Others
 
     var fontSizeLabelXLarge: TypographyFontSizeSemanticToken { get }
     var fontSizeLabelLarge: TypographyFontSizeSemanticToken { get }
@@ -80,9 +85,9 @@ public protocol TypographySemanticTokens {
     var fontSizeCodeMedium: TypographyFontSizeSemanticToken { get }
     var fontSizeCodeSmall: TypographyFontSizeSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Light height - Mobile
+    // MARK: - Semantic token - Typography - Font - Line height - Mobile
 
-    var fontLineHeightMobileDislayLarge: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightMobileDisplayLarge: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightMobileDisplayMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightMobileDisplaySmall: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightMobileHeadingXLarge: TypographyFontLineHeightSemanticToken { get }
@@ -92,10 +97,12 @@ public protocol TypographySemanticTokens {
     var fontLineHeightMobileBodyLarge: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightMobileBodyMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightMobileBodySmall: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightMobileCodeMedium: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightMobileCodeSmall: TypographyFontLineHeightSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Light height - Tablet
+    // MARK: - Semantic token - Typography - Font - Line height - Tablet
 
-    var fontLineHeightTabletDislayLarge: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightTabletDisplayLarge: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightTabletDisplayMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightTabletDisplaySmall: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightTabletHeadingXLarge: TypographyFontLineHeightSemanticToken { get }
@@ -105,8 +112,10 @@ public protocol TypographySemanticTokens {
     var fontLineHeightTabletBodyLarge: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightTabletBodyMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightTabletBodySmall: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightTabletCodeMedium: TypographyFontLineHeightSemanticToken { get }
+    var fontLineHeightTabletCodeSmall: TypographyFontLineHeightSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Light height - Others
+    // MARK: - Semantic token - Typography - Font - Line height - Others
 
     var fontLineHeightLabelXLarge: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightLabelLarge: TypographyFontLineHeightSemanticToken { get }
@@ -115,9 +124,12 @@ public protocol TypographySemanticTokens {
     var fontLineHeightCodeMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { get }
 
-    // MARK: Semantic token - Typography - Font - Paragraph spacing - Mobile
+    // MARK: - Semantic token - Typography - Font - Letter spacing
+    // TODO: Missing details about the types of the associated raw tokens
 
-    var fontParagraphSpacingMobileDislayLarge: TypographyFontParagraphSpacingRawToken { get }
+    // MARK: - Semantic token - Typography - Font - Paragraph spacing - Mobile
+
+    var fontParagraphSpacingMobileDisplayLarge: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingMobileDisplayMedium: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingMobileDisplaySmall: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingMobileHeadingXLarge: TypographyFontParagraphSpacingRawToken { get }
@@ -127,10 +139,12 @@ public protocol TypographySemanticTokens {
     var fontParagraphSpacingMobileBodyLarge: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingMobileBodyMedium: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingMobileBodySmall: TypographyFontParagraphSpacingRawToken { get }
+    var fontParagraphSpacingMobileCodeMedium: TypographyFontParagraphSpacingRawToken { get }
+    var fontParagraphSpacingMobileCodeSmall: TypographyFontParagraphSpacingRawToken { get }
 
-    // MARK: Semantic token - Typography - Font - Paragraph spacing - Tablet
+    // MARK: - Semantic token - Typography - Font - Paragraph spacing - Tablet
 
-    var fontParagraphSpacingTabletDislayLarge: TypographyFontParagraphSpacingRawToken { get }
+    var fontParagraphSpacingTabletDisplayLarge: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingTabletDisplayMedium: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingTabletDisplaySmall: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingTabletHeadingXLarge: TypographyFontParagraphSpacingRawToken { get }
@@ -140,8 +154,10 @@ public protocol TypographySemanticTokens {
     var fontParagraphSpacingTabletBodyLarge: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingTabletBodyMedium: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingTabletBodySmall: TypographyFontParagraphSpacingRawToken { get }
+    var fontParagraphSpacingTabletCodeMedium: TypographyFontParagraphSpacingRawToken { get }
+    var fontParagraphSpacingTabletCodeSmall: TypographyFontParagraphSpacingRawToken { get }
 
-    // MARK: Semantic token - Typography - Font - Paragraph spacing - Others
+    // MARK: - Semantic token - Typography - Font - Paragraph spacing - Others
 
     var fontParagraphSpacingLabelXLarge: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingLabelLarge: TypographyFontParagraphSpacingRawToken { get }
@@ -149,4 +165,7 @@ public protocol TypographySemanticTokens {
     var fontParagraphSpacingLabelSmall: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingCodeMedium: TypographyFontParagraphSpacingRawToken { get }
     var fontParagraphSpacingCodeSmall: TypographyFontParagraphSpacingRawToken { get }
+
+    // MARK: - Semantic tplens - Typography - Composites
+    // TODO: Missing specifications, composite semantic tokens to dd for display, heading, body, label, code
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#51 

### Description

<!-- Describe your changes in detail -->

- [x] Review and update raw tokens for typographty
- [x] Review and update semantic tokens for typography
- [x] Add unit tests for raw tokens for typography (order relationship)
- [x] Add unit tests for semantic tokens for typography (overridings)
- [x] [Tackle issue about font families](https://github.com/Orange-OpenSource/ouds-ios/issues/51#issuecomment-2271734993)
- [x] [Tackle issue about letter spacings](https://github.com/Orange-OpenSource/ouds-ios/issues/51#issuecomment-2271734993)
- [x] Check if other issues must be investigated

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

See #51

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
