### PR TITLE
[#51] Update typography tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.2.0...develop)
 
+### Added
+
+- [Library] Add letter spacing and more font family tokens for typography ([#51](https://github.com/Orange-OpenSource/ouds-ios/issues/51))
 
 ## [0.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.1.0...0.2.0) - 2024-09-19
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
@@ -11,6 +11,11 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System 
 //
 
+import OUDSFoundations
+
+/// An operator to make for example comparisons between `TypographyCompositeRawToken`
+infix operator <|
+
 /// Composite raw tokens are here to pack a set of specific values according to the global design system tool.
 /// Here a *typography* is finaly defined by some specific values.
 public struct TypographyCompositeRawToken: Equatable {
@@ -28,4 +33,17 @@ public struct TypographyCompositeRawToken: Equatable {
 
     /// The font letter spacing to associated with the font family
     public let letterSpacing: TypographyFontLetterSpacingRawToken
+
+    /// Operator which will return true `true` if `lhs` is smaller than `rhs`.
+    /// By "smaller" we mean smaller `size` and smaller or equal `lineHeight`, `weight` and `letterSpacing`
+    /// - Parameters:
+    ///    - lhs: The typography composite token we expect to be smaller than `rhs`
+    ///    - rhs: The typography composite token we expect to be bigger than `lhs`
+    /// - Returns Bool: `true` if `lhs` smaller than `rhs`, `false` otherwise
+    static func <| (lhs: TypographyCompositeRawToken, rhs: TypographyCompositeRawToken) -> Bool {
+        lhs.size < rhs.size
+        && lhs.lineHeight <= rhs.lineHeight
+        && lhs.weight <= rhs.weight
+        && lhs.letterSpacing <= rhs.letterSpacing
+    }
 }

--- a/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
@@ -34,7 +34,7 @@ public struct TypographyCompositeRawToken: Equatable {
     /// The font letter spacing to associated with the font family
     public let letterSpacing: TypographyFontLetterSpacingRawToken
 
-    /// Operator which will return true `true` if `lhs` is smaller than `rhs`.
+    /// Operator which will return `true` if `lhs` is smaller than `rhs`.
     /// By "smaller" we mean smaller `size` and smaller or equal `lineHeight`, `weight` and `letterSpacing`
     /// - Parameters:
     ///    - lhs: The typography composite token we expect to be smaller than `rhs`

--- a/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Composites/TypographyRawTokens+Composites.swift
@@ -23,8 +23,9 @@ public struct TypographyCompositeRawToken: Equatable {
     /// The line height to apply on texts
     public let lineHeight: TypographyFontLineHeightRawToken
 
-    /// The font weight to associated wit the font family
+    /// The font weight to associate with the font family
     public let weight: TypographyFontWeightRawToken
 
-    // TODO: How to deal "letter spacing"?
+    /// The font letter spacing to associated with the font family
+    public let letterSpacing: TypographyFontLetterSpacingRawToken
 }

--- a/OUDS/Core/Tokens/RawTokens/Sources/TypeAliases/TypographyRawTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/TypeAliases/TypographyRawTokens+Aliases.swift
@@ -22,5 +22,8 @@ public typealias TypographyFontWeightRawToken = String
 /// In the global design system tool, *font size* raw tokens are basically `CGFloat` values, to keep grammar clean and clear with design system grammar.
 public typealias TypographyFontSizeRawToken = CGFloat
 
-/// In the global design system tool, *font line height* raw tokens are basically `Int` values, to keep grammar clean and clear with design system grammar.
+/// In the global design system tool, *font line height* raw tokens are basically `CGFloat` values, to keep grammar clean and clear with design system grammar.
 public typealias TypographyFontLineHeightRawToken = CGFloat
+
+/// In the global design system tool, *font letter spacing* raw tokens are basically `CGFloat` values, to keep grammar clean and clear with design system grammar.
+public typealias TypographyFontLetterSpacingRawToken = CGFloat

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Values.swift
@@ -17,7 +17,7 @@ extension TypographyRawTokens {
 
     // MARK: Primitive token - Typography - Font size
 
-    // Warning: values in pixels!
+    // WARNING: values in pixels and not in points, do not use as is!
 
     public static let fontSize100: TypographyFontSizeRawToken = 10
     public static let fontSize150: TypographyFontSizeRawToken = 12
@@ -40,7 +40,7 @@ extension TypographyRawTokens {
 
     // MARK: Primitive token - Typography - Line height
 
-    // Warning: values in pixels!
+    // WARNING: values in pixels and not in points, do not use as is!
 
     public static let fontLineHeight250: TypographyFontLineHeightRawToken = 16
     public static let fontLineHeight350: TypographyFontLineHeightRawToken = 20
@@ -58,17 +58,41 @@ extension TypographyRawTokens {
     public static let fontLineHeight1850: TypographyFontLineHeightRawToken = 72
     public static let fontLineHeight2050: TypographyFontLineHeightRawToken = 80
 
+    // MARK: Primitive token - Typography - Letter spacing
+
+    // WARNING: values in pixels and not in points, do not use as is!
+
+    public static let fontLetterSpacing150: TypographyFontLetterSpacingRawToken = 150
+    public static let fontLetterSpacing175: TypographyFontLetterSpacingRawToken = 175
+    public static let fontLetterSpacing200: TypographyFontLetterSpacingRawToken = 200
+    public static let fontLetterSpacing250: TypographyFontLetterSpacingRawToken = 250
+    public static let fontLetterSpacing300: TypographyFontLetterSpacingRawToken = 300
+    public static let fontLetterSpacing350: TypographyFontLetterSpacingRawToken = 350
+    public static let fontLetterSpacing450: TypographyFontLetterSpacingRawToken = 450
+    public static let fontLetterSpacing550: TypographyFontLetterSpacingRawToken = 550
+    public static let fontLetterSpacing650: TypographyFontLetterSpacingRawToken = 650
+    public static let fontLetterSpacing750: TypographyFontLetterSpacingRawToken = 750
+    public static let fontLetterSpacing850: TypographyFontLetterSpacingRawToken = 850
+    public static let fontLetterSpacing950: TypographyFontLetterSpacingRawToken = 950
+    public static let fontLetterSpacing1050: TypographyFontLetterSpacingRawToken = 1050
+    public static let fontLetterSpacing1150: TypographyFontLetterSpacingRawToken = 1150
+    public static let fontLetterSpacing1250: TypographyFontLetterSpacingRawToken = 1250
+    public static let fontLetterSpacing1450: TypographyFontLetterSpacingRawToken = 1450
+    public static let fontLetterSpacing1850: TypographyFontLetterSpacingRawToken = 1850
+
     // MARK: Primitive token - Typography - Font family
 
+    // WARNING: Raw values, do not use as is, ensure fonts are available
+
     public static let fontFamilyBrandDefault: TypographyFontFamilyRawToken = "Helvetica Neue"
-    // TODO: How to manage font-family-brand-tv = "Helvetica Neue LT"? Not existing in iOS SwiftUI
+    public static let fontFamilyBrandTV: TypographyFontFamilyRawToken = "Helvetica Neue LT"
     public static let fontFamilySystemArial: TypographyFontFamilyRawToken = "Arial"
     public static let fontFamilySystemHelvetica: TypographyFontFamilyRawToken = "Helvetica"
-    // TODO: How to manage font-family-system-noto-sans = "Noto sans"? Not existing in iOS SwiftUI
-    // TODO: How to manage font-family-system-sf-pro-text = "SF Pro Text"? Not existing in iOS SwiftUI
-    // TODO: How to manage font-family-system-roboto = "Roboto"? Not existing in iOS SwiftUI
+    public static let fontFamilySystemNotoSans: TypographyFontFamilyRawToken = "Noto sans"
+    public static let fontFamilySystemSFProText: TypographyFontFamilyRawToken = "SF Pro Text"
+    public static let fontFamilySystemRoboto: TypographyFontFamilyRawToken = "Roboto"
     public static let fontFamilyMonospaceMenlo: TypographyFontFamilyRawToken = "Menlo"
-    // TODO: How to manage font-family-system-monaco = "Monaco"? Not existing in iOS SwiftUI
+    public static let fontFamilyMonospaceMonaco: TypographyFontFamilyRawToken = "Monaco"
     public static let fontFamilyMonospaceCourierNew: TypographyFontFamilyRawToken = "Courier New"
 
     // MARK: Primitive token - Typography - Font weight
@@ -80,31 +104,29 @@ extension TypographyRawTokens {
     public static let fontWeight500: TypographyFontWeightRawToken = "medium"
     public static let fontWeight600: TypographyFontWeightRawToken = "semibold"
     public static let fontWeight700: TypographyFontWeightRawToken = "bold"
-    // TODO: How to manage fontWeight800 = "extra bold"? Not existing in iOS SwiftUI
     public static let fontWeight900: TypographyFontWeightRawToken = "heavy"
-    // TODO: How to manage fontWeight950 = "extra black"? Not existing in iOS SwiftUI
 
     // MARK: Primitive token - Typography - Composite
 
-    public static let typeRegular150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight400)
-    public static let typeRegular175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight400)
-    public static let typeRegular200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight400)
-    public static let typeRegular250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight400)
-    public static let typeBold150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight700)
-    public static let typeBold175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight700)
-    public static let typeBold200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight700)
-    public static let typeBold250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight700)
-    public static let typeBold300 = TypographyCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeight700)
-    public static let typeBold350 = TypographyCompositeRawToken(size: fontSize350, lineHeight: fontLineHeight550, weight: fontWeight700)
-    public static let typeBold450 = TypographyCompositeRawToken(size: fontSize450, lineHeight: fontLineHeight550, weight: fontWeight700)
-    public static let typeBold550 = TypographyCompositeRawToken(size: fontSize550, lineHeight: fontLineHeight650, weight: fontWeight700)
-    public static let typeBold650 = TypographyCompositeRawToken(size: fontSize650, lineHeight: fontLineHeight750, weight: fontWeight700)
-    public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeight700)
-    public static let typeBold850 = TypographyCompositeRawToken(size: fontSize850, lineHeight: fontLineHeight950, weight: fontWeight700)
-    public static let typeBold950 = TypographyCompositeRawToken(size: fontSize950, lineHeight: fontLineHeight1050, weight: fontWeight700)
-    public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeight700)
-    public static let typeBold1150 = TypographyCompositeRawToken(size: fontSize1150, lineHeight: fontLineHeight1250, weight: fontWeight700)
-    public static let typeBold1250 = TypographyCompositeRawToken(size: fontSize1250, lineHeight: fontLineHeight1350, weight: fontWeight700)
-    public static let typeBold1450 = TypographyCompositeRawToken(size: fontSize1450, lineHeight: fontLineHeight1450, weight: fontWeight700)
-    public static let typeBold1850 = TypographyCompositeRawToken(size: fontSize1850, lineHeight: fontLineHeight1850, weight: fontWeight700)
+    public static let typeRegular150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing150)
+    public static let typeRegular175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing175)
+    public static let typeRegular200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing200)
+    public static let typeRegular250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight400, letterSpacing: fontLetterSpacing250)
+    public static let typeBold150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing150)
+    public static let typeBold175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing175)
+    public static let typeBold200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing200)
+    public static let typeBold250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight700, letterSpacing: fontLetterSpacing250)
+    public static let typeBold300 = TypographyCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeight700, letterSpacing: fontLetterSpacing300)
+    public static let typeBold350 = TypographyCompositeRawToken(size: fontSize350, lineHeight: fontLineHeight550, weight: fontWeight700, letterSpacing: fontLetterSpacing350)
+    public static let typeBold450 = TypographyCompositeRawToken(size: fontSize450, lineHeight: fontLineHeight550, weight: fontWeight700, letterSpacing: fontLetterSpacing450)
+    public static let typeBold550 = TypographyCompositeRawToken(size: fontSize550, lineHeight: fontLineHeight650, weight: fontWeight700, letterSpacing: fontLetterSpacing550)
+    public static let typeBold650 = TypographyCompositeRawToken(size: fontSize650, lineHeight: fontLineHeight750, weight: fontWeight700, letterSpacing: fontLetterSpacing650)
+    public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeight700, letterSpacing: fontLetterSpacing750)
+    public static let typeBold850 = TypographyCompositeRawToken(size: fontSize850, lineHeight: fontLineHeight950, weight: fontWeight700, letterSpacing: fontLetterSpacing850)
+    public static let typeBold950 = TypographyCompositeRawToken(size: fontSize950, lineHeight: fontLineHeight1050, weight: fontWeight700, letterSpacing: fontLetterSpacing950)
+    public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeight700, letterSpacing: fontLetterSpacing1050)
+    public static let typeBold1150 = TypographyCompositeRawToken(size: fontSize1150, lineHeight: fontLineHeight1250, weight: fontWeight700, letterSpacing: fontLetterSpacing1150)
+    public static let typeBold1250 = TypographyCompositeRawToken(size: fontSize1250, lineHeight: fontLineHeight1350, weight: fontWeight700, letterSpacing: fontLetterSpacing1250)
+    public static let typeBold1450 = TypographyCompositeRawToken(size: fontSize1450, lineHeight: fontLineHeight1450, weight: fontWeight700, letterSpacing: fontLetterSpacing1450)
+    public static let typeBold1850 = TypographyCompositeRawToken(size: fontSize1850, lineHeight: fontLineHeight1850, weight: fontWeight700, letterSpacing: fontLetterSpacing1850)
 }

