### PR TITLE
Update border semantic tokens (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] Update border semantic tokens values ([#106](https://github.com/Orange-OpenSource/ouds-ios/issues/106))
 - [Showcase] Add fake components for demo and tokens tests
 - [Library] Remove spread value for elevation tokens
 - [Library] Remove paragraph spacing tokens for typography

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+BorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+BorderSemanticTokens.swift
@@ -26,10 +26,10 @@ extension OUDSTheme: BorderSemanticTokens {
     @objc open var borderWidthNone: BorderWidthSemanticToken { BorderRawTokens.borderWidth0 }
     @objc open var borderWidthDefault: BorderWidthSemanticToken { BorderRawTokens.borderWidth25 }
     @objc open var borderWidthThin: BorderWidthSemanticToken { BorderRawTokens.borderWidth25 }
-    @objc open var borderWidthThick: BorderWidthSemanticToken { BorderRawTokens.borderWidth50 }
-    @objc open var borderWidthThicker: BorderWidthSemanticToken { BorderRawTokens.borderWidth75 }
-    @objc open var borderWidthThickest: BorderWidthSemanticToken { BorderRawTokens.borderWidth100 }
-    @objc open var borderWidthInterfactivePrimaryFocus: BorderWidthSemanticToken { BorderRawTokens.borderWidth100 }
+    @objc open var borderWidthMedium: BorderWidthSemanticToken { BorderRawTokens.borderWidth50 }
+    @objc open var borderWidthThick: BorderWidthSemanticToken { BorderRawTokens.borderWidth75 }
+    @objc open var borderWidthThicker: BorderWidthSemanticToken { BorderRawTokens.borderWidth100 }
+    @objc open var borderWidthOutsideFocus: BorderWidthSemanticToken { BorderRawTokens.borderWidth50 }
 
     // MARK: Semantic token - Border - Radius
 

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Themes.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Themes.md
@@ -37,7 +37,7 @@ extension YourCustomTheme {
 
     // Override components tokens if needed
     override var ftiBorderStyle: BorderStyleSemanticToken { borderStyleDrag }
-    override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThickest }
+    override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThick }
     
     // Override colors semantic tokens if needed
     override var colorBackgroundDefaultPrimaryLight: ColorSemanticToken! { ColorRawTokens.colorFunctionalSun500 }
@@ -86,7 +86,7 @@ extension OrangeCustomTheme { // For FormsTextInputComponentTokens, used in comp
 
     public override var ftiBorderStyle: BorderStyleSemanticToken { borderStyleDrag }
 
-    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThickest }
+    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThick }
 }
 
 extension OrangeCustomTheme { // For ColorSemanticTokens using anywhere

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+BorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+BorderSemanticTokens.swift
@@ -26,10 +26,10 @@ extension MockTheme {
     override var borderWidthNone: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken }
     override var borderWidthDefault: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
     override var borderWidthThin: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
+    override var borderWidthMedium: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
     override var borderWidthThick: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
     override var borderWidthThicker: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
-    override var borderWidthThickest: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
-    override var borderWidthInterfactivePrimaryFocus: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
+    override var borderWidthOutsideFocus: BorderWidthSemanticToken { Self.mockThemeBorderWidthRawToken}
 
     // MARK: Semantic token - Border - Radius
 

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfBorderSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfBorderSemanticTokens.swift
@@ -45,6 +45,11 @@ final class TestThemeOverrideOfBorderSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.borderWidthThin == MockTheme.mockThemeBorderWidthRawToken)
     }
 
+    func testInheritedThemeCanOverrideSemanticTokenBorderWidthMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.borderWidthMedium, abstractTheme.borderWidthMedium)
+        XCTAssertTrue(inheritedTheme.borderWidthMedium == MockTheme.mockThemeBorderWidthRawToken)
+    }
+
     func testInheritedThemeCanOverrideSemanticTokenBorderWidthThick() throws {
         XCTAssertNotEqual(inheritedTheme.borderWidthThick, abstractTheme.borderWidthThick)
         XCTAssertTrue(inheritedTheme.borderWidthThick == MockTheme.mockThemeBorderWidthRawToken)
@@ -55,14 +60,9 @@ final class TestThemeOverrideOfBorderSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.borderWidthThicker == MockTheme.mockThemeBorderWidthRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenBorderWidthThickest() throws {
-        XCTAssertNotEqual(inheritedTheme.borderWidthThickest, abstractTheme.borderWidthThickest)
-        XCTAssertTrue(inheritedTheme.borderWidthThickest == MockTheme.mockThemeBorderWidthRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenBorderWidthInterfactivePrimaryFocus() throws {
-        XCTAssertNotEqual(inheritedTheme.borderWidthInterfactivePrimaryFocus, abstractTheme.borderWidthInterfactivePrimaryFocus)
-        XCTAssertTrue(inheritedTheme.borderWidthInterfactivePrimaryFocus == MockTheme.mockThemeBorderWidthRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenBorderWidthOutsideFocus() throws {
+        XCTAssertNotEqual(inheritedTheme.borderWidthOutsideFocus, abstractTheme.borderWidthOutsideFocus)
+        XCTAssertTrue(inheritedTheme.borderWidthOutsideFocus == MockTheme.mockThemeBorderWidthRawToken)
     }
 
     // MARK: - Semantic token - Border - Radius

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/BorderSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/BorderSemanticTokens.swift
@@ -35,10 +35,10 @@ public protocol BorderSemanticTokens {
     var borderWidthNone: BorderWidthSemanticToken { get }
     var borderWidthDefault: BorderWidthSemanticToken { get }
     var borderWidthThin: BorderWidthSemanticToken { get }
+    var borderWidthMedium: BorderWidthSemanticToken { get }
     var borderWidthThick: BorderWidthSemanticToken { get }
     var borderWidthThicker: BorderWidthSemanticToken { get }
-    var borderWidthThickest: BorderWidthSemanticToken { get }
-    var borderWidthInterfactivePrimaryFocus: BorderWidthSemanticToken { get }
+    var borderWidthOutsideFocus: BorderWidthSemanticToken { get }
 
     // MARK: - Semantic token - Border - Radius
 

--- a/OUDS/README.md
+++ b/OUDS/README.md
@@ -251,7 +251,7 @@ extension OrangeCustomTheme { // For FormsTextInputComponentTokens, used in comp
 
     public override var ftiBorderStyle: BorderStyleSemanticToken { borderStyleDrag }
 
-    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThickest }
+    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThick }
 }
 
 extension OrangeCustomTheme { // For ColorSemanticTokens using anywhere

--- a/Showcase/Showcase/OrangeCustomTheme.swift
+++ b/Showcase/Showcase/OrangeCustomTheme.swift
@@ -40,7 +40,7 @@ extension OrangeCustomTheme { // For FormsTextInputComponentTokens
 
     public override var ftiBorderStyle: BorderStyleSemanticToken { borderStyleDrag }
 
-    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthThickest }
+    public override var ftiBorderWidth: BorderWidthSemanticToken { borderWidthDefault }
 }
 
 extension OrangeCustomTheme { // For ColorSemanticTokens


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#106

### Description

<!-- Describe your changes in detail -->

Apply new values for border semantic tokens

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
