### PR TITLE
[#87] Update value for opacity800

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Library] "OUDSThemesCommons" product has been renamed to "OUDS"
+- [Library] Update value of opacity raw token "opacity800" from 0.88 to 0.80 ([#87](https://github.com/Orange-OpenSource/ouds-ios/issues/87))
+- [Library] Add missing unit tests for opacity raw tokens
 
 ### Fixed
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/OpacityRawTokens.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/OpacityRawTokens.swift
@@ -36,6 +36,6 @@ public enum OpacityRawTokens {
     public static let opacity500: OpacityRawToken = 0.32
     public static let opacity600: OpacityRawToken = 0.48
     public static let opacity700: OpacityRawToken = 0.64
-    public static let opacity800: OpacityRawToken = 0.88
+    public static let opacity800: OpacityRawToken = 0.80
     public static let opacity900: OpacityRawToken = 1
 }

--- a/OUDS/Core/Tokens/RawTokens/Tests/OpacityRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/OpacityRawTokensTests.swift
@@ -52,4 +52,8 @@ final class OpacityRawTokensTests: XCTestCase {
     func testOpacityRawToken700LessThan800() throws {
         XCTAssertLessThan(OpacityRawTokens.opacity700, OpacityRawTokens.opacity800)
     }
+
+    func testOpacityRawToken800LessThan900() throws {
+        XCTAssertLessThan(OpacityRawTokens.opacity800, OpacityRawTokens.opacity900)
+    }
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#87

### Description

- @julien-deramond submtited a PR to update _opacity800_ (#86)
- I checked his branch
- I merge into another branch so as to update the CHANGELOG and add a missing unit tests

### Motivation & Context

See #87 

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (N/A) My change follows accessibility good practices

#### Design

- (N/A)  My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (N/A) Design review has been done
- (N/A) Accessibiltiy review has been done
- (N/A) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