--- a/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
@@ -14,6 +14,8 @@
 import XCTest
 import OUDSTokensRaw
 
+// swiftlint:disable type_body_length
+
 /// The aim of this tests class is to look for regressions in **typography raw tokens**.
 /// Because these values will be at least generated through an external tool, is it not relevant to test each token values.
 /// Indeed, each future generation of Swift code may break theses tests because there are new values.
@@ -24,9 +26,12 @@ final class TypographyRawTokensTests: XCTestCase {
     // MARK: - Primitive token - Typography - Font family
 
     // Just to ensure the font families in tokens are the ones in system with the same name
-
     func testTypographyRawTokenFontFamilyBrandDefault() throws {
         XCTAssertEqual(TypographyRawTokens.fontFamilyBrandDefault, "Helvetica Neue")
+    }
+
+    func testTypographyRawTokenFontFamilyBrandTV() throws {
+        XCTAssertEqual(TypographyRawTokens.fontFamilyBrandTV, "Helvetica Neue LT")
     }
 
     func testTypographyRawTokenFontFamilySystemArial() throws {
@@ -37,8 +42,24 @@ final class TypographyRawTokensTests: XCTestCase {
         XCTAssertEqual(TypographyRawTokens.fontFamilySystemHelvetica, "Helvetica")
     }
 
+    func testTypographyRawTokenFontFamilySystemNotoSans() throws {
+        XCTAssertEqual(TypographyRawTokens.fontFamilySystemNotoSans, "Noto sans")
+    }
+
+    func testTypographyRawTokenFontFamilySystemSFProText() throws {
+        XCTAssertEqual(TypographyRawTokens.fontFamilySystemSFProText, "SF Pro Text")
+    }
+
+    func testTypographyRawTokenFontFamilySystemRoboto() throws {
+        XCTAssertEqual(TypographyRawTokens.fontFamilySystemRoboto, "Roboto")
+    }
+
     func testTypographyRawTokenFontFamilyMonospaceMenlo() throws {
         XCTAssertEqual(TypographyRawTokens.fontFamilyMonospaceMenlo, "Menlo")
+    }
+
+    func testTypographyRawTokenFontFamilyMonospaceMonaco() throws {
+        XCTAssertEqual(TypographyRawTokens.fontFamilyMonospaceMonaco, "Monaco")
     }
 
     func testTypographyRawTokenFontFamilyCourrierNew() throws {
@@ -173,6 +194,72 @@ final class TypographyRawTokensTests: XCTestCase {
         XCTAssertLessThan(TypographyRawTokens.fontLineHeight1850, TypographyRawTokens.fontLineHeight2050)
     }
 
+    // MARK: - Primitive token - Typography - Letter spacong
+
+    func testTypographyRawTokensFontLetterSpacing150LessThanFontLetterSpacing175() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing150, TypographyRawTokens.fontLetterSpacing175)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing175LessThanFontLetterSpacing200() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing175, TypographyRawTokens.fontLetterSpacing200)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing200LessThanFontLetterSpacing250() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing200, TypographyRawTokens.fontLetterSpacing250)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing250LessThanFontLetterSpacing300() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing250, TypographyRawTokens.fontLetterSpacing300)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing300LessThanFontLetterSpacing350() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing300, TypographyRawTokens.fontLetterSpacing350)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing350LessThanFontLetterSpacing450() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing350, TypographyRawTokens.fontLetterSpacing450)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing450LessThanFontLetterSpacing550() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing450, TypographyRawTokens.fontLetterSpacing550)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing550LessThanFontLetterSpacing650() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing550, TypographyRawTokens.fontLetterSpacing650)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing650LessThanFontLetterSpacing750() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing650, TypographyRawTokens.fontLetterSpacing750)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing750LessThanFontLetterSpacing850() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing750, TypographyRawTokens.fontLetterSpacing850)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing850LessThanFontLetterSpacing950() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing850, TypographyRawTokens.fontLetterSpacing950)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing950LessThanFontLetterSpacing1050() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing950, TypographyRawTokens.fontLetterSpacing1050)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing1050LessThanFontLetterSpacing1150() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing1050, TypographyRawTokens.fontLetterSpacing1150)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing1150LessThanFontLetterSpacing1250() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing1150, TypographyRawTokens.fontLetterSpacing1250)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing1250LessThanFontLetterSpacing1450() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing1250, TypographyRawTokens.fontLetterSpacing1450)
+    }
+
+    func testTypographyRawTokensFontLetterSpacing1450LessThanFontLetterSpacing1850() throws {
+        XCTAssertLessThan(TypographyRawTokens.fontLetterSpacing1450, TypographyRawTokens.fontLetterSpacing1850)
+    }
+
     // MARK: - Primitive token - Typography - Font family
 
     func testTypographyRawTokensFontFamiliesAreAllDifferent() throws {
@@ -227,113 +314,134 @@ final class TypographyRawTokensTests: XCTestCase {
         XCTAssertLessThan(TypographyRawTokens.typeRegular150.size, TypographyRawTokens.typeRegular175.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.lineHeight, TypographyRawTokens.typeRegular175.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.weight, TypographyRawTokens.typeRegular175.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.letterSpacing, TypographyRawTokens.typeRegular175.letterSpacing)
     }
 
     func testTypographyRawTokensTypeRegular175LessThanTypeRegular200() throws {
         XCTAssertLessThan(TypographyRawTokens.typeRegular175.size, TypographyRawTokens.typeRegular200.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.lineHeight, TypographyRawTokens.typeRegular200.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.weight, TypographyRawTokens.typeRegular200.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.letterSpacing, TypographyRawTokens.typeRegular200.letterSpacing)
     }
 
     func testTypographyRawTokensTypeRegular200LessThanTypeRegular250() throws {
         XCTAssertLessThan(TypographyRawTokens.typeRegular200.size, TypographyRawTokens.typeRegular250.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.lineHeight, TypographyRawTokens.typeRegular250.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.weight, TypographyRawTokens.typeRegular250.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.letterSpacing, TypographyRawTokens.typeRegular250.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold150LessThanTypeBold175() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold150.size, TypographyRawTokens.typeBold175.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.lineHeight, TypographyRawTokens.typeBold175.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.weight, TypographyRawTokens.typeBold175.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.letterSpacing, TypographyRawTokens.typeBold175.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold175LessThanTypeBold200() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold175.size, TypographyRawTokens.typeBold200.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.lineHeight, TypographyRawTokens.typeBold200.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.weight, TypographyRawTokens.typeBold200.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.letterSpacing, TypographyRawTokens.typeBold200.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold200LessThanTypeBold250() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold200.size, TypographyRawTokens.typeBold250.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.lineHeight, TypographyRawTokens.typeBold250.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.weight, TypographyRawTokens.typeBold250.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.letterSpacing, TypographyRawTokens.typeBold250.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold250LessThanTypeBold300() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold250.size, TypographyRawTokens.typeBold300.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.lineHeight, TypographyRawTokens.typeBold300.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.weight, TypographyRawTokens.typeBold300.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.letterSpacing, TypographyRawTokens.typeBold300.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold300LessThanTypeBold350() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold300.size, TypographyRawTokens.typeBold350.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.lineHeight, TypographyRawTokens.typeBold350.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.weight, TypographyRawTokens.typeBold350.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.letterSpacing, TypographyRawTokens.typeBold350.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold350LessThanTypeBold450() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold350.size, TypographyRawTokens.typeBold450.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.lineHeight, TypographyRawTokens.typeBold450.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.weight, TypographyRawTokens.typeBold450.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.letterSpacing, TypographyRawTokens.typeBold450.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold450LessThanTypeBold550() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold450.size, TypographyRawTokens.typeBold550.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.lineHeight, TypographyRawTokens.typeBold550.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.weight, TypographyRawTokens.typeBold550.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.letterSpacing, TypographyRawTokens.typeBold550.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold550LessThanTypeBold650() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold550.size, TypographyRawTokens.typeBold650.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.lineHeight, TypographyRawTokens.typeBold650.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.weight, TypographyRawTokens.typeBold650.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.letterSpacing, TypographyRawTokens.typeBold650.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold650LessThanTypeBold750() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold650.size, TypographyRawTokens.typeBold750.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.lineHeight, TypographyRawTokens.typeBold750.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.weight, TypographyRawTokens.typeBold750.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.letterSpacing, TypographyRawTokens.typeBold750.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold750LessThanTypeBold850() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold750.size, TypographyRawTokens.typeBold850.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.lineHeight, TypographyRawTokens.typeBold850.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.weight, TypographyRawTokens.typeBold850.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.letterSpacing, TypographyRawTokens.typeBold850.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold850LessThanTypeBold950() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold850.size, TypographyRawTokens.typeBold950.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.lineHeight, TypographyRawTokens.typeBold950.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.weight, TypographyRawTokens.typeBold950.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.letterSpacing, TypographyRawTokens.typeBold950.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold950LessThanTypeBold1050() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold950.size, TypographyRawTokens.typeBold1050.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.lineHeight, TypographyRawTokens.typeBold1050.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.weight, TypographyRawTokens.typeBold1050.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.letterSpacing, TypographyRawTokens.typeBold1050.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold1050LessThanTypeBold1150() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold1050.size, TypographyRawTokens.typeBold1150.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.lineHeight, TypographyRawTokens.typeBold1150.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.weight, TypographyRawTokens.typeBold1150.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.letterSpacing, TypographyRawTokens.typeBold1150.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold1150LessThanTypeBold1250() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold1150.size, TypographyRawTokens.typeBold1250.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.lineHeight, TypographyRawTokens.typeBold1250.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.weight, TypographyRawTokens.typeBold1250.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.letterSpacing, TypographyRawTokens.typeBold1250.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold1250LessThanTypeBold1450() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold1250.size, TypographyRawTokens.typeBold1450.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.lineHeight, TypographyRawTokens.typeBold1450.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.weight, TypographyRawTokens.typeBold1450.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.letterSpacing, TypographyRawTokens.typeBold1450.letterSpacing)
     }
 
     func testTypographyRawTokensTypeBold1450LessThanTypeBold1850() throws {
         XCTAssertLessThan(TypographyRawTokens.typeBold1450.size, TypographyRawTokens.typeBold1850.size)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.lineHeight, TypographyRawTokens.typeBold1850.lineHeight)
         XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.weight, TypographyRawTokens.typeBold1850.weight)
