### PR TITLE
[#36] Manage regular and compact layouts for sizing and spacing tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Library] Manage regular and compact layouts for sizing and spacing tokens
+- [Library] Box shadow 0 has been defined and elevation drag changed
 - [Doc] Create the basics of a documentation ([#9](https://github.com/Orange-OpenSource/ouds-ios/issues/9))
 - [Library] Add more semanttic and raw tokens for typography
 - [Library] Add more semantic and raw tokens for typography, and SwiftUI API to apply them
@@ -16,17 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Library] "OUDSThemesCommons" product has been renamed to "OUDS"
 - [Library] Update value of opacity raw token "opacity800" from 0.88 to 0.80 ([#87](https://github.com/Orange-OpenSource/ouds-ios/issues/87))
 - [Library] Add missing unit tests for opacity raw tokens
+- [Library] "OUDSThemesCommons" product has been renamed to "OUDS"
 
 ### Removed
 
 - [Library] Remove token borderRadiusPill and borderRadiusCircle ([#58](https://github.com/Orange-OpenSource/ouds-ios/issues/58))
-- [Library] Box shadow 0 has been defined and elevation drag changed
 - [Library] "Emphasis" words have been replaced by "emphasized"
-- [Library] "Box shadow" words have been removed in elevation semantic and raw tokens
-- [Library] Manage regular and compact layouts for sizing and spacing tokens 
+- [Library] "Box shadow" words have been removed in elevation semantic and raw tokens 
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Box shadow 0 has been defined and elevation drag changed
 - [Library] "Emphasis" words have been replaced by "emphasized"
 - [Library] "Box shadow" words have been removed in elevation semantic and raw tokens
+- [Library] Manage regular and compact layouts for sizing and spacing tokens 
 
 ### Fixed
 

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+SizingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+SizingSemanticTokens.swift
@@ -15,6 +15,7 @@ import Foundation
 import OUDSTokensRaw
 import OUDSTokensSemantic
 
+// swiftlint:disable line_length
 /// Defines basic values common to all themes for `SizingSemanticTokens`.
 /// These values can be overriden inside `OUDSTheme` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OUDSTheme: SizingSemanticTokens {
@@ -48,44 +49,42 @@ extension OUDSTheme: SizingSemanticTokens {
 
     // MARK: Semantic token - Sizing - Width height - Icon typography - Heading
 
-    // TODO: What should we do? In issue #36 there are 3 possible values (web paradigm ?), selected here the xl-2xl-3xl case
-    @objc open var sizeWidthHeightIconIsHeadingSmallShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension500 }
-    @objc open var sizeWidthHeightIconIsHeadingSmallMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension550 }
-    @objc open var sizeWidthHeightIconIsHeadingSmallTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension600 }
-    @objc open var sizeWidthHeightIconIsHeadingMediumShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension550 }
-    @objc open var sizeWidthHeightIconIsHeadingMediumMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension600 }
-    @objc open var sizeWidthHeightIconIsHeadingMediumTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension650 }
-    @objc open var sizeWidthHeightIconIsHeadingLargeShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension600 }
-    @objc open var sizeWidthHeightIconIsHeadingLargeMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension650 }
-    @objc open var sizeWidthHeightIconIsHeadingLargeTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension700 }
-    @objc open var sizeWidthHeightIconIsHeadingXLargeShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension700 }
-    @objc open var sizeWidthHeightIconIsHeadingXLargeMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension750 }
-    @objc open var sizeWidthHeightIconIsHeadingXLargeTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension800 }
+    @objc open var sizeWidthHeightIconIsHeadingSmallShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension400, regular: DimensionRawTokens.dimension400) }
+    @objc open var sizeWidthHeightIconIsHeadingSmallMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension500, regular: DimensionRawTokens.dimension500 ) }
+    @objc open var sizeWidthHeightIconIsHeadingSmallTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension550, regular: DimensionRawTokens.dimension550 ) }
+    @objc open var sizeWidthHeightIconIsHeadingMediumShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension400, regular: DimensionRawTokens.dimension500 ) }
+    @objc open var sizeWidthHeightIconIsHeadingMediumMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension500, regular: DimensionRawTokens.dimension550 ) }
+    @objc open var sizeWidthHeightIconIsHeadingMediumTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension550, regular: DimensionRawTokens.dimension600 ) }
+    @objc open var sizeWidthHeightIconIsHeadingLargeShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension500, regular: DimensionRawTokens.dimension550 ) }
+    @objc open var sizeWidthHeightIconIsHeadingLargeMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension550, regular: DimensionRawTokens.dimension600 ) }
+    @objc open var sizeWidthHeightIconIsHeadingLargeTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension600, regular: DimensionRawTokens.dimension650 ) }
+    @objc open var sizeWidthHeightIconIsHeadingXLargeShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension550, regular: DimensionRawTokens.dimension650 ) }
+    @objc open var sizeWidthHeightIconIsHeadingXLargeMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension600, regular: DimensionRawTokens.dimension700 ) }
+    @objc open var sizeWidthHeightIconIsHeadingXLargeTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension650, regular: DimensionRawTokens.dimension800 ) }
 
     // MARK: Semantic token - Sizing - Width height - Icon typography - Body
 
