### PR TITLE
[#58] Remove border tokens radius circle and radius pill (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Update value of opacity raw token "opacity800" from 0.88 to 0.80 ([#87](https://github.com/Orange-OpenSource/ouds-ios/issues/87))
 - [Library] Add missing unit tests for opacity raw tokens
 
+### Removed
+
+- [Library] Remove token borderRadiusPill and borderRadiusCircle ([#58](https://github.com/Orange-OpenSource/ouds-ios/issues/58))
+
 ### Fixed
 
 - [Library] Fix some typos in documentation ([#89](https://github.com/Orange-OpenSource/ouds-ios/issues/89))
@@ -59,7 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Add raw tokens and semantic tokens for border ([#30](https://github.com/Orange-OpenSource/ouds-ios/issues/30))
 - [Library] Define Swift Package architecture of library and tokens (raw and semantic) ([#33](https://github.com/Orange-OpenSource/ouds-ios/issues/33))
 - [Library] Define Swift Package library for OUDS ([#46](https://github.com/Orange-OpenSource/ouds-ios/issues/46))
-
 - [Showcase] Publication of comment on issues about new alpha build upload on TestFlight ([#56](https://github.com/Orange-OpenSource/ouds-ios/issues/56))
 - [Showcase] Distribute demo app development version ([#12](https://github.com/Orange-OpenSource/ouds-ios/issues/12)) 
 - [Showcase] Distribute demo app for feature validation ([#13](https://github.com/Orange-OpenSource/ouds-ios/issues/13))

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+BorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+BorderSemanticTokens.swift
@@ -38,8 +38,6 @@ extension OUDSTheme: BorderSemanticTokens {
     @objc open var borderRadiusShort: BorderRadiusSemanticToken { BorderRawTokens.borderRadius75 }
     @objc open var borderRadiusMedium: BorderRadiusSemanticToken { BorderRawTokens.borderRadius150 }
     @objc open var borderRadiusTall: BorderRadiusSemanticToken { BorderRawTokens.borderRadius300 }
-    @objc open var borderRadiusPill: BorderRadiusSemanticToken { BorderRawTokens.borderRadius9999 }
-    // TODO: How to deal with "border-radius-circle : 50%"?
 
     // MARK: Semantic token - Border - Style
 

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+BorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+BorderSemanticTokens.swift
@@ -38,7 +38,6 @@ extension MockTheme {
     override var borderRadiusShort: BorderRadiusSemanticToken { Self.mockThemeBorderRadiusRawToken }
     override var borderRadiusMedium: BorderRadiusSemanticToken { Self.mockThemeBorderRadiusRawToken }
     override var borderRadiusTall: BorderRadiusSemanticToken { Self.mockThemeBorderRadiusRawToken }
-    override var borderRadiusPill: BorderRadiusSemanticToken { Self.mockThemeBorderRadiusRawToken }
 
     // MARK: Semantic token - Border - Style
 

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfBorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfBorderSemanticTokens.swift
@@ -92,11 +92,6 @@ final class TestThemeOverrideOfBorderSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.borderRadiusTall == MockTheme.mockThemeBorderRadiusRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenBorderRadiusPill() throws {
-        XCTAssertNotEqual(inheritedTheme.borderRadiusPill, abstractTheme.borderRadiusPill)
-        XCTAssertTrue(inheritedTheme.borderRadiusPill == MockTheme.mockThemeBorderRadiusRawToken)
-    }
-
     // MARK: - Semantic token - Border - Style
 
     func testInheritedThemeCanOverrideSemanticTokenBorderStyleDefault() throws {

--- a/OUDS/Core/Tokens/RawTokens/Sources/BorderRawTokens.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/BorderRawTokens.swift
@@ -65,7 +65,6 @@ public enum BorderRawTokens {
     public static let borderRadius500: BorderRadiusRawToken = borderBase * 5
     public static let borderRadius600: BorderRadiusRawToken = borderBase * 6
     public static let borderRadius800: BorderRadiusRawToken = borderBase * 8
-    public static let borderRadius9999: BorderRadiusRawToken = 2000
 
     // MARK: Primitive token - Border - Style
 

--- a/OUDS/Core/Tokens/RawTokens/Tests/BorderRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/BorderRawTokensTests.swift
@@ -93,10 +93,6 @@ final class BorderRawTokensTests: XCTestCase {
         XCTAssertLessThan(BorderRawTokens.borderRadius600, BorderRawTokens.borderRadius800)
     }
 
-    func testBorderRadiusRawToken800LessThan9999() throws {
-        XCTAssertLessThan(BorderRawTokens.borderRadius800, BorderRawTokens.borderRadius9999)
-    }
-
     // MARK: - Primitive token - Border - Style
 
     /// Border styles raw tokens must be different

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/BorderSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/BorderSemanticTokens.swift
@@ -47,8 +47,6 @@ public protocol BorderSemanticTokens {
     var borderRadiusShort: BorderRadiusSemanticToken { get }
     var borderRadiusMedium: BorderRadiusSemanticToken { get }
     var borderRadiusTall: BorderRadiusSemanticToken { get }
-    var borderRadiusPill: BorderRadiusSemanticToken { get }
-    // TODO: How to deal with "border-radius-circle"?
 
     // MARK: - Semantic token - Border - Style
 


### PR DESCRIPTION
### Related issues

#58

### Description

- Rmeove useless border raw tokens for radius circle and radius pill

### Motivation & Context

Be compliant with specifications

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
