### PR TITLE
[#127] Add more details about raw and semantic tokens definitions in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Update color semantic tokens to better manage light and dark modes values
 - [Library] Update elevation colors focus light and dark
 - [Library] Rename space padding inline component tokens by removing "component" word
-- [Library] Improve documentation about raw tokens definitions
 - [Library] Improve documentation about raw and semantic tokens definitions ([#127](https://github.com/Orange-OpenSource/ouds-ios/issues/127))
 - [Library] Rename some sizing semantic tokens ([#122](https://github.com/Orange-OpenSource/ouds-ios/issues/122))
 - [Library] Replace "adaptable" word by "scaled" in space semantic tokens, "fix" by "fixed" and remove "layout" ([#117](https://github.com/Orange-OpenSource/ouds-ios/issues/117))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Update elevation colors focus light and dark
 - [Library] Rename space padding inline component tokens by removing "component" word
 - [Library] Improve documentation about raw tokens definitions
+- [Library] Improve documentation about raw and semantic tokens definitions ([#127](https://github.com/Orange-OpenSource/ouds-ios/issues/127))
 - [Library] Rename some sizing semantic tokens ([#122](https://github.com/Orange-OpenSource/ouds-ios/issues/122))
 - [Library] Replace "adaptable" word by "scaled" in space semantic tokens, "fix" by "fixed" and remove "layout" ([#117](https://github.com/Orange-OpenSource/ouds-ios/issues/117))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Update color semantic tokens to better manage light and dark modes values
 - [Library] Update elevation colors focus light and dark
 - [Library] Rename space padding inline component tokens by removing "component" word
+- [Library] Improve documentation about raw tokens definitions
 - [Library] Rename some sizing semantic tokens ([#122](https://github.com/Orange-OpenSource/ouds-ios/issues/122))
 - [Library] Replace "adaptable" word by "scaled" in space semantic tokens, "fix" by "fixed" and remove "layout" ([#117](https://github.com/Orange-OpenSource/ouds-ios/issues/117))
 

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
@@ -98,7 +98,7 @@ In addition, there are hundreds of _semantics tokens_ and we needed to add them 
 
 That is the reason why tokens are exposed as `@objc open` to be available and overridable anywhere. 
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme. It's only syntaxic sugar to bring _design words_ in our product.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme. It's only syntaxic sugar to bring _design words_ in our product.
 
 Example with [OUDSTokensComponent/ColorSemanticTokens](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/colorsemantictokens):
 
@@ -125,7 +125,7 @@ In fact, we choose to use as most as possible primitive types for raw values, li
 
 So we expose also in higher level some properties so as to convert when needed some of these types to `SwiftUI` types (like `Font.Weight` and `Color`).
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme.
 
 Using more simple and primitive types will help also to test the library. With also type aliases we force users to use our types and not higher level types like _SwiftUI_ types.
 

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
@@ -98,7 +98,7 @@ In addition, there are hundreds of _semantics tokens_ and we needed to add them 
 
 That is the reason why tokens are exposed as `@objc open` to be available and overridable anywhere. 
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are avaialble for those who want too make their own theme. It's only syntaxic sugar to bring _design words_ in our product.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme. It's only syntaxic sugar to bring _design words_ in our product.
 
 Example with [OUDSTokensComponent/ColorSemanticTokens](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/colorsemantictokens):
 

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Tokens.md
@@ -157,23 +157,12 @@ extension String { // The OUDS library still exposes this comptuer property
 ## Add, edit or remove tokens
 
 If you need to add, edit or remove tokens, you will have to follow some simple steps.
-You may need to [create an issue](https://github.com/Orange-OpenSource/ouds-ios/issues) or [a pull request](https://github.com/Orange-OpenSource/ouds-ios/pulls) to submit the evolutions you want.
+You may need to [create an issue](https://github.com/Orange-OpenSource/ouds-ios/issues) or [a pull request](https://github.com/Orange-OpenSource/ouds-ios/pulls) to submit the evolutions you want. Use for example the _Token Update Request_ issue template.
 
 ### For raw tokens
 
-First, find the file containing the tokens you target. For example, _raw tokens_ are listed and gathered in dedicated files (one file for elevation tokens, one file for dimensions tokens, etc.).
-Then, in the _enum_, add as _static let_ the new raw rotken you want, or update or remove the one you target. Beware, some of them are not *raw types* but *composite types* because they wrap severla values.
-
-Do not forget to update the unit tests. Indeed we don't want to test realy the values of each raw token, because for each update of values the unit tests will have to be updated, and it is time wasting. Thus we only test relationship between tokens. For exemple, for a color palette we ensure the colors are lighter and lighter (or darker and darker). For sizes we check if a variable remains lower than the next one, etc.
-
-Beware, if you want remove tokens and if the raw tokens you want to remove are shared to others, prefer keeping the old value until the next release and flag it as deprecated so as to avoid to break the backward compatibility.
+You can refer to the *OUDSTokensRaw* documentation or [get it online](https://ios.unified-design-system.orange.com/documentation/oudstokensraw/)
 
 ### For semantic tokens
 
-Semantic tokens are declared in dedicated protocols, i.e. each semantic token family is gathered in its own protocol definition. It allows to not spread tokens everywhere, keep things clean, and will force themes to implement them so as to be sure the tokens will always been defined.
-You may need thus to add the semantic tokens you want in the suitable protocol, then update the theme which defines the vavlues by implementing the protocol.
-You can declare a semantic token (or several) in a protocol, and define them in your theme assigning in the end a raw token as value.
-
-Do not forget to update the unit tests. Indeed we don't tests the real values of the semantic tokens which can change a lot, but we test if the semantic tokens can be overriden, i.e. if a theme which is a subclass of an higher level them can change the value for each semantic token. It will ensure that tokens remain overridable.
-
-Beware, if you want remove tokens and if the semantic tokens you want to remove are shared to others, prefer keeping the old value until the next release and flag it as deprecated so as to avoid to break the backward compatibility.
+You can refer to the *OUDSTokensSemantic* documentation or [get it online](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/

--- a/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
+++ b/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
@@ -8,7 +8,7 @@ In fact, we choose to use as most as possible primitive types for raw values, li
 
 So we expose also in higher level some properties so as to convert when needed some of these types to `SwiftUI` types (like `Font.Weight` and `Color`).
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme.
 
 Using more simple and primitive types will help also to test the library. With also type aliases we force users to use our types and not higher level types like _SwiftUI_ types.
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
+++ b/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
@@ -4,15 +4,15 @@ _Raw tokens_ are smallest _tokens_ possible. They are associated to raw values a
 
 ## Overview
 
-In fact, we choose to use as most as possible primitive types for raw values, like `Int`, `Double`, `CGFloat` or `String` so as to handle the smallest types with few impacts on the memory for ecodesign principles. Indeed with hundreds of raw tokens, it will be more efficient to store primitive small types than structs or classes.
+In fact, we choose to use as most as possible primitive types for raw values, like `Int`, `Double`, `CGFloat` or `String` so as to handle the smallest types with few impacts on the memory for ecodesign principles. Indeed with hundreds of raw tokens, it will be more efficient to store primitive small types than Swift `struct` or `class` objects.
 
 So we expose also in higher level some properties so as to convert when needed some of these types to `SwiftUI` types (like `Font.Weight` and `Color`).
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are avaialble for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
 
 Using more simple and primitive types will help also to test the library. With also type aliases we force users to use our types and not higher level types like _SwiftUI_ types.
 
-We also choose to add in _extension_ all the tokens values in a separated file so as to help the *Figma*-JSON-to-Swift parser to build files to copy and past easily in the project and keeping all the other objects.
+We also choose to add in _extension_ all the tokens values in a separated file so as to help the *Figma*-JSON-to-Swift parser to build files to copy and paste easily in the project and keeping all the other objects.
 
 Example for ``ColorRawTokens`:
 
@@ -22,7 +22,7 @@ public typealias ColorRawToken = String
 
 public enum ColorRawTokens { } // Gathers all color raw tokens
 
-extension ColorRawTokens {
+extension ColorRawTokens { // In a separated file
 
     public static let colorFunctionalWhite: ColorRawToken = "#FFFFFF"
     public static let colorFunctionalScarlet400: ColorRawToken = "#FF4D4E"
@@ -31,11 +31,28 @@ extension ColorRawTokens {
 }
 
 extension String {
-    public var color: Color {
+    public var color: Color { // Helper for SwiftUI
         Color(hexadecimalCode: self)
     }
 }
 ```
+
+## Architecture
+
+The *Composites* folder contains some _composite class_ defined to match the objects available in *Figma*.
+In fact the design system implementations should expose pack of values so as to gather several tokens in one object. For exemple `ElevationCompositeRawToken` can be used for predefined elevations effects, and `TypographyCompositeRawToken` can be used for predefined typography.
+All such *composites* are defined here.
+
+The *Declarations* folder contains all the Swift `enum` objects which will gather the raw tokens.
+In fact, raw tokens are defined as `static let` _stored properties_, an adding them in an `enum` is more optimized for namespaces reasons. Thus all `public enum` gathering raw tokens are defined there.
+
+The *TypeAliases* folder contains all the *typealias* values used for the raw tokens.
+Indeed these aliases are here to bring clarity and meanings in the library, and also to help users (i.e. developers) to know what kind of objects they handle with the same vocabulary as the one used in *Figma*, and in general, in the whole design system. They can be seen as a ligh level of abstraction with meanings, without having to define real types with `struct` or `class`.
+
+The *Values* folder is maybe the hotter one.
+In fact all the raw tokens values are defined there, and if a JSON to Swift parser generate files, these files must be stored there. It contains only pure raw tokens Swift values, without any type aliases definitions or objects declarations.
+
+In a nutshell, place the generated values somewhere, and the types and objects elsewhere.
 
 ## Topics
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
+++ b/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
@@ -14,7 +14,7 @@ Using more simple and primitive types will help also to test the library. With a
 
 We also choose to add in _extension_ all the tokens values in a separated file so as to help the *Figma*-JSON-to-Swift parser to build files to copy and paste easily in the project and keeping all the other objects.
 
-Example for ``ColorRawTokens`:
+Example for ``ColorRawTokens``:
 
 ```swift
 // Define types for color raw tokens
@@ -53,6 +53,33 @@ The *Values* folder is maybe the hotter one.
 In fact all the raw tokens values are defined there, and if a JSON to Swift parser generate files, these files must be stored there. It contains only pure raw tokens Swift values, without any type aliases definitions or objects declarations.
 
 In a nutshell, place the generated values somewhere, and the types and objects elsewhere.
+
+## Raw tokens management
+
+### How to add raw tokens
+
+First, you need to define which from family this semantic comes. We have today up to 7 families: *border*, *color*, *dimension*, *elevation*, *grid*, *opacity* and *typography*.
+If your token is not from one of these groups, maybe you should redesign your token or create a new family. To do that, you will have to create a dedicated Swift `enum`, with a useful name, and declare as a `static let` the raw tokens in an `extension`. If you already know the family, just update the matching files.
+
+If you need to define Swift `typealias`, update the suitable file in the *TypeAliases* folder.
+
+Please, respect the nomenclature of the files, e.g. for a new family "Awesome raw" tokens:
+- declaration of raw tokens family must be `AwesomeRawTokens.swift`
+- values must be in `AwesomeRawTokens+Values.swift`
+- type aliases must be in `AwesomeRawTokens+Aliases.swift`
+- composites objects must be in `AwesomeRawTokens+Composites.swift`
+
+*Composites* here are notions from *Figma* and are here to pack several raw tokens together to expose a plain, useful and usable object.
+
+Then, update the unit tests. We do not test the raw tokens values as they are, because these values will be generated and keeping up to date the unit tests may be time wasting.
+But we can however test the relationships between tokens, for exemple for colors if they go lighter and lighter, or for dimensions if they go smaller and smaller. If some raw tokens like font weights strongly rely on the values, we still test these values.
+
+### How to update or remove raw tokens
+
+Quite simple, find the raw token you want to update or remove, and update or remove it.
+But beware, if you change the name of the property or if you move it from an `enum` to another, or if you remove the token, you must keep retrocompatibility as much as possible so as to avoid to break any public API. Keep also the CHANGELOG and/or the release updated with some BREAKING CHANGE notification, and also the Git history clean.
+
+If you update the value, keep also the CHANGELOG and/or RELEASE NOTE updated so as to let yout users know the variables have been changed.
 
 ## Topics
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
@@ -11,7 +11,7 @@ In addition, there are hundreds of _semantics tokens_ and we needed to add them 
 
 That is the reason why tokens are exposed as `@objc open` to be available and oveeridable anywhere. 
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are avaialble for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
 
 Example with ``ColorSemanticTokens``:
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
@@ -43,6 +43,30 @@ These protocols list all semantic tokens for each "family". Thus, any theme impl
 
 In a nutshell, declare the tokens somewhere in protocols, and define theme in theme implementation.
 
+## Semantic tokens management
+
+### How to add semantic tokens
+
+First, you need to define which from family this semantic comes. We have today 9 families: *border*, *color*, *dimension*, *elevation*, *grid*, *opacity*, *sizing*, *spacing* and *typography*.
+If your token is not from one of these groups, maybe you should redesign your token or create a new family. To do that, you will have to create a dedicated Swift `protocol`, with a useful name, and declare as a `var` the semantic token. If you already know the family, jsut update the matching files.
+
+If you need to define Swift `typealias`n update the suitable file in the *TypeAliases* folder. If you think users may manipule your tokens with tuples, or pack of tokens, you can add your own *composite* object.
+
+Please, respect the nomenclature of the files, e.g. for a new family "Awesome semantic" tokens:
+- values must be in `AwesomeSemanticTokens.swift`
+- type aliases must be in `AwesomeSemanticTokens+Aliases.swift`
+- composites objects must be in `AwesomeSemanticTokens+Composites.swift`
+
+Then, update the unit tests. For each semantic tokens we check if a subtheme can override the token, i.e. update the `MockTheme` by overring the property with a fake value, then compare it to the `OUDSTheme` containing a default value. If you have defined also composite objects, add unit tests to check if they do their job.
+
+### How to update or remove semantic tokens
+
+Quite simple, find the semantic token you want to update or remove, and update or remove it.
+But beware, if you change the name of the property or if you move it from a `protocol` to another, or if you remove the token, you must keep retrocompatibility as much as possible so as to avoid to break any public API. Keep also the CHANGELOG and/or the release updated with some BREAKING CHANGE notification, and also the Git history clean.
+
+If you update the value, keep also the CHANGELOG and/or RELEASE NOTE updated so as to let yout users know the variables have been changed.
+
+
 ## Topics
 
 ### Group

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
@@ -11,7 +11,7 @@ In addition, there are hundreds of _semantics tokens_ and we needed to add them 
 
 That is the reason why tokens are exposed as `@objc open` to be available and oveeridable anywhere. 
 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme.
 
 Example with ``ColorSemanticTokens``:
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
@@ -48,9 +48,9 @@ In a nutshell, declare the tokens somewhere in protocols, and define theme in th
 ### How to add semantic tokens
 
 First, you need to define which from family this semantic comes. We have today 9 families: *border*, *color*, *dimension*, *elevation*, *grid*, *opacity*, *sizing*, *spacing* and *typography*.
-If your token is not from one of these groups, maybe you should redesign your token or create a new family. To do that, you will have to create a dedicated Swift `protocol`, with a useful name, and declare as a `var` the semantic token. If you already know the family, jsut update the matching files.
+If your token is not from one of these groups, maybe you should redesign your token or create a new family. To do that, you will have to create a dedicated Swift `protocol`, with a useful name, and declare as a `var` the semantic token. If you already know the family, just update the matching files.
 
-If you need to define Swift `typealias`n update the suitable file in the *TypeAliases* folder. If you think users may manipule your tokens with tuples, or pack of tokens, you can add your own *composite* object.
+If you need to define Swift `typealias`, update the suitable file in the *TypeAliases* folder. If you think users may handle your tokens with tuples, or pack of tokens, you can add your own *composite* object.
 
 Please, respect the nomenclature of the files, e.g. for a new family "Awesome semantic" tokens:
 - values must be in `AwesomeSemanticTokens.swift`

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/_OUDSTokensSemantic.docc/OUDSTokensSemantic.md
@@ -28,6 +28,21 @@ extension OUDSTheme: ColorSemanticTokens {
 }
 ```
 
+## Architecture
+
+The *Composites* folder contains some _composite class_ defined to pack double values for dedicated needs, like size classes management (_regular_ or _compact_ device modes), and also for color schemes management (_light_ and _dark_ modes).
+This *composites* are not the same as the ones defined in the *Figma* design systme, they are just utilities to handle tuple of values, without the syntaxe of tuples and with some helper functions.
+
+The *TypeAliases* folder contains all the *typealias* values used for the semantic tokens.
+Indeed these aliases are here to bring clarity and meanings in the library, and also to help users (i.e. developers) to know what kind of objects they handle with the same vocabulary as the one used in *Figma*, and in general, in the whole design system. They can be seen as a ligh level of abstraction with meanings, without having to define real types with `struct` or `class`.
+Type aliases here point to raw tokens aliases, thus by transition they point to real types.
+
+The *Values* folder is maybe the hotter one.
+In fact all the semantic tokens values are defined there, and if a JSON to Swift parser generate files, these files must be stored there. We need any _theme_ can embed and override all or some of the tokens, and if a new theme must be implemented from nothing, it must implement all the semantic tokens. Thus each semantic tokens group is declared in a Swft `protocol`.
+These protocols list all semantic tokens for each "family". Thus, any theme implementation (at least `OUDSTheme`) must implement the values, and if possible through a _Swift_ extension of the `class` so as to keep seperated the objects.
+
+In a nutshell, declare the tokens somewhere in protocols, and define theme in theme implementation.
+
 ## Topics
 
 ### Group

--- a/OUDS/README.md
+++ b/OUDS/README.md
@@ -131,7 +131,7 @@ They can be seen as an high level of usage with functional meanings.
 Thus if we need for example to change a warning color, supposing this color is defined as a _semantic token_, we onlyhave to change its assigned value and all components using the _semantic token_ won't be impacted in their definition.
 In addition, there are hundreds of _semantics tokens_ and we needed to add them to the abstract root theme using extensions for clarity reasons to prevent to have a _Swift class_ with thousands of lines. Each _raw token_ "family" is then declared in its dedicated _Swift protocol_ any root theme must implement. Because we choose to split responsabilities and objects into their own modules, we faced troubles to make possible for children themes to override properties declared in _protocols_ and defined in _extensions_.
 That is the reason why tokens are exposed as `@objc open` to be available and oveeridable anywhere. 
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme.
 
 Example with `ColorSemanticTokens`:
 
@@ -152,7 +152,7 @@ _Raw tokens_ are smallest _tokens_ possible. They are associated to raw values a
 
 In fact, we choose to use as most as possible primitive types for raw values, like `Int`, `Double`, `CGFloat` or `String` so as to handle the smallest types with few impacts on the memory for ecodesign principles. Indeed with hundreds of raw tokens, it will be more efficient to store primitive small types than structs or classes.
 So we expose also in higher level some properties so as to convert when needed some of these types to `SwiftUI` types (like `Font.Weight` and `Color`).
-To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want too make their own theme.
+To keep the same semantics as the ones used in our specifications, _typealias_ are used to as to make the links to _primitive types_ and our logic of _tokens_. These type aliases are available for those who want to make their own theme.
 
 Using more simple and primitive types will help also to test the library. With also type aliases we force users to use our types and not higher level types like _SwiftUI_ types.
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#127

### Description

<!-- Describe your changes in detail -->

Add more details about how to define, add, update or remove raw and semantic tokens

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
