### PR TITLE
Add some fake components and tokens for demo and tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Showcase] Add fake components for demo and tokens tests
 - [Library] Remove spread value for elevation tokens
 - [Library] Remove paragraph spacing tokens for typography
 - [Library] Term "fluid" has been replaced by "adaptable" in spacing semantic tokens

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -1,0 +1,73 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+import OUDSFoundations
+import OUDSTokensSemantic
+import SwiftUI
+
+/// An OUDS component for buttons.
+/// __Warning: This is a draft component__.
+///
+/// This component is created to illustrate the mecanism of theme and tokens and for tests.
+public struct OUDSButton: View {
+
+    // MARK: - Properties
+
+    /// The text to display inside the button
+    private let text: String
+
+    /// The action to process when the button is activated by a user interaction like a tap
+    private let action: () -> Void
+
+    /// To get tokens to customize the component
+    @Environment(\.theme) private var theme
+
+    /// To choose if ight or dark color must be used
+    @Environment(\.colorScheme) private var colorScheme
+
+    /// To get programatically and on the fly the horizontal layout size
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    // MARK: - Init
+
+    /// Initializes the button.
+    ///
+    /// - Parameters:
+    ///   - text: Text displayed in the button.
+    ///   - action: Will be called when the user clicks the button.
+    public init(text: String, action: @escaping () -> Void) {
+        self.text = text
+        self.action = action
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        Button {
+            action()
+        } label: {
+            Text(text)
+                .systemFont(typography: theme.buttonTypography)
+                .padding(theme.buttonInternalSpacing)
+                .foregroundColor(colorScheme == .light
+                                 ? theme.buttonForegroundColorLight.color
+                                 : theme.buttonForegroundColorDark.color)
+                .modifier(BorderStyleModifier(theme.buttonBorderStyle,
+                                              theme.buttonBorderWidth,
+                                              theme.buttonBorderRadius,
+                                              theme.buttonBorderColorLight,
+                                              theme.buttonBorderColorDark))
+        }.frame(width: theme.buttonWidth, height: theme.buttonHeight)
+    }
+}

--- a/OUDS/Core/Components/Sources/Extensions/View+Font.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Font.swift
@@ -1,0 +1,35 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+import SwiftUI
+
+extension View {
+
+    /// Applies a `CustomFontModifier` on the current `View` so as to add a specific `Font`.
+    /// - Parameters:
+    ///    - familyName: The font family name to load later (e.g. "Luciole")
+    ///    - token: The typography token to use to get useful values for `compact` or `regular` mode
+    /// - Returns: The `View` with the custom font applied
+    func customFont(familyName: String, typography token: TypographyCompositeSemanticToken) -> some View {
+        self.modifier(CustomFontModifier(token: token, fontFamilyName: familyName))
+    }
+
+    /// Applies a `FontModifier` to use the system font on the current `View` with a specific token
+    /// - Parameter token: The typography token to use to get useful values for `compact` or `regular` mode
+    /// - Returns: The `View` with the custom font applied
+    func systemFont(typography token: TypographyCompositeSemanticToken) -> some View {
+        self.modifier(FontModifier(token: token))
+    }
+}

--- a/OUDS/Core/Components/Sources/Forms/TextInput/OUDSFormsTextInput.swift
+++ b/OUDS/Core/Components/Sources/Forms/TextInput/OUDSFormsTextInput.swift
@@ -18,35 +18,48 @@ import SwiftUI
 /// An OUDS component for text input in formulars.
 /// __Warning: This is a draft component__.
 ///
-/// This commponent is created to illustrate the mecanism of theme and tokens.
+/// This component is created to illustrate the mecanism of theme and tokens.
 public struct OUDSFormsTextInput: View {
 
-    var placeholder: String
+    // MARK: - Properties
+
+    private let label: String
+    private let hint: String
+    private let placeholder: String
+    private let isEnabled: Bool
+
     @Binding var value: String
-    var isEnabled: Bool
 
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.theme) var theme
+
+    // MARK: - Initializer
 
     /// Use this initializer to create a text field that binds to a bound optional
     /// value and propose a placeholder.
     ///
     /// - Parameters:
