### PR TITLE
[#119] Remove tokens `elevationZIndex` and add `elevationX200`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.2.0...develop)
 
+### Added
+
+- [Library] Add `elevationX200` raw token ([#119](https://github.com/Orange-OpenSource/ouds-ios/issues/119))
+
+### Removed
+
+- [Library] Remove raw tokens `elevationZIndex` ([#119](https://github.com/Orange-OpenSource/ouds-ios/issues/119))
 
 ## [0.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.1.0...0.2.0) - 2024-09-19
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/ElevationRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/ElevationRawTokens+Values.swift
@@ -15,27 +15,10 @@
 /// Should be fully generated in the future.
 extension ElevationRawTokens {
 
-    // MARK: Primitive token - Elevation - Z Index
-
-    public static let elevationZIndex0: ElevationRawToken = 0
-    public static let elevationZIndexMinus9999: ElevationRawToken = -9999
-    public static let elevationZIndex1000: ElevationRawToken = 1000
-    public static let elevationZIndex1010: ElevationRawToken = 1010
-    public static let elevationZIndex1020: ElevationRawToken = 1020
-    public static let elevationZIndex1030: ElevationRawToken = 1030
-    public static let elevationZIndex1035: ElevationRawToken = 1035
-    public static let elevationZIndex1038: ElevationRawToken = 1038
-    public static let elevationZIndex1040: ElevationRawToken = 1040
-    public static let elevationZIndex1045: ElevationRawToken = 1045
-    public static let elevationZIndex1050: ElevationRawToken = 1050
-    public static let elevationZIndex1060: ElevationRawToken = 1060
-    public static let elevationZIndex1070: ElevationRawToken = 1070
-    public static let elevationZIndex1080: ElevationRawToken = 1080
-    public static let elevationZIndex1090: ElevationRawToken = 1090
-
     // MARK: Primitive token - Elevation - X
 
     public static let elevationX0: ElevationRawToken = 0
+    public static let elevationX200: ElevationRawToken = 2
 
     // MARK: Primitive token - Elevation - Y
 

--- a/OUDS/Core/Tokens/RawTokens/Tests/ElevationRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/ElevationRawTokensTests.swift
@@ -62,6 +62,12 @@ final class ElevationRawTokensTests: XCTestCase {
         XCTAssertTrue(radius == 6)
     }
 
+    // MARK: - Primitive token - Elevation - X
+
+    func testElevationXRawToken0LessThanX200() throws {
+        XCTAssertLessThan(ElevationRawTokens.elevationX0, ElevationRawTokens.elevationX200)
+    }
+
     // MARK: - Primitive token - Elevation - Y
 
     func testElevationYRawToken0LessThanY100() throws {

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/ElevationSemanticTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/ElevationSemanticTokens+Aliases.swift
@@ -13,9 +13,6 @@
 
 import OUDSTokensRaw
 
-/// Basically an elevation semantic token for Z Index is a raw token for elevation, with the same final type, to keep grammar clean and clear with design system grammar.
-public typealias ElevationZIndexSemanticToken = ElevationRawToken
-
 /// Basically an elevation semantic token for X offset is a raw token for elevation, with the same final type, to keep grammar clean and clear with design system grammar.
 public typealias ElevationXSemanticToken = ElevationRawToken
 


### PR DESCRIPTION
Closes #119

_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#119 

### Description

<!-- Describe your changes in detail -->

- Add missing raw toekn elevation X 200
- Remove Z Index raw tokens for elevations

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