-    // TODO: What should we do? In issue #36 there are 3 possible values (web paradigm ?), selected here the xl-2xl-3xl case
-    @objc open var sizeWidthHeightIconIsBodySmallShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension200 }
-    @objc open var sizeWidthHeightIconIsBodySmallMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension250 }
-    @objc open var sizeWidthHeightIconIsBodySmallTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension300 }
-    @objc open var sizeWidthHeightIconIsBodyMediumShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension250 }
-    @objc open var sizeWidthHeightIconIsBodyMediumMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension300 }
-    @objc open var sizeWidthHeightIconIsBodyMediumTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension350 }
-    @objc open var sizeWidthHeightIconIsBodyLargeShort: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension400 }
-    @objc open var sizeWidthHeightIconIsBodyLargeMedium: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension500 }
-    @objc open var sizeWidthHeightIconIsBodyLargeTall: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension550 }
+    @objc open var sizeWidthHeightIconIsBodySmallShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension150, regular: DimensionRawTokens.dimension150 ) }
+    @objc open var sizeWidthHeightIconIsBodySmallMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension200, regular: DimensionRawTokens.dimension200 ) }
+    @objc open var sizeWidthHeightIconIsBodySmallTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension250, regular: DimensionRawTokens.dimension250 ) }
+    @objc open var sizeWidthHeightIconIsBodyMediumShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension200, regular: DimensionRawTokens.dimension200 ) }
+    @objc open var sizeWidthHeightIconIsBodyMediumMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension250, regular: DimensionRawTokens.dimension250 ) }
+    @objc open var sizeWidthHeightIconIsBodyMediumTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension300, regular: DimensionRawTokens.dimension300 ) }
+    @objc open var sizeWidthHeightIconIsBodyLargeShort: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension250, regular: DimensionRawTokens.dimension250 ) }
+    @objc open var sizeWidthHeightIconIsBodyLargeMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension300, regular: DimensionRawTokens.dimension300 ) }
+    @objc open var sizeWidthHeightIconIsBodyLargeTall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension350, regular: DimensionRawTokens.dimension350 ) }
 
     // MARK: Semantic token - Sizing - Max width
 
-    // TODO: What should we do? In issue #36 there are 3 possible values (web paradigm ?), selected here the xl-2xl-3xl case
-    @objc open var sizeMaxWidthTypographyDisplaySmall: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyDisplayMedium: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyDisplayLarge: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyHeadingSmall: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension7000 }
-    @objc open var sizeMaxWidthTypographyHeadingMedium: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyHeadingLarge: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyHeadingXLarge: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension11000 }
-    @objc open var sizeMaxWidthTypographyBodySmall: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension6000 }
-    @objc open var sizeMaxWidthTypographyBodyMedium: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension7000 }
-    @objc open var sizeMaxWidthTypographyBodyLarge: SizingMaxWidthSemanticToken { DimensionRawTokens.dimension7000 }
+    @objc open var sizeMaxWidthTypographyDisplaySmall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyDisplayMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyDisplayLarge: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyHeadingSmall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension6000, regular: DimensionRawTokens.dimension6000 ) }
+    @objc open var sizeMaxWidthTypographyHeadingMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyHeadingLarge: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyHeadingXLarge: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension9000, regular: DimensionRawTokens.dimension9000 ) }
+    @objc open var sizeMaxWidthTypographyBodySmall: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension6000, regular: DimensionRawTokens.dimension6000 ) }
+    @objc open var sizeMaxWidthTypographyBodyMedium: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension6000, regular: DimensionRawTokens.dimension6000 ) }
+    @objc open var sizeMaxWidthTypographyBodyLarge: SizingCompositeSemanticToken { SizingCompositeSemanticToken(compact: DimensionRawTokens.dimension6000, regular: DimensionRawTokens.dimension6000 ) }
 }
