### PR TITLE
Remove spread value from elevation tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [DemoApp] Display fake components for elevation rendering tests
 - [Library] A theme can now override the custom font family
 - [Library] Add more unit tests for theme overriding and raw tokens controls
 - [Library] Add and update raw and semantic grid tokens ([#40](https://github.com/Orange-OpenSource/ouds-ios/issues/40))
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] Remove spread value for elevation tokens
 - [Library] Remove paragraph spacing tokens for typography
 - [Library] Term "fluid" has been replaced by "adaptable" in spacing semantic tokens
 - [Doc] Improve DocC documentation about tokens and views extensions

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -27,9 +27,9 @@ myView.shadow(elevation: theme.elevationDragLight)
 ColorRawTokens.colorTransparentBlack400)
 
 // And if you look deeper, the raw token "elevationBottom_3_500" can be like:
-public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack500)
+public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack500)
 
-// Blur and spread will be used to compute the radius value
+// Blur will be used to compute the radius value
 ```
 
 ### Apply a specific typography

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+ElevationSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+ElevationSemanticTokens.swift
@@ -15,7 +15,6 @@ import Foundation
 import OUDSTokensRaw
 import OUDSTokensSemantic
 
-// swiftlint:disable line_length
 /// Defines basic values common to all themes for `ElevationSemanticTokenss`.
 /// These values can be overriden inside `OUDSTheme` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 /// The aim of this extensions is to make relationships between all semantic tokens for elevations and associated raw tokens.
@@ -74,18 +73,6 @@ extension OUDSTheme: ElevationSemanticTokens {
     @objc open var elevationBlurStickyEmphasized: ElevationBlurSemanticToken { ElevationRawTokens.elevationBlur400 }
     @objc open var elevationBlurStickyNavigationScrolled: ElevationBlurSemanticToken { ElevationRawTokens.elevationBlur400 }
     @objc open var elevationBlurFocus: ElevationBlurSemanticToken { ElevationRawTokens.elevationBlur0 }
-
-    // MARK: Semantic token - Elevation - Spread
-
-    @objc open var elevationSpreadNone: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpread0 }
-    @objc open var elevationSpreadRaised: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpread0 }
-    @objc open var elevationSpreadDrag: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN100 }
-    @objc open var elevationSpreadOverlayDefault: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN100 }
-    @objc open var elevationSpreadOverlayEmphasized: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN300 }
-    @objc open var elevationSpreadStickyDefault: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN100 }
-    @objc open var elevationSpreadStickyEmphasized: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN100 }
-    @objc open var elevationSpreadStickyNavigationScrolled: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpreadN100 }
-    @objc open var elevationSpreadFocus: ElevationSpreadSemanticToken { ElevationRawTokens.elevationSpread300 }
 
     // MARK: Semantic token - Elevation - Color - None
 
@@ -155,7 +142,6 @@ extension OUDSTheme: ElevationSemanticTokens {
     @objc open var elevationStickyNavigationScrolledLight: ElevationCompositeSemanticToken { ElevationRawTokens.elevationBottom_1_500 }
     @objc open var elevationStickyNavigationScrolledDark: ElevationCompositeSemanticToken { ElevationRawTokens.elevationBottom_1_500 }
 
-    @objc open var elevationFocusLight: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 3, color: ColorRawTokens.colorTransparentWhite900) }
-    @objc open var elevationFocusDark: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 3, color: ColorRawTokens.colorTransparentWhite900) }
+    @objc open var elevationFocusLight: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentWhite900) }
+    @objc open var elevationFocusDark: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentWhite900) }
 }
-// swiftlint:enable line_length

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+ElevationSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+ElevationSemanticTokens.swift
@@ -21,12 +21,10 @@ extension MockTheme {
     static let mockThemeXRawToken: ElevationRawToken = 711
     static let mockThemeYRawToken: ElevationRawToken = 713
     static let mockThemeBlurRawToken: ElevationRawToken = 816
-    static let mockThemeSpreadRawToken: ElevationRawToken = 80085
     static let mockThemeElevationColorRawToken: ColorRawToken = ColorRawTokens.colorFunctionalMalachite500
     static let mockThemeCompositeRawToken: ElevationCompositeRawToken = ElevationCompositeRawToken(x: 118,
                                                                                                    y: 712,
                                                                                                    blur: 118,
-                                                                                                   spread: 218,
                                                                                                    color: ColorRawTokens.colorFunctionalDodgerBlue800)
 
     // MARK: Semantic token - Elevation - Z index
@@ -81,18 +79,6 @@ extension MockTheme {
     override var elevationBlurStickyEmphasized: ElevationBlurSemanticToken { Self.mockThemeBlurRawToken }
     override var elevationBlurStickyNavigationScrolled: ElevationBlurSemanticToken { Self.mockThemeBlurRawToken }
     override var elevationBlurFocus: ElevationBlurSemanticToken { Self.mockThemeBlurRawToken }
-
-    // MARK: Semantic token - Elevation - Spread
-
-    override var elevationSpreadNone: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadRaised: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadDrag: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadOverlayDefault: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadOverlayEmphasized: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadStickyDefault: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadStickyEmphasized: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadStickyNavigationScrolled: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
-    override var elevationSpreadFocus: ElevationSpreadSemanticToken { Self.mockThemeSpreadRawToken }
 
     // MARK: Semantic token - Elevation - Color - None
 

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfElevationSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfElevationSemanticTokens.swift
@@ -243,53 +243,6 @@ final class TestThemeOverrideOfElevationSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.elevationBlurFocus == MockTheme.mockThemeBlurRawToken)
     }
 
-    // MARK: - Semantic token - Elevation - Spread
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadNone() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadNone, abstractTheme.elevationSpreadNone)
-        XCTAssertTrue(inheritedTheme.elevationSpreadNone == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadRaised() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadRaised, abstractTheme.elevationSpreadRaised)
-        XCTAssertTrue(inheritedTheme.elevationSpreadRaised == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadDrag() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadDrag, abstractTheme.elevationSpreadDrag)
-        XCTAssertTrue(inheritedTheme.elevationSpreadDrag == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadOverlayDefault() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadOverlayDefault, abstractTheme.elevationSpreadOverlayDefault)
-        XCTAssertTrue(inheritedTheme.elevationSpreadOverlayDefault == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadOverlayEmphasized() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadOverlayEmphasized, abstractTheme.elevationSpreadOverlayEmphasized)
-        XCTAssertTrue(inheritedTheme.elevationSpreadOverlayEmphasized == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadStickyDefault() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadStickyDefault, abstractTheme.elevationSpreadStickyDefault)
-        XCTAssertTrue(inheritedTheme.elevationSpreadStickyDefault == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadStickyEmphasized() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadStickyEmphasized, abstractTheme.elevationSpreadStickyEmphasized)
-        XCTAssertTrue(inheritedTheme.elevationSpreadStickyEmphasized == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadStickyNavigationScrolled() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadStickyNavigationScrolled, abstractTheme.elevationSpreadStickyNavigationScrolled)
-        XCTAssertTrue(inheritedTheme.elevationSpreadStickyNavigationScrolled == MockTheme.mockThemeSpreadRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenElevationSpreadFocus() throws {
-        XCTAssertNotEqual(inheritedTheme.elevationSpreadFocus, abstractTheme.elevationSpreadFocus)
-        XCTAssertTrue(inheritedTheme.elevationSpreadFocus == MockTheme.mockThemeSpreadRawToken)
-    }
-
     // MARK: - Semantic token - Elevation - Color - None
 
     func testInheritedThemeCanOverrideSemanticTokenElevationColorNoneLight() throws {

--- a/OUDS/Core/Themes/Inverse/Sources/InverseTheme+ElevationSemanticTokens.swift
+++ b/OUDS/Core/Themes/Inverse/Sources/InverseTheme+ElevationSemanticTokens.swift
@@ -15,7 +15,6 @@ import Foundation
 import OUDSTokensRaw
 import OUDSTokensSemantic
 
-// swiftlint:disable line_length
 extension InverseTheme {
 
     // MARK: Semantic token - Elevation - Color - None
@@ -86,7 +85,6 @@ extension InverseTheme {
     public override var elevationStickyNavigationScrolledLight: ElevationCompositeSemanticToken { ElevationRawTokens.elevationBottom_1_500 }
     public override var elevationStickyNavigationScrolledDark: ElevationCompositeSemanticToken { ElevationRawTokens.elevationBottom_1_500 }
 
-    public override var elevationFocusLight: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 3, color: ColorRawTokens.colorTransparentWhite900) }
-    public override var elevationFocusDark: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 3, color: ColorRawTokens.colorTransparentWhite900) }
+    public override var elevationFocusLight: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentWhite900) }
+    public override var elevationFocusDark: ElevationCompositeSemanticToken { ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentWhite900) }
 }
-// swiftlint:enable line_length

--- a/OUDS/Core/Tokens/RawTokens/Sources/ElevationRawTokens.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/ElevationRawTokens.swift
@@ -28,27 +28,24 @@ public final class ElevationCompositeRawToken: NSObject { // For @objc compatibi
     public let x: ElevationRawToken
     /// The Y offset for the elevation
     public let y: ElevationRawToken
-    /// The *Figma* blur effect for the elevation
+    /// The *Figma* blur effect for the elevation, to use for `radius` computations.
     public let blur: ElevationRawToken
-    /// The *Figma* spread effect for the elevation
-    public let spread: ElevationRawToken
     /// The color of the shadow effect
     public let color: ColorRawToken
 
-    /// The *Figma* tool uses its own implementation of shadow or elevation effect with a *blur* and a *spread* values defined in the *tokens*.
+    /// The *Figma* tool uses its own implementation of shadow or elevation effect with a *blur* and a *spread* values defined in the *tokens*, inherited from web universe.
     /// However *SwiftUI* for shadows effects uses only a *radius* which does not match the *Figma* *blur* and *spread* radiuses values.
-    /// Thus this value is computed from them so as to try to reproduce the same effect applying the formula
+    /// Thus this value is computed from the *blur* value so as to try to reproduce the same effect applying the formula
     ///
-    /// ** radius = blur + (spread / 2) **
+    /// ** radius = blur +  / 2**
     public var radius: ElevationRawToken {
-        blur + spread / 2 // Or maybe `CGFloat(blur + abs(spread))` ((╯°□°)╯︵ ┻━┻ according to GenAI tools)
+        blur / 2
     }
 
-    public init(x: ElevationRawToken, y: ElevationRawToken, blur: ElevationRawToken, spread: ElevationRawToken, color: ColorRawToken) {
+    public init(x: ElevationRawToken, y: ElevationRawToken, blur: ElevationRawToken, color: ColorRawToken) {
         self.x = x
         self.y = y
         self.blur = blur
-        self.spread = spread
         self.color = color
     }
 
@@ -57,7 +54,6 @@ public final class ElevationCompositeRawToken: NSObject { // For @objc compatibi
         return self.x == other.x
         && self.y == other.y
         && self.blur == other.blur
-        && self.spread == other.spread
         && self.color == other.color
     }
 }
@@ -113,52 +109,45 @@ public enum ElevationRawTokens {
     public static let elevationBlur600: ElevationRawToken = 12
     public static let elevationBlur700: ElevationRawToken = 20
 
-    // MARK: Primitive token - Elevation - Spread
-
-    public static let elevationSpreadN100: ElevationRawToken = -1
-    public static let elevationSpreadN200: ElevationRawToken = -2
-    public static let elevationSpreadN300: ElevationRawToken = -4
-    public static let elevationSpreadN400: ElevationRawToken = -8
-    public static let elevationSpread0: ElevationRawToken = 0
-    public static let elevationSpread300: ElevationRawToken = 3
-
     // MARK: Primitive token - Elevation - Box Shadow
 
-    public static let elevationBottom_0 = ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 0, color: ColorRawTokens.colorTransparentBlack0)
-    public static let elevationBottom_1_100 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_1_200 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_1_300 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_1_400 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_1_500 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_1_600 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack600)
-    public static let elevationBottom_2_100 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_2_200 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_2_300 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_2_400 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_2_500 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_2_600 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, spread: 0, color: ColorRawTokens.colorTransparentBlack600)
-    public static let elevationBottom_3_100 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_3_200 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_3_300 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_3_400 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_3_600 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack600)
-    public static let elevationBottom_4_100 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_4_200 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_4_300 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_4_400 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_4_500 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_4_600 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, spread: -2, color: ColorRawTokens.colorTransparentBlack600)
-    public static let elevationBottom_5_100 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_5_200 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_5_300 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_5_400 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_5_500 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_5_600 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack600)
-    public static let elevationBottom_6_100 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack100)
-    public static let elevationBottom_6_200 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack200)
-    public static let elevationBottom_6_300 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack300)
-    public static let elevationBottom_6_400 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack400)
-    public static let elevationBottom_6_500 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack500)
-    public static let elevationBottom_6_600 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, spread: -8, color: ColorRawTokens.colorTransparentBlack600)
+    // WARNING: Not the same syntax between CSS and Figma, maybe blur and Y and inverted, beware
+
+    public static let elevationBottom_0 = ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentBlack0)
+    public static let elevationBottom_1_100 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_1_200 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_1_300 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_1_400 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_1_500 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_1_600 = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack600)
+    public static let elevationBottom_2_100 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_2_200 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_2_300 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_2_400 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_2_500 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_2_600 = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack600)
+    public static let elevationBottom_3_100 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_3_200 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_3_300 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_3_400 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_3_600 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack600)
+    public static let elevationBottom_4_100 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_4_200 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_4_300 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_4_400 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_4_500 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_4_600 = ElevationCompositeRawToken(x: 0, y: 8, blur: 8, color: ColorRawTokens.colorTransparentBlack600)
+    public static let elevationBottom_5_100 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_5_200 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_5_300 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_5_400 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_5_500 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_5_600 = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack600)
+    public static let elevationBottom_6_100 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack100)
+    public static let elevationBottom_6_200 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack200)
+    public static let elevationBottom_6_300 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack300)
+    public static let elevationBottom_6_400 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack400)
+    public static let elevationBottom_6_500 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack500)
+    public static let elevationBottom_6_600 = ElevationCompositeRawToken(x: 0, y: 20, blur: 20, color: ColorRawTokens.colorTransparentBlack600)
 }

--- a/OUDS/Core/Tokens/RawTokens/Tests/ElevationRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/ElevationRawTokensTests.swift
@@ -29,39 +29,39 @@ final class ElevationRawTokensTests: XCTestCase {
 
     func testRadiusComputation() throws {
         // Given
-        var token = ElevationCompositeRawToken(x: 0, y: 0, blur: 0, spread: 0, color: ColorRawTokens.colorTransparentBlack500)
+        var token = ElevationCompositeRawToken(x: 0, y: 0, blur: 0, color: ColorRawTokens.colorTransparentBlack500)
         // When
         var radius = token.radius
         // Then
         XCTAssertTrue(radius == 0)
 
         // Given
-        token = ElevationCompositeRawToken(x: 0, y: 2, blur: 1, spread: 0, color: ColorRawTokens.colorTransparentBlack400)
+        token = ElevationCompositeRawToken(x: 0, y: 2, blur: 1, color: ColorRawTokens.colorTransparentBlack400)
+        // When
+        radius = token.radius
+        // Then
+        XCTAssertTrue(radius == 0.5)
+
+        // Given
+        token = ElevationCompositeRawToken(x: 0, y: 3, blur: 2, color: ColorRawTokens.colorTransparentBlack300)
         // When
         radius = token.radius
         // Then
         XCTAssertTrue(radius == 1)
 
         // Given
-        token = ElevationCompositeRawToken(x: 0, y: 3, blur: 2, spread: 0, color: ColorRawTokens.colorTransparentBlack300)
+        token = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack500)
         // When
         radius = token.radius
         // Then
         XCTAssertTrue(radius == 2)
 
         // Given
-        token = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, spread: -1, color: ColorRawTokens.colorTransparentBlack500)
+        token = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack300)
         // When
         radius = token.radius
         // Then
-        XCTAssertTrue(radius == 3.5)
-
-        // Given
-        token = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, spread: -4, color: ColorRawTokens.colorTransparentBlack300)
-        // When
-        radius = token.radius
-        // Then
-        XCTAssertTrue(radius == 10)
+        XCTAssertTrue(radius == 6)
     }
 
     // MARK: - Primitive token - Elevation - Z Index
@@ -176,28 +176,6 @@ final class ElevationRawTokensTests: XCTestCase {
 
     func testElevationBlurRawToken600LessThanBlur700() throws {
         XCTAssertLessThan(ElevationRawTokens.elevationBlur600, ElevationRawTokens.elevationBlur700)
-    }
-
-    // MARK: - Primitive token - Elevation - Spread
-
-    func testElevationSpreadMinus400LessThanMinus300() throws {
-        XCTAssertLessThan(ElevationRawTokens.elevationSpreadN400, ElevationRawTokens.elevationSpreadN300)
-    }
-
-    func testElevationSpreadMinus300LessThanMinus200() throws {
-        XCTAssertLessThan(ElevationRawTokens.elevationSpreadN300, ElevationRawTokens.elevationSpreadN200)
-    }
-
-    func testElevationSpreadMinus200LessThanMinus100() throws {
-        XCTAssertLessThan(ElevationRawTokens.elevationSpreadN200, ElevationRawTokens.elevationSpreadN100)
-    }
-
-    func testElevationSpreadMinus100LessThan0() throws {
-        XCTAssertLessThan(ElevationRawTokens.elevationSpreadN100, ElevationRawTokens.elevationSpread0)
-    }
-
-    func testElevationSpread0LessThan300() throws {
-        XCTAssertLessThan(ElevationRawTokens.elevationSpread0, ElevationRawTokens.elevationSpread300)
     }
 
     // MARK: - Primitive token - Elevation - Box Shadow
@@ -427,7 +405,6 @@ final class ElevationRawTokensTests: XCTestCase {
     func assertCompositeLowerThan(_ left: ElevationCompositeRawToken, _ right: ElevationCompositeRawToken) {
         XCTAssertLessThanOrEqual(left.y, right.y)
         XCTAssertLessThanOrEqual(left.blur, right.blur)
-        XCTAssertGreaterThanOrEqual(left.spread, right.spread)
     }
 }
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/ElevationSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/ElevationSemanticTokens.swift
@@ -28,9 +28,6 @@ public typealias ElevationYSemanticToken = ElevationRawToken
 /// Basically an elevation semantic token for blur effect is a raw token for elevation, with the same final type
 public typealias ElevationBlurSemanticToken = ElevationRawToken
 
-/// Basically an elevation semantic token for spread effect is a raw token for elevation, with the same final type
-public typealias ElevationSpreadSemanticToken = ElevationRawToken
-
 /// Basically an elevation semantic token for shadow colors is a raw token for colors
 public typealias ElevationColorSemanticToken = ColorRawToken
 
@@ -41,7 +38,7 @@ public typealias ElevationCompositeSemanticToken = ElevationCompositeRawToken
 
 /// This is a group of semantic tokens for **elevations**.
 /// It defines all elevation semantic tokens a theme must have. (`ElevationZIndexSemanticToken`,`ElevationXSemanticToken`,`ElevationYSemanticToken`,
-/// `ElevationBlurSemanticToken`,`ElevationSpreadSemanticToken` and `ElevationColorSemanticToken`)
+/// `ElevationBlurSemanticToken` and `ElevationColorSemanticToken`)
 public protocol ElevationSemanticTokens {
 
     // MARK: Semantic token - Elevation - Z index
@@ -96,18 +93,6 @@ public protocol ElevationSemanticTokens {
     var elevationBlurStickyEmphasized: ElevationBlurSemanticToken { get }
     var elevationBlurStickyNavigationScrolled: ElevationBlurSemanticToken { get }
     var elevationBlurFocus: ElevationBlurSemanticToken { get }
-
-    // MARK: Semantic token - Elevation - Spread
-
-    var elevationSpreadNone: ElevationSpreadSemanticToken { get }
-    var elevationSpreadRaised: ElevationSpreadSemanticToken { get }
-    var elevationSpreadDrag: ElevationSpreadSemanticToken { get }
-    var elevationSpreadOverlayDefault: ElevationSpreadSemanticToken { get }
-    var elevationSpreadOverlayEmphasized: ElevationSpreadSemanticToken { get }
-    var elevationSpreadStickyDefault: ElevationSpreadSemanticToken { get }
-    var elevationSpreadStickyEmphasized: ElevationSpreadSemanticToken { get }
-    var elevationSpreadStickyNavigationScrolled: ElevationSpreadSemanticToken { get }
-    var elevationSpreadFocus: ElevationSpreadSemanticToken { get }
 
     // MARK: Semantic token - Elevation - Color - None
 

--- a/Showcase/Showcase.xcodeproj/project.pbxproj
+++ b/Showcase/Showcase.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		070C35682C7762B90029C6A8 /* OUDSThemesSosh in Frameworks */ = {isa = PBXBuildFile; productRef = 070C35672C7762B90029C6A8 /* OUDSThemesSosh */; };
 		51087A7B2C46DF9F00160CCF /* Bundle+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51087A7A2C46DF9F00160CCF /* Bundle+extension.swift */; };
 		510A9CD02C5679A300430620 /* OUDSComponents in Frameworks */ = {isa = PBXBuildFile; productRef = 510A9CCF2C5679A300430620 /* OUDSComponents */; };
+		511B8EC12C99861600E7C2F1 /* ElevationsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511B8EC02C99861600E7C2F1 /* ElevationsList.swift */; };
 		512364792C3D7B2D00572FD5 /* Podfile.lock in Resources */ = {isa = PBXBuildFile; fileRef = 512364782C3D7B2D00572FD5 /* Podfile.lock */; };
 		5123647B2C3D7B3500572FD5 /* Gemfile.lock in Resources */ = {isa = PBXBuildFile; fileRef = 5123647A2C3D7B3500572FD5 /* Gemfile.lock */; };
 		513AD9402C5AAADE0003253B /* OUDSTokensComponent in Frameworks */ = {isa = PBXBuildFile; productRef = 513AD93F2C5AAADE0003253B /* OUDSTokensComponent */; };
@@ -64,6 +65,7 @@
 		07FDCDB72C296C370009AA13 /* .swiftformat */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = .swiftformat; path = ../.swiftformat; sourceTree = "<group>"; };
 		07FDCDB82C296C370009AA13 /* .gitignore */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = .gitignore; path = ../.gitignore; sourceTree = "<group>"; };
 		51087A7A2C46DF9F00160CCF /* Bundle+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+extension.swift"; sourceTree = "<group>"; };
+		511B8EC02C99861600E7C2F1 /* ElevationsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationsList.swift; sourceTree = "<group>"; };
 		512364782C3D7B2D00572FD5 /* Podfile.lock */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile.lock; sourceTree = "<group>"; };
 		5123647A2C3D7B3500572FD5 /* Gemfile.lock */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Gemfile.lock; path = ../Gemfile.lock; sourceTree = "<group>"; };
 		5149BADA2C3D6F4F000FA4BF /* Podfile */ = {isa = PBXFileReference; lastKnownFileType = text; path = Podfile; sourceTree = "<group>"; };
@@ -157,6 +159,14 @@
 			name = Configuration;
 			sourceTree = "<group>";
 		};
+		511B8EBF2C9985C700E7C2F1 /* Elevations */ = {
+			isa = PBXGroup;
+			children = (
+				511B8EC02C99861600E7C2F1 /* ElevationsList.swift */,
+			);
+			path = Elevations;
+			sourceTree = "<group>";
+		};
 		51BD760C2C466FCF0033365D /* About */ = {
 			isa = PBXGroup;
 			children = (
@@ -168,6 +178,7 @@
 		51BD760E2C466FCF0033365D /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				511B8EBF2C9985C700E7C2F1 /* Elevations */,
 				51BD760D2C466FCF0033365D /* ComponentsPage.swift */,
 			);
 			path = Components;
@@ -411,6 +422,7 @@
 				51B4F7F42C5BEAB700312019 /* OrangeCustomTheme.swift in Sources */,
 				51BD76292C466FCF0033365D /* WebView.swift in Sources */,
 				51BD76232C466FCF0033365D /* GuidelinesPage.swift in Sources */,
+				511B8EC12C99861600E7C2F1 /* ElevationsList.swift in Sources */,
 				51087A7B2C46DF9F00160CCF /* Bundle+extension.swift in Sources */,
 				51BD76222C466FCF0033365D /* ComponentsPage.swift in Sources */,
 				51BD76212C466FCF0033365D /* AboutPage.swift in Sources */,

--- a/Showcase/Showcase/Pages/Components/ComponentsPage.swift
+++ b/Showcase/Showcase/Pages/Components/ComponentsPage.swift
@@ -11,47 +11,19 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
-import OUDS
-import OUDSThemesOrange
 import SwiftUI
+import OUDSTokensSemantic
+import OUDSTokensRaw
+
+// MARK: - View for display
 
 struct ComponentsPage: View {
 
-    let theme = OrangeTheme()
     var body: some View {
-        OUDSThemeableView(theme: theme) {
-            NavigationView {
-                ScrollView {
-                    Text("Display Large").typeDisplayLarge(theme)
-                    Text("Display Medium").typeDisplayMedium(theme)
-                    Text("Display Small").typeDisplaySmall(theme)
-
-                    Text("Heading X Large").typeHeadingXLarge(theme)
-                    Text("Heading Large").typeHeadingLarge(theme)
-                    Text("Heading Medium").typeHeadingMedium(theme)
-                    Text("Heading Small").typeHeadingSmall(theme)
-
-                    Text("Body Default Large").typeBodyDefaultLarge(theme)
-                    Text("Body Default Medium").typeBodyDefaultMedium(theme)
-                    Text("Body Default Small").typeBodyDefaultSmall(theme)
-                    Text("Body Strong Large").typeBodyStrongLarge(theme)
-                    Text("Body Strong Medium").typeBodyStrongMedium(theme)
-                    Text("Body Strong Small").typeBodyStrongSmall(theme)
-
-                    Text("Label Default X Large").typeLabelDefaultXLarge(theme)
-                    Text("Label Default Large").typeLabelDefaultLarge(theme)
-                    Text("Label Default Medium").typeLabelDefaultMedium(theme)
-                    Text("Label Default Small").typeLabelDefaultSmall(theme)
-                    Text("Label Strong X Large").typeLabelStrongXLarge(theme)
-                    Text("Label Strong Large").typeLabelStrongLarge(theme)
-                    Text("Label Strong Medium").typeLabelStrongMedium(theme)
-                    Text("Label Strong Small").typeLabelStrongSmall(theme)
-
-                    Text("Code Medium").typeLabelCodeMedium(theme)
-                    Text("Code Small").typeLabelCodeSmall(theme)
-                }
+        NavigationView {
+            ElevationsList()
+                .background(Color.white)
                 .navigationTitle("app_bottomBar_components")
-            }
         }
     }
 }

--- a/Showcase/Showcase/Pages/Components/Elevations/ElevationsList.swift
+++ b/Showcase/Showcase/Pages/Components/Elevations/ElevationsList.swift
@@ -1,0 +1,63 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+import OUDSTokensRaw
+import SwiftUI
+
+// MARK: - Raw tokens
+
+let raised = ElevationCompositeRawToken(x: 0, y: 1, blur: 2, color: ColorRawTokens.colorTransparentBlack500)
+let overlayDefault = ElevationCompositeRawToken(x: 0, y: 2, blur: 3, color: ColorRawTokens.colorTransparentBlack400)
+let allSticky = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack300)
+let drag = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorTransparentBlack500)
+let overlayEmphasized = ElevationCompositeRawToken(x: 0, y: 12, blur: 12, color: ColorRawTokens.colorTransparentBlack300)
+
+// MARK: - Rectangle for elevation tests
+
+/// Simple rectangle
+struct ElevationRectangle: View {
+    let elevation: ElevationCompositeSemanticToken
+    var body: some View {
+        Rectangle()
+            .frame(width: 300, height: 80)
+            .foregroundColor("#f4f4f4".color)
+            .shadow(elevation: elevation)
+    }
+}
+
+// MARK: - List of rectangles for rendering tests
+
+/// Just a debug `View` to list the elevations effects and render them
+struct ElevationsList: View {
+
+    var body: some View {
+        ScrollView {
+            ElevationRectangle(elevation: raised)
+            Spacer().padding(.bottom, 20)
+
+            ElevationRectangle(elevation: overlayDefault)
+            Spacer().padding(.bottom, 20)
+
+            ElevationRectangle(elevation: allSticky)
+            Spacer().padding(.bottom, 20)
+
+            ElevationRectangle(elevation: drag)
+            Spacer().padding(.bottom, 20)
+
+            ElevationRectangle(elevation: overlayEmphasized)
+            Spacer().padding(.bottom, 20)
+        }
+    }
+}


### PR DESCRIPTION
### Related issues

#32

### Description

Shadow effect of elevation can be computed only with Figma blur, thus the spread is useless.
Remove spread properties, update tests, add some fake components in demo app for visual tests, update doc.
Closes #32

### Motivation & Context

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