+        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.letterSpacing, TypographyRawTokens.typeBold1850.letterSpacing)
     }
 }
+
+// swiftlint:enable type_body_length

--- a/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
@@ -2,17 +2,17 @@
 // Software Name: OUDS iOS
 // SPDX-FileCopyrightText: Copyright (c) Orange SA
 // SPDX-License-Identifier: MIT
-// 
+//
 // This software is distributed under the MIT license,
 // the text of which is available at https://opensource.org/license/MIT/
 // or see the "LICENSE" file for more details.
-// 
+//
 // Authors: See CONTRIBUTORS.txt
-// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
 import XCTest
-import OUDSTokensRaw
+@testable import OUDSTokensRaw
 
 // swiftlint:disable type_body_length
 
@@ -311,137 +311,79 @@ final class TypographyRawTokensTests: XCTestCase {
     // MARK: - Primitive token - Typography - Composite
 
     func testTypographyRawTokensTypeRegular150LessThanTypeRegular175() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeRegular150.size, TypographyRawTokens.typeRegular175.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.lineHeight, TypographyRawTokens.typeRegular175.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.weight, TypographyRawTokens.typeRegular175.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular150.letterSpacing, TypographyRawTokens.typeRegular175.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeRegular150 <| TypographyRawTokens.typeRegular175)
     }
 
     func testTypographyRawTokensTypeRegular175LessThanTypeRegular200() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeRegular175.size, TypographyRawTokens.typeRegular200.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.lineHeight, TypographyRawTokens.typeRegular200.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.weight, TypographyRawTokens.typeRegular200.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular175.letterSpacing, TypographyRawTokens.typeRegular200.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeRegular175 <| TypographyRawTokens.typeRegular200)
     }
 
     func testTypographyRawTokensTypeRegular200LessThanTypeRegular250() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeRegular200.size, TypographyRawTokens.typeRegular250.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.lineHeight, TypographyRawTokens.typeRegular250.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.weight, TypographyRawTokens.typeRegular250.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeRegular200.letterSpacing, TypographyRawTokens.typeRegular250.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeRegular200 <| TypographyRawTokens.typeRegular250)
     }
 
     func testTypographyRawTokensTypeBold150LessThanTypeBold175() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold150.size, TypographyRawTokens.typeBold175.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.lineHeight, TypographyRawTokens.typeBold175.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.weight, TypographyRawTokens.typeBold175.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold150.letterSpacing, TypographyRawTokens.typeBold175.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold150 <| TypographyRawTokens.typeBold175)
     }
 
     func testTypographyRawTokensTypeBold175LessThanTypeBold200() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold175.size, TypographyRawTokens.typeBold200.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.lineHeight, TypographyRawTokens.typeBold200.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.weight, TypographyRawTokens.typeBold200.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold175.letterSpacing, TypographyRawTokens.typeBold200.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold175 <| TypographyRawTokens.typeBold200)
     }
 
     func testTypographyRawTokensTypeBold200LessThanTypeBold250() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold200.size, TypographyRawTokens.typeBold250.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.lineHeight, TypographyRawTokens.typeBold250.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.weight, TypographyRawTokens.typeBold250.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold200.letterSpacing, TypographyRawTokens.typeBold250.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold200 <| TypographyRawTokens.typeBold250)
     }
 
     func testTypographyRawTokensTypeBold250LessThanTypeBold300() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold250.size, TypographyRawTokens.typeBold300.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.lineHeight, TypographyRawTokens.typeBold300.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.weight, TypographyRawTokens.typeBold300.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold250.letterSpacing, TypographyRawTokens.typeBold300.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold250 <| TypographyRawTokens.typeBold300)
     }
 
     func testTypographyRawTokensTypeBold300LessThanTypeBold350() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold300.size, TypographyRawTokens.typeBold350.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.lineHeight, TypographyRawTokens.typeBold350.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.weight, TypographyRawTokens.typeBold350.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold300.letterSpacing, TypographyRawTokens.typeBold350.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold300 <| TypographyRawTokens.typeBold350)
     }
 
     func testTypographyRawTokensTypeBold350LessThanTypeBold450() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold350.size, TypographyRawTokens.typeBold450.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.lineHeight, TypographyRawTokens.typeBold450.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.weight, TypographyRawTokens.typeBold450.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold350.letterSpacing, TypographyRawTokens.typeBold450.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold350 <| TypographyRawTokens.typeBold450)
     }
 
     func testTypographyRawTokensTypeBold450LessThanTypeBold550() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold450.size, TypographyRawTokens.typeBold550.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.lineHeight, TypographyRawTokens.typeBold550.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.weight, TypographyRawTokens.typeBold550.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold450.letterSpacing, TypographyRawTokens.typeBold550.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold450 <| TypographyRawTokens.typeBold550)
     }
 
     func testTypographyRawTokensTypeBold550LessThanTypeBold650() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold550.size, TypographyRawTokens.typeBold650.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.lineHeight, TypographyRawTokens.typeBold650.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.weight, TypographyRawTokens.typeBold650.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold550.letterSpacing, TypographyRawTokens.typeBold650.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold550 <| TypographyRawTokens.typeBold650)
     }
 
     func testTypographyRawTokensTypeBold650LessThanTypeBold750() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold650.size, TypographyRawTokens.typeBold750.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.lineHeight, TypographyRawTokens.typeBold750.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.weight, TypographyRawTokens.typeBold750.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold650.letterSpacing, TypographyRawTokens.typeBold750.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold650 <| TypographyRawTokens.typeBold750)
     }
 
     func testTypographyRawTokensTypeBold750LessThanTypeBold850() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold750.size, TypographyRawTokens.typeBold850.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.lineHeight, TypographyRawTokens.typeBold850.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.weight, TypographyRawTokens.typeBold850.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold750.letterSpacing, TypographyRawTokens.typeBold850.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold750 <| TypographyRawTokens.typeBold850)
     }
 
     func testTypographyRawTokensTypeBold850LessThanTypeBold950() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold850.size, TypographyRawTokens.typeBold950.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.lineHeight, TypographyRawTokens.typeBold950.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.weight, TypographyRawTokens.typeBold950.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold850.letterSpacing, TypographyRawTokens.typeBold950.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold850 <| TypographyRawTokens.typeBold950)
     }
 
     func testTypographyRawTokensTypeBold950LessThanTypeBold1050() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold950.size, TypographyRawTokens.typeBold1050.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.lineHeight, TypographyRawTokens.typeBold1050.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.weight, TypographyRawTokens.typeBold1050.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold950.letterSpacing, TypographyRawTokens.typeBold1050.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold950 <| TypographyRawTokens.typeBold1050)
     }
 
     func testTypographyRawTokensTypeBold1050LessThanTypeBold1150() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold1050.size, TypographyRawTokens.typeBold1150.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.lineHeight, TypographyRawTokens.typeBold1150.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.weight, TypographyRawTokens.typeBold1150.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1050.letterSpacing, TypographyRawTokens.typeBold1150.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold1050 <| TypographyRawTokens.typeBold1150)
     }
 
     func testTypographyRawTokensTypeBold1150LessThanTypeBold1250() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold1150.size, TypographyRawTokens.typeBold1250.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.lineHeight, TypographyRawTokens.typeBold1250.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.weight, TypographyRawTokens.typeBold1250.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1150.letterSpacing, TypographyRawTokens.typeBold1250.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold1150 <| TypographyRawTokens.typeBold1250)
     }
 
     func testTypographyRawTokensTypeBold1250LessThanTypeBold1450() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold1250.size, TypographyRawTokens.typeBold1450.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.lineHeight, TypographyRawTokens.typeBold1450.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.weight, TypographyRawTokens.typeBold1450.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1250.letterSpacing, TypographyRawTokens.typeBold1450.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold1250 <| TypographyRawTokens.typeBold1450)
     }
 
     func testTypographyRawTokensTypeBold1450LessThanTypeBold1850() throws {
-        XCTAssertLessThan(TypographyRawTokens.typeBold1450.size, TypographyRawTokens.typeBold1850.size)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.lineHeight, TypographyRawTokens.typeBold1850.lineHeight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.weight, TypographyRawTokens.typeBold1850.weight)
-        XCTAssertLessThanOrEqual(TypographyRawTokens.typeBold1450.letterSpacing, TypographyRawTokens.typeBold1850.letterSpacing)
+        XCTAssertTrue(TypographyRawTokens.typeBold1450 <| TypographyRawTokens.typeBold1850)
     }
 }
-
 // swiftlint:enable type_body_length


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#51

### Description

<!-- Describe your changes in detail -->

Add last tokens and unit tests

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

-(NA) My change follows accessibility good practices

#### Design

-(NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
-(NA) Design review has been done
-(NA) Accessibiltiy review has been done
-(NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