+// swiftlint:enable line_length

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+SpacingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+SpacingSemanticTokens.swift
@@ -15,6 +15,7 @@ import Foundation
 import OUDSTokensRaw
 import OUDSTokensSemantic
 
+// swiftlint:disable line_length
 /// Defines basic values common to all themes for `SpacingSemanticTokens`.
 /// These values can be overriden inside `OUDSTheme` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OUDSTheme: SpacingSemanticTokens {
@@ -34,17 +35,16 @@ extension OUDSTheme: SpacingSemanticTokens {
 
     // MARK: Semantic token - Spacing - Layout fluid
 
-    // TODO: What should we do? In issue #36 there are 3 possible values (web paradigm ?), selected here the xl-2xl-3xl case
-    @objc open var spaceLayoutFluidNone: SpacingLayoutSemanticToken { DimensionRawTokens.dimension0 }
-    @objc open var spaceLayoutFluidSmash: SpacingLayoutSemanticToken { DimensionRawTokens.dimension50 }
-    @objc open var spaceLayoutFluidShortest: SpacingLayoutSemanticToken { DimensionRawTokens.dimension100 }
-    @objc open var spaceLayoutFluidShorter: SpacingLayoutSemanticToken { DimensionRawTokens.dimension200 }
-    @objc open var spaceLayoutFluidShort: SpacingLayoutSemanticToken { DimensionRawTokens.dimension300 }
-    @objc open var spaceLayoutFluidMedium: SpacingLayoutSemanticToken { DimensionRawTokens.dimension400 }
-    @objc open var spaceLayoutFluidTall: SpacingLayoutSemanticToken { DimensionRawTokens.dimension500 }
-    @objc open var spaceLayoutFluidTaller: SpacingLayoutSemanticToken { DimensionRawTokens.dimension600 }
-    @objc open var spaceLayoutFluidTallest: SpacingLayoutSemanticToken { DimensionRawTokens.dimension700 }
-    @objc open var spaceLayoutFluidSpacious: SpacingLayoutSemanticToken { DimensionRawTokens.dimension800 }
+    @objc open var spaceLayoutFluidNone: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension0, regular: DimensionRawTokens.dimension0) }
+    @objc open var spaceLayoutFluidSmash: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension25, regular: DimensionRawTokens.dimension50) }
+    @objc open var spaceLayoutFluidShortest: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension50, regular: DimensionRawTokens.dimension100) }
+    @objc open var spaceLayoutFluidShorter: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension100, regular: DimensionRawTokens.dimension150) }
+    @objc open var spaceLayoutFluidShort: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension150, regular: DimensionRawTokens.dimension200) }
+    @objc open var spaceLayoutFluidMedium: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension200, regular: DimensionRawTokens.dimension300) }
+    @objc open var spaceLayoutFluidTall: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension300, regular: DimensionRawTokens.dimension400) }
+    @objc open var spaceLayoutFluidTaller: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension400, regular: DimensionRawTokens.dimension500) }
+    @objc open var spaceLayoutFluidTallest: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension500, regular: DimensionRawTokens.dimension600) }
+    @objc open var spaceLayoutFluidSpacious: SpacingCompositeSemanticToken { SpacingCompositeSemanticToken(compact: DimensionRawTokens.dimension600, regular: DimensionRawTokens.dimension700) }
 
     // MARK: Semantic token - Spacing - Padding - Padding inline
 