+    ///    - label: The text to display in the top of the component
+    ///    - hint: The text to display in above the input field
     ///    - placeholder: Text in placeholder
     ///    - value: Binding of the value
     ///    - isEnabled: Flag to indicate if input is enabled (_true_ by default)
-    public init(placeholder: String, value: Binding<String>, isEnabled: Bool = true) {
+    public init(label: String, hint: String, placeholder: String, value: Binding<String>, isEnabled: Bool = true) {
+        self.label = label
+        self.hint = hint
         self.placeholder = placeholder
         self._value = value
         self.isEnabled = isEnabled
     }
+
+    // MARK: - Body
 
     public var body: some View {
         VStack(spacing: theme.spacePaddingBlockComponentTall) {
 
             Label(
                 title: {
-                    Text("Example of OUDSFormsTextInput")
+                    Text(label)
                         .fontWeight(theme.ftiTitleFontWeight.fontWeight)
                         .font(.system(size: theme.ftiTitleFontSize))
                         .foregroundColor(theme.ftiTitleColor.color)
@@ -54,7 +67,7 @@ public struct OUDSFormsTextInput: View {
                 icon: { /*@START_MENU_TOKEN@*/Image(systemName: "42.circle")/*@END_MENU_TOKEN@*/ }
             )
 
-            Text("Write below some awesome text!")
+            Text(hint)
                 .fontWeight(theme.ftiSubtitleFontWeight.fontWeight)
                 .font(.system(size: theme.ftiSubtitleFontSize))
                 .foregroundColor(theme.ftiSubtitleColor.color)

--- a/OUDS/Core/Components/Sources/ViewModifiers/BorderStyleModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/BorderStyleModifier.swift
@@ -63,18 +63,17 @@ struct BorderStyleModifier: ViewModifier {
 
     // MARK: - Body
 
+    @ViewBuilder
     func body(content: Content) -> some View {
         if token == "solid" {
-            return AnyView(solid(content))
+            solid(content)
+        } else if token == "dashed" {
+            dashed(content)
+        } else if token == "dotted" {
+            dotted(content)
+        } else { // if token == "none" and unmanaged cases
+            none(content)
         }
-        if token == "dashed" {
-            return AnyView(dashed(content))
-        }
-        if token == "dotted" {
-            return AnyView(dotted(content))
-        }
-        // if token == "none" and unmanaged cases
-        return AnyView(none(content))
     }
 
     private func none(_ content: Content) -> some View {

--- a/OUDS/Core/Components/Sources/ViewModifiers/BorderStyleModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/BorderStyleModifier.swift
@@ -1,0 +1,115 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+import OUDSFoundations
+import SwiftUI
+
+/// A `ViewModifier` which will apply a specific border style to a `View` using several semantic tokens.
+struct BorderStyleModifier: ViewModifier {
+
+    // MARK: - Properties
+
+    /// The style to apply on the component
+    private let token: BorderStyleSemanticToken
+
+    /// The width of the border
+    private let width: BorderWidthSemanticToken
+
+    /// The radius of the border to apply
+    private let radius: BorderRadiusSemanticToken
+
+    /// The color in light scheme of the border
+    private let colorLight: ColorSemanticToken
+
+    /// The color in dark scheme of the border
+    private let colorDark: ColorSemanticToken
+
+    /// Color to apply depending to the `colorScheme`
+    private var colorToApply: Color {
+        colorScheme == .light ? colorLight.color : colorDark.color
+    }
+
+    /// To know if the device is in light mode or in dark mode
+    @Environment(\.colorScheme) private var colorScheme
+
+    // MARK: - Initializer
+
+    init(_ token: BorderStyleSemanticToken,
+         _ width: BorderWidthSemanticToken,
+         _ radius: BorderRadiusSemanticToken,
+         _ colorLight: ColorSemanticToken,
+         _ colorDark: ColorSemanticToken) {
+        self.token = token
+        self.width = width
+        self.radius = radius
+        self.colorLight = colorLight
+        self.colorDark = colorDark
+        if token != "solid" && token != "dashed" && token != "dotted" {
+            OUDSLogger.error("Unmanaged token: '\(token)'!")
+        }
+    }
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        if token == "solid" {
+            return AnyView(solid(content))
+        }
+        if token == "dashed" {
+            return AnyView(dashed(content))
+        }
+        if token == "dotted" {
+            return AnyView(dotted(content))
+        }
+        // if token == "none" and unmanaged cases
+        return AnyView(none(content))
+    }
+
+    private func none(_ content: Content) -> some View {
+        content
+    }
+
+    private func solid(_ content: Content) -> some View {
+        content.background(
+            RoundedRectangle(
+                cornerRadius: radius,
+                style: .circular
+            )
+            .border(colorToApply, width: width)
+        )
+    }
+
+    private func dashed(_ content: Content) -> some View {
+        content.background(
+            RoundedRectangle(
+                cornerRadius: radius,
+                style: .circular
+            )
+            .stroke(style: StrokeStyle(lineWidth: width, dash: [10, 5]))
+            .foregroundColor(colorToApply)
+        )
+    }
+
+    private func dotted(_ content: Content) -> some View {
+        content.background(
+            RoundedRectangle(
+                cornerRadius: radius,
+                style: .circular
+            )
+            .stroke(style: StrokeStyle(lineWidth: width, dash: [1, 5]))
+            .foregroundColor(colorToApply)
+        )
+    }
+}

--- a/OUDS/Core/Components/Sources/ViewModifiers/CustomFontModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/CustomFontModifier.swift
@@ -1,0 +1,56 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+import SwiftUI
+
+/// A `ViewModifier` applying a custom font on a `View`
+/// Note that `CustomFontModifier` expects to lad a custom external font and not any font embeded in the device.
+struct CustomFontModifier: ViewModifier {
+
+    // MARK: - Properties
+
+    /// The typography style to apply
+    let token: TypographyCompositeSemanticToken
+
+    /// The name of the custom font family, should be registered previously in the app, like "Luciole".
+    let fontFamilyName: String
+
+    /// The size of the font to apply
+    private var fontSize: CGFloat {
+        sizeClass == .compact ? token.compact.size : token.regular.size
+    }
+
+    /// The line spacing to apply line height effect
+    private var lineSpacing: CGFloat {
+        sizeClass == .compact
+        ? token.compact.lineHeight - token.compact.size
+        : token.regular.lineHeight - token.regular.size
+    }
+
+    /// The weight to apply on the font, like "Bold" or "BoldItalic"
+    private var weight: String {
+        sizeClass == .compact ? token.compact.weight : token.regular.weight
+    }
+
+    @Environment(\.horizontalSizeClass) private var sizeClass // TODO: reguar / comapct mode util
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        content
+            .font(.custom(fontFamilyName.compose(withFont: weight), size: fontSize))
+            .lineSpacing(lineSpacing)
+    }
+}

--- a/OUDS/Core/Components/Sources/ViewModifiers/FontModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/FontModifier.swift
@@ -1,0 +1,54 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+import SwiftUI
+
+/// A `ViewModifier` which will apply the system `Font` in a component `View` using a `TypographyCompositeSemanticToken`
+/// Note that `FontModifier` use default system font but nothing for others fonts embeded in device
+struct FontModifier: ViewModifier {
+
+    // MARK: - Properties
+
+    // TODO: How to manage other fonts on device?
+
+    let token: TypographyCompositeSemanticToken
+
+    /// The size of the font to apply
+    private var fontSize: CGFloat {
+        sizeClass == .compact ? token.compact.size : token.regular.size
+    }
+
+    /// The line spacing to apply line height effect
+    private var lineSpacing: CGFloat {
+        sizeClass == .compact
+        ? token.compact.lineHeight - token.compact.size
+        : token.regular.lineHeight - token.regular.size
+    }
+
+    /// The weight to apply on the font.
+    private var weight: Font.Weight {
+        sizeClass == .compact ? token.compact.weight.fontWeight : token.regular.weight.fontWeight
+    }
+
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    // MARK: - Body
+
+    func body(content: Content) -> some View {
+        content
+            .font(.system(size: fontSize, weight: weight))
+            .lineSpacing(lineSpacing)
+    }
+}

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+ComponentTokens/OUDSTheme+ButtonsComponentTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+ComponentTokens/OUDSTheme+ButtonsComponentTokens.swift
@@ -1,0 +1,40 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensComponent
+import OUDSTokensRaw
+import OUDSTokensSemantic
+
+/// Defines for `OUDSButton` the basic configuration which can be overriden in subthemes / subclasses of this theme.
+/// **Warning: These are random and dumb values**
+extension OUDSTheme: ButtonsComponentTokens {
+
+    @objc open var buttonInternalSpacing: SpacingPaddingInlineSemanticToken { spacePaddingInlineComponentShort }
+
+    @objc open var buttonBorderStyle: BorderStyleSemanticToken { borderStyleDefault }
+    @objc open var buttonBorderColorLight: ColorSemanticToken { colorBorderDefaultLight! }
+    @objc open var buttonBorderColorDark: ColorSemanticToken { colorBorderDefaultDark! }
+    @objc open var buttonBorderWidth: BorderWidthSemanticToken { borderWidthDefault }
+    @objc open var buttonBorderRadius: BorderRadiusSemanticToken { borderRadiusShort }
+
+    @objc open var buttonForegroundColorLight: ColorSemanticToken { colorContentBrandPrimaryLight! }
+    @objc open var buttonForegroundColorDark: ColorSemanticToken { colorContentBrandPrimaryDark! }
+    @objc open var buttonBackgroundColorLight: ColorSemanticToken { colorBackgroundBrandPrimaryLight! }
+    @objc open var buttonBackgroundColorDark: ColorSemanticToken { colorBackgroundBrandPrimaryDark! }
+
+    @objc open var buttonWidth: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension3000 }
+    @objc open var buttonHeight: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension1000 }
+
+    @objc open var buttonTypography: TypographyCompositeSemanticToken { typeDisplayMedium }
+}

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+ComponentTokens/OUDSTheme+FormsTextInputComponentToken.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+ComponentTokens/OUDSTheme+FormsTextInputComponentToken.swift
@@ -16,11 +16,12 @@ import OUDSTokensRaw
 import OUDSTokensSemantic
 import OUDSTokensComponent
 
-/// Defines for `FormsTextInputComponentToken` the basic configuration which can be overriden in subthemes / subclasses of this theme.
+/// Defines for `FormsTextInputComponentTokens` the basic configuration which can be overriden in subthemes / subclasses of this theme.
 /// **Warning: These are random and dumb values**
-extension OUDSTheme: FormsTextInputComponentToken {
+extension OUDSTheme: FormsTextInputComponentTokens {
 
-    // TODO: What should we done if missing value? E.g. missing color or alias with empty values in the end
+    // NOTE: What should we done if missing value? E.g. missing color or alias with empty values in the end
+
     private static let defaultBlack: ColorSemanticToken = ColorRawTokens.colorFunctionalBlack
     private static let defaultWhite: ColorSemanticToken = ColorRawTokens.colorFunctionalWhite
 

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Themes.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Themes.md
@@ -69,7 +69,7 @@ import OUDSThemesOrange     // To override OrangeTheme (which is default theme)
 // Can be for example a country theme
 class OrangeCustomTheme: OrangeTheme { }
 
-extension OrangeCustomTheme { // For FormsTextInputComponentToken, used in component FormsTextInputComponent
+extension OrangeCustomTheme { // For FormsTextInputComponentTokens, used in component FormsTextInputComponent
 
     public override var ftiTitleFontWeight: TypographyFontWeightSemanticToken { fontWeightLabelStrong }
     public override var ftiTitleFontSize: TypographyFontSizeSemanticToken { fontSizeLabelXLarge }

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
@@ -27,11 +27,11 @@ These _tokens_ ([OUDSTokensComponent](https://ios.unified-design-system.orange.c
 Thus if a component needs to change for example its _background color_, and if a _component token_ is used for it, then only the value of this _token_ should be changed without any modification on the _component_ definition.
 _Components_ use _component tokens_ exposed through the _theme_ to get their style values.
 
-Example with a fake component `FormsTextInputComponentToken`:
+Example with a fake component `FormsTextInputComponentTokens`:
 
 ```swift
 // Declare the component tokens
-public protocol FormsTextInputComponentToken {
+public protocol FormsTextInputComponentTokens {
     var ftiTitleFontWeight: TypographyFontWeightSemanticToken { get }
     var ftiTitleFontSize: TypographyFontSizeSemanticToken { get }
     var ftiTitleColor: ColorSemanticToken { get }
@@ -42,7 +42,7 @@ public protocol FormsTextInputComponentToken {
 }
 
 // Define the component tokens
-extension OUDSTheme: FormsTextInputComponentToken {
+extension OUDSTheme: FormsTextInputComponentTokens {
     private static let defaultBlack: ColorSemanticToken = ColorRawTokens.colorFunctionalBlack
     private static let defaultWhite: ColorSemanticToken = ColorRawTokens.colorFunctionalWhite
 

--- a/OUDS/Core/Tokens/ComponentTokens/Sources/ButtonsComponentTokens.swift
+++ b/OUDS/Core/Tokens/ComponentTokens/Sources/ButtonsComponentTokens.swift
@@ -1,0 +1,44 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import Foundation
+import OUDSTokensSemantic
+
+/// This is a component tokens list for buttons like `OUDSButton`.
+/// **Warning: This is a draft component **
+public protocol ButtonsComponentTokens {
+
+    /*
+     NOTE:
+     1. Maybe composite tokens for border can be useful to define several types of buttons
+     2. Maybe a composite tokens should be defined and used to gather all these atomic semantic tokens
+     */
+
+    var buttonInternalSpacing: SpacingPaddingInlineSemanticToken { get }
+
+    var buttonBorderStyle: BorderStyleSemanticToken { get }
+    var buttonBorderColorLight: ColorSemanticToken { get }
+    var buttonBorderColorDark: ColorSemanticToken { get }
+    var buttonBorderWidth: BorderWidthSemanticToken { get }
+    var buttonBorderRadius: BorderRadiusSemanticToken { get }
+
+    var buttonForegroundColorLight: ColorSemanticToken { get }
+    var buttonForegroundColorDark: ColorSemanticToken { get }
+    var buttonBackgroundColorLight: ColorSemanticToken { get }
+    var buttonBackgroundColorDark: ColorSemanticToken { get }
+
+    var buttonWidth: SizingWidthHeightSemanticToken { get }
+    var buttonHeight: SizingWidthHeightSemanticToken { get }
+
+    var buttonTypography: TypographyCompositeSemanticToken { get }
+}

--- a/OUDS/Core/Tokens/ComponentTokens/Sources/FormsTextInputComponentTokens.swift
+++ b/OUDS/Core/Tokens/ComponentTokens/Sources/FormsTextInputComponentTokens.swift
@@ -16,7 +16,7 @@ import OUDSTokensSemantic
 
 /// This is a component token for a text input in formulars.
 /// **Warning: This is a draft component **
-public protocol FormsTextInputComponentToken {
+public protocol FormsTextInputComponentTokens {
 
     var ftiTitleFontWeight: TypographyFontWeightSemanticToken { get }
     var ftiTitleFontSize: TypographyFontSizeSemanticToken { get }

--- a/OUDS/Core/Tokens/ComponentTokens/Sources/_OUDSTokensComponent.docc/OUDSTokensComponent.md
+++ b/OUDS/Core/Tokens/ComponentTokens/Sources/_OUDSTokensComponent.docc/OUDSTokensComponent.md
@@ -7,11 +7,11 @@ These _tokens_ can be used to apply some style and configuration values to _comp
 Thus if a component need to change for example its _background color_, and if a _component token_ is used for it, then only the value of this _token_ should be changed without any modification on the _component_ definition.
 _Components_ use _component tokens_ exposed through the _theme_ to get their style values.
 
-Example with a fake component named `FormsTextInputComponent` using component tokens in `FormsTextInputComponentToken`:
+Example with a fake component named `FormsTextInputComponent` using component tokens in `FormsTextInputComponentTokens`:
 
 ```swift
 // Declare component tokens
-public protocol FormsTextInputComponentToken {
+public protocol FormsTextInputComponentTokens {
     var ftiTitleFontWeight: TypographyFontWeightSemanticToken { get }
     var ftiTitleFontSize: TypographyFontSizeSemanticToken { get }
     var ftiTitleColor: ColorSemanticToken { get }
@@ -22,7 +22,7 @@ public protocol FormsTextInputComponentToken {
 }
 
 // Define the component tokens
-extension OUDSTheme: FormsTextInputComponentToken {
+extension OUDSTheme: FormsTextInputComponentTokens {
     private static let defaultBlack: ColorSemanticToken = ColorRawTokens.colorFunctionalBlack
     private static let defaultWhite: ColorSemanticToken = ColorRawTokens.colorFunctionalWhite
 
@@ -71,5 +71,5 @@ struct OUDSFormsTextInput: View {
 
 ### Group
 
-- ``FormsTextInputComponentToken``
+- ``FormsTextInputComponentTokens``
 

--- a/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
@@ -34,12 +34,12 @@ extension String {
         return Font.Weight.regular
     }
 
-    /// Forges the font family name which is expected for the given weight.
+    /// Forges the font name which is expected for the given weight.
     /// Beware, the function does not check if the font exists.
     /// - Parameters:
     ///    - name: The font family name (e.g. "Menlo")
     ///    - weight: The weight to apply (e.g. "bold", "italic")
-    /// - Returns String: The full name of the font family to use (e.g. "Menlo-Bold" or "Menlo-Italic")
+    /// - Returns String: The full name of the font to use (e.g. "Menlo-Bold" or "Menlo-Italic")
     public func compose(withFont weight: String) -> String {
         guard !self.isEmpty else {
             OUDSLogger.error("No font family to compose with weight")

--- a/OUDS/README.md
+++ b/OUDS/README.md
@@ -67,10 +67,10 @@ These _tokens_ can be used to apply some style and configuration values to _comp
 Thus if a component need to change for example its _background color_, and if a _component token_ is used for it, then only the value of this _token_ should be changed without any modification on the _component_ definition.
 _Components_ use _component tokens_ exposed through the _theme_ to get their style values.
 
-Example with `FormsTextInputComponentToken`:
+Example with `FormsTextInputComponentTokens`:
 
 ```swift
-public protocol FormsTextInputComponentToken {
+public protocol FormsTextInputComponentTokens {
     var ftiTitleFontWeight: TypographyFontWeightSemanticToken { get }
     var ftiTitleFontSize: TypographyFontSizeSemanticToken { get }
     var ftiTitleColor: ColorSemanticToken { get }
@@ -80,7 +80,7 @@ public protocol FormsTextInputComponentToken {
     var ftiBorderWidth: BorderWidthSemanticToken { get }
 }
 
-extension OUDSTheme: FormsTextInputComponentToken {
+extension OUDSTheme: FormsTextInputComponentTokens {
     private static let defaultBlack: ColorSemanticToken = ColorRawTokens.colorFunctionalBlack
     private static let defaultWhite: ColorSemanticToken = ColorRawTokens.colorFunctionalWhite
 
@@ -234,7 +234,7 @@ import OUDSThemesOrange     // To override OrangeTheme (which is default theme)
 // Can be for example a country theme
 class OrangeCustomTheme: OrangeTheme { }
 
-extension OrangeCustomTheme { // For FormsTextInputComponentToken, used in component FormsTextInputComponent
+extension OrangeCustomTheme { // For FormsTextInputComponentTokens, used in component FormsTextInputComponent
 
     public override var ftiTitleFontWeight: TypographyFontWeightSemanticToken { fontWeightLabelStrong }
     public override var ftiTitleFontSize: TypographyFontSizeSemanticToken { fontSizeLabelXLarge }

--- a/Showcase/Showcase/OrangeCustomTheme.swift
+++ b/Showcase/Showcase/OrangeCustomTheme.swift
@@ -21,9 +21,9 @@ import OUDSThemesOrange
 // Can be for example a country theme
 class OrangeCustomTheme: OrangeTheme { }
 
-/// Overrides for `FormsTextInputComponentToken` the  configuration which for this theme.
+/// Overrides for `FormsTextInputComponentTokens` the  configuration which for this theme.
 /// **Warning: These are random and dumb values**
-extension OrangeCustomTheme { // For FormsTextInputComponentToken
+extension OrangeCustomTheme { // For FormsTextInputComponentTokens
 
     public override var ftiTitleFontWeight: TypographyFontWeightSemanticToken { fontWeightLabelStrong }
     public override var ftiTitleFontSize: TypographyFontSizeSemanticToken { fontSizeLabelXLarge }
@@ -47,4 +47,25 @@ extension OrangeCustomTheme { // For ColorSemanticTokens
 
     override var colorBackgroundDefaultPrimaryLight: ColorSemanticToken! { ColorRawTokens.colorFunctionalSun500 }
     override var colorBackgroundDefaultPrimaryDark: ColorSemanticToken! { ColorRawTokens.colorFunctionalSun800 }
+}
+
+extension OrangeCustomTheme { // For ButtonsComponentTokens
+
+    override var buttonInternalSpacing: SpacingPaddingInlineSemanticToken { spacePaddingInlineComponentShorter }
+
+    override var buttonBorderStyle: BorderStyleSemanticToken { borderStyleDrag }
+    override var buttonBorderColorLight: ColorSemanticToken { colorBorderDefaultLight! }
+    override var buttonBorderColorDark: ColorSemanticToken { colorBorderDefaultDark! }
+    override var buttonBorderWidth: BorderWidthSemanticToken { borderWidthDefault }
+    override var buttonBorderRadius: BorderRadiusSemanticToken { borderRadiusShort }
+
+    override var buttonForegroundColorLight: ColorSemanticToken { sysColorBrandNeutralMutedLower! }
+    override var buttonForegroundColorDark: ColorSemanticToken { sysColorBrandNeutralMutedWhite! }
+    override var buttonBackgroundColorLight: ColorSemanticToken { sysColorBrandPositiveLowest! }
+    override var buttonBackgroundColorDark: ColorSemanticToken { sysColorBrandPositiveHighest! }
+
+    override var buttonWidth: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension2000 }
+    override var buttonHeight: SizingWidthHeightSemanticToken { DimensionRawTokens.dimension800 }
+
+    override var buttonTypography: TypographyCompositeSemanticToken { typeDisplaySmall }
 }

--- a/Showcase/Showcase/Pages/Guidelines/GuidelinesPage.swift
+++ b/Showcase/Showcase/Pages/Guidelines/GuidelinesPage.swift
@@ -29,19 +29,25 @@ struct GuidelinesPage: View {
     var body: some View {
         OUDSThemeableView(theme: selectedTheme) {
             NavigationView {
-                VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, spacing: 20) {
+                VStack(alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/, spacing: 30) {
 
-                    OUDSFormsTextInput(placeholder: "Display large",
+                    OUDSFormsTextInput(label: "Awesome form",
+                                       hint: "Type something",
+                                       placeholder: "Display large",
                                        value: $writtenText)
+
+                    OUDSButton(text: "Some button") {}
 
                     Button("Try OUDS Orange Theme") {
                         selectedTheme = OrangeTheme()
                         print("Showcase app - Selected OUDS Orange theme")
                     }
+
                     Button("Try custom \"local\" theme") {
                         selectedTheme = OrangeCustomTheme()
                         print("Showcase app - Selected app custom theme")
                     }
+
                 }
                 .padding(.horizontal, 20)
                 .navigationTitle("app_bottomBar_guidelines")


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
No issue

### Description

<!-- Describe your changes in detail -->
Add a fake `OUDSButton` with its component tokens so as to test typgoraphy, border and some view modifiers.
Improve also the public and internal API for view drawings.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Have something more and new for demo, and go a bit further with components because of the lack of specifications!

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

None

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