@@ -137,3 +137,4 @@ extension OUDSTheme: SpacingSemanticTokens {
     @objc open var spaceRowGapComponentIsIconTall: SpacingGapStackSemanticToken { DimensionRawTokens.dimension100 }
     @objc open var spaceRowGapComponentIsIconTaller: SpacingGapStackSemanticToken { DimensionRawTokens.dimension200 }
 }
+// swiftlint:enable line_length

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+SizingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+SizingSemanticTokens.swift
@@ -18,6 +18,7 @@ import OUDSTokensSemantic
 extension MockTheme {
 
     static let mockThemeSizeRawToken: DimensionRawToken = 118_000
+    static let mockThemeSizeCompositeToken: SizingCompositeSemanticToken = SizingCompositeSemanticToken(compact: 1, regular: 151)
 
     // MARK: Semantic token - Sizing - Width height - Icon decorative
 
@@ -48,41 +49,41 @@ extension MockTheme {
 
     // MARK: Semantic token - Sizing - Width height - Icon typography - Heading
 
-    override var sizeWidthHeightIconIsHeadingSmallShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingSmallMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingSmallTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingMediumShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingMediumMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingMediumTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingLargeShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingLargeMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingLargeTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingXLargeShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingXLargeMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsHeadingXLargeTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
+    override var sizeWidthHeightIconIsHeadingSmallShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingSmallMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingSmallTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingMediumShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingMediumMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingMediumTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingLargeShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingLargeMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingLargeTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingXLargeShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingXLargeMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsHeadingXLargeTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
 
     // MARK: Semantic token - Sizing - Width height - Icon typography - Body
 
-    override var sizeWidthHeightIconIsBodySmallShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodySmallMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodySmallTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyMediumShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyMediumMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyMediumTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyLargeShort: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyLargeMedium: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeWidthHeightIconIsBodyLargeTall: SizingWidthHeightSemanticToken { Self.mockThemeSizeRawToken }
+    override var sizeWidthHeightIconIsBodySmallShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodySmallMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodySmallTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyMediumShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyMediumMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyMediumTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyLargeShort: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyLargeMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeWidthHeightIconIsBodyLargeTall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
 
     // MARK: Semantic token - Sizing - Max width
 
-    override var sizeMaxWidthTypographyDisplaySmall: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyDisplayMedium: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyDisplayLarge: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyHeadingSmall: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyHeadingMedium: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyHeadingLarge: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyHeadingXLarge: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyBodySmall: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyBodyMedium: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
-    override var sizeMaxWidthTypographyBodyLarge: SizingMaxWidthSemanticToken { Self.mockThemeSizeRawToken }
+    override var sizeMaxWidthTypographyDisplaySmall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyDisplayMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyDisplayLarge: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyHeadingSmall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyHeadingMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyHeadingLarge: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyHeadingXLarge: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyBodySmall: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyBodyMedium: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
+    override var sizeMaxWidthTypographyBodyLarge: SizingCompositeSemanticToken { Self.mockThemeSizeCompositeToken }
 }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+SpacingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+SpacingSemanticTokens.swift
@@ -18,6 +18,7 @@ import OUDSTokensSemantic
 extension MockTheme {
 
     static let mockThemeSpaceRawToken: DimensionRawToken = 911
+    static let mockThemeSpaceSemanticToken: SpacingCompositeSemanticToken = SpacingCompositeSemanticToken(compact: 1, regular: 151)
 
     // MARK: Semantic token - Spacing - Layout fix
 
@@ -34,16 +35,16 @@ extension MockTheme {
 
     // MARK: Semantic token - Spacing - Layout fluid
 
-    override var spaceLayoutFluidNone: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidSmash: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidShortest: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidShorter: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidShort: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidMedium: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidTall: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidTaller: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidTallest: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
-    override var spaceLayoutFluidSpacious: SpacingLayoutSemanticToken { Self.mockThemeSpaceRawToken }
+    override var spaceLayoutFluidNone: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidSmash: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidShortest: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidShorter: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidShort: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidMedium: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidTall: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidTaller: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidTallest: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
+    override var spaceLayoutFluidSpacious: SpacingCompositeSemanticToken { Self.mockThemeSpaceSemanticToken }
 
     // MARK: Semantic token - Spacing - Padding - Padding inline
 

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfSizingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfSizingSemanticTokens.swift
@@ -141,160 +141,160 @@ final class TestThemeOverrideOfSizingSemanticTokens: XCTestCase {
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingSmallShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingSmallShort, abstractTheme.sizeWidthHeightIconIsHeadingSmallShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingSmallMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingSmallMedium, abstractTheme.sizeWidthHeightIconIsHeadingSmallMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingSmallTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingSmallTall, abstractTheme.sizeWidthHeightIconIsHeadingSmallTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingSmallTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingMediumShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingMediumShort, abstractTheme.sizeWidthHeightIconIsHeadingMediumShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingMediumMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingMediumMedium, abstractTheme.sizeWidthHeightIconIsHeadingMediumMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingMediumTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingMediumTall, abstractTheme.sizeWidthHeightIconIsHeadingMediumTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingMediumTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingLargeShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingLargeShort, abstractTheme.sizeWidthHeightIconIsHeadingLargeShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingLargeMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingLargeMedium, abstractTheme.sizeWidthHeightIconIsHeadingLargeMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingLargeTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingLargeTall, abstractTheme.sizeWidthHeightIconIsHeadingLargeTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingLargeTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingXLargeShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeShort, abstractTheme.sizeWidthHeightIconIsHeadingXLargeShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingXLargeMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeMedium, abstractTheme.sizeWidthHeightIconIsHeadingXLargeMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsHeadingXLargeTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeTall, abstractTheme.sizeWidthHeightIconIsHeadingXLargeTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsHeadingXLargeTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     // MARK: - Semantic token - Sizing - Width height - Icon typography - Body
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodySmallShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodySmallShort, abstractTheme.sizeWidthHeightIconIsBodySmallShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodySmallMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodySmallMedium, abstractTheme.sizeWidthHeightIconIsBodySmallMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodySmallTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodySmallTall, abstractTheme.sizeWidthHeightIconIsBodySmallTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodySmallTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyMediumShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyMediumShort, abstractTheme.sizeWidthHeightIconIsBodyMediumShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyMediumMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyMediumMedium, abstractTheme.sizeWidthHeightIconIsBodyMediumMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyMediumTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyMediumTall, abstractTheme.sizeWidthHeightIconIsBodyMediumTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyMediumTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyLargeShort() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyLargeShort, abstractTheme.sizeWidthHeightIconIsBodyLargeShort)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeShort == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeShort.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyLargeMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyLargeMedium, abstractTheme.sizeWidthHeightIconIsBodyLargeMedium)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeWidthHeightIconIsBodyLargeTall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeWidthHeightIconIsBodyLargeTall, abstractTheme.sizeWidthHeightIconIsBodyLargeTall)
-        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeTall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeWidthHeightIconIsBodyLargeTall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     // MARK: - Semantic token - Sizing - Max width
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyDisplaySmall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyDisplaySmall, abstractTheme.sizeMaxWidthTypographyDisplaySmall)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplaySmall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplaySmall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyDisplayMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyDisplayMedium, abstractTheme.sizeMaxWidthTypographyDisplayMedium)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplayMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplayMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyDisplayLarge() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyDisplayLarge, abstractTheme.sizeMaxWidthTypographyDisplayLarge)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplayLarge == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyDisplayLarge.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyHeadingSmall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyHeadingSmall, abstractTheme.sizeMaxWidthTypographyHeadingSmall)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingSmall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingSmall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyHeadingMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyHeadingMedium, abstractTheme.sizeMaxWidthTypographyHeadingMedium)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyHeadingLarge() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyHeadingLarge, abstractTheme.sizeMaxWidthTypographyHeadingLarge)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingLarge == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingLarge.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyHeadingXLarge() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyHeadingXLarge, abstractTheme.sizeMaxWidthTypographyHeadingXLarge)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingXLarge == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyHeadingXLarge.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyBodySmall() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyBodySmall, abstractTheme.sizeMaxWidthTypographyBodySmall)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodySmall == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodySmall.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyBodyMedium() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyBodyMedium, abstractTheme.sizeMaxWidthTypographyBodyMedium)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodyMedium == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodyMedium.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSizeMaxWidthTypographyBodyLarge() throws {
         XCTAssertNotEqual(inheritedTheme.sizeMaxWidthTypographyBodyLarge, abstractTheme.sizeMaxWidthTypographyBodyLarge)
-        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodyLarge == MockTheme.mockThemeSizeRawToken)
+        XCTAssertTrue(inheritedTheme.sizeMaxWidthTypographyBodyLarge.isEqual(MockTheme.mockThemeSizeCompositeToken))
     }
 }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfSpacingSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfSpacingSemanticTokens.swift
@@ -86,52 +86,52 @@ final class TestThemeOverrideOfSpacingSemanticTokens: XCTestCase {
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidNone() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidNone, abstractTheme.spaceLayoutFluidNone)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidNone == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidNone.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidSmash() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidSmash, abstractTheme.spaceLayoutFluidSmash)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidSmash == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidSmash.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidShortest() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidShortest, abstractTheme.spaceLayoutFluidShortest)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShortest == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShortest.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidShorter() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidShorter, abstractTheme.spaceLayoutFluidShorter)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShorter == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShorter.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidShort() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidShort, abstractTheme.spaceLayoutFluidShort)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShort == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidShort.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidMedium() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidMedium, abstractTheme.spaceLayoutFluidMedium)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidMedium == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidMedium.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidTall() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidTall, abstractTheme.spaceLayoutFluidTall)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTall == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTall.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidTaller() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidTaller, abstractTheme.spaceLayoutFluidTaller)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTaller == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTaller.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidTallest() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidTallest, abstractTheme.spaceLayoutFluidTallest)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTallest == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidTallest.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     func testInheritedThemeCanOverrideSemanticTokenSpaceLayoutFluidSpacious() throws {
         XCTAssertNotEqual(inheritedTheme.spaceLayoutFluidSpacious, abstractTheme.spaceLayoutFluidSpacious)
-        XCTAssertTrue(inheritedTheme.spaceLayoutFluidSpacious == MockTheme.mockThemeSpaceRawToken)
+        XCTAssertTrue(inheritedTheme.spaceLayoutFluidSpacious.isEqual(MockTheme.mockThemeSpaceSemanticToken))
     }
 
     // MARK: - Semantic token - Spacing - Padding - Padding inline

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/SizingSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/SizingSemanticTokens.swift
@@ -22,7 +22,30 @@ public typealias SizingWidthHeightSemanticToken = DimensionRawToken
 /// Basically a size semantic token for max width is a dimension raw token, it has the same final type
 public typealias SizingMaxWidthSemanticToken = DimensionRawToken
 
-// MARK: - Semantic tokens
+// MARK: Semantic tokens
+
+// MARK: - Composite Semantic Token
+
+/// Composite semantic tokens which will wrap a combination of `SizingWidthHeightSemanticToken` depending to viewports.
+public final class SizingCompositeSemanticToken: NSObject {
+
+    /// For **extra-compact** and **compact** viewports
+    public let compact: SizingWidthHeightSemanticToken
+    /// For **regular** and **medium** viewports
+    public let regular: SizingWidthHeightSemanticToken
+
+    public init(compact: SizingWidthHeightSemanticToken, regular: SizingWidthHeightSemanticToken) {
+        self.compact = compact
+        self.regular = regular
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SizingCompositeSemanticToken else { return false }
+        return self.compact == other.compact && self.regular == other.regular
+    }
+}
+
+// MARK: - Sizing Semantic Tokens
 
 /// This is a group of semantic tokens for **sizing**.
 /// It defines all `SizingSemanticToken` a theme must have.
@@ -57,41 +80,41 @@ public protocol SizingSemanticTokens {
 
     // MARK: - Semantic token - Sizing - Width height - Icon typography - Heading
 
-    var sizeWidthHeightIconIsHeadingSmallShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingSmallMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingSmallTall: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingMediumShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingMediumMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingMediumTall: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingLargeShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingLargeMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingLargeTall: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingXLargeShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingXLargeMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsHeadingXLargeTall: SizingWidthHeightSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingSmallShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingSmallMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingSmallTall: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingMediumShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingMediumMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingMediumTall: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingLargeShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingLargeMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingLargeTall: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingXLargeShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingXLargeMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsHeadingXLargeTall: SizingCompositeSemanticToken { get }
 
     // MARK: - Semantic token - Sizing - Width height - Icon typography - Body
 
-    var sizeWidthHeightIconIsBodySmallShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodySmallMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodySmallTall: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyMediumShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyMediumMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyMediumTall: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyLargeShort: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyLargeMedium: SizingWidthHeightSemanticToken { get }
-    var sizeWidthHeightIconIsBodyLargeTall: SizingWidthHeightSemanticToken { get }
+    var sizeWidthHeightIconIsBodySmallShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodySmallMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodySmallTall: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyMediumShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyMediumMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyMediumTall: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyLargeShort: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyLargeMedium: SizingCompositeSemanticToken { get }
+    var sizeWidthHeightIconIsBodyLargeTall: SizingCompositeSemanticToken { get }
 
     // MARK: - Semantic token - Sizing - Max width
 
-    var sizeMaxWidthTypographyDisplaySmall: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyDisplayMedium: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyDisplayLarge: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyHeadingSmall: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyHeadingMedium: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyHeadingLarge: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyHeadingXLarge: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyBodySmall: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyBodyMedium: SizingMaxWidthSemanticToken { get }
-    var sizeMaxWidthTypographyBodyLarge: SizingMaxWidthSemanticToken { get }
+    var sizeMaxWidthTypographyDisplaySmall: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyDisplayMedium: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyDisplayLarge: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyHeadingSmall: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyHeadingMedium: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyHeadingLarge: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyHeadingXLarge: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyBodySmall: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyBodyMedium: SizingCompositeSemanticToken { get }
+    var sizeMaxWidthTypographyBodyLarge: SizingCompositeSemanticToken { get }
 }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/SpacingSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/SpacingSemanticTokens.swift
@@ -34,7 +34,30 @@ public typealias SpacingGapInlineSemanticToken = DimensionRawToken
 /// Basically a space semantic token for gap stack is a dimension raw token, it has the same final type
 public typealias SpacingGapStackSemanticToken = DimensionRawToken
 
-// MARK: - Semantic tokens
+// MARK: Semantic tokens
+
+// MARK: - Composite Semantic Token
+
+/// Composite semantic tokens which will wrap a combination of `DimensionRawToken` depending to viewports.
+public final class SpacingCompositeSemanticToken: NSObject {
+
+    /// For **extra-compact** and **compact** viewports
+    public let compact: DimensionRawToken
+    /// For **regular** and **medium** viewports
+    public let regular: DimensionRawToken
+
+    public init(compact: DimensionRawToken, regular: DimensionRawToken) {
+        self.compact = compact
+        self.regular = regular
+    }
+
+    public override func isEqual(_ object: Any?) -> Bool {
+        guard let other = object as? SpacingCompositeSemanticToken else { return false }
+        return self.compact == other.compact && self.regular == other.regular
+    }
+}
+
+// MARK: - Spacing Semantic Tokens
 
 /// This is a group of semantic tokens for **spacing**.
 /// It defines all `SpacingSemanticToken` a theme must have.
@@ -55,16 +78,16 @@ public protocol SpacingSemanticTokens {
 
     // MARK: Semantic token - Spacing - Layout fluid
 
-    var spaceLayoutFluidNone: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidSmash: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidShortest: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidShorter: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidShort: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidMedium: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidTall: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidTaller: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidTallest: SpacingLayoutSemanticToken { get }
-    var spaceLayoutFluidSpacious: SpacingLayoutSemanticToken { get }
+    var spaceLayoutFluidNone: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidSmash: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidShortest: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidShorter: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidShort: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidMedium: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidTall: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidTaller: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidTallest: SpacingCompositeSemanticToken { get }
+    var spaceLayoutFluidSpacious: SpacingCompositeSemanticToken { get }
 
     // MARK: Semantic token - Spacing - Padding - Padding inline
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#36 (but should not be closed)

### Description

<!-- Describe your changes in detail -->
- Manage viewports for regular and compact modes fir sizing and spacing tokens
- Add more tests

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)


### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
