### PR TITLE
[#139] Remove web-specific grid raw tokens and non-max-min-width grid semantic tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Library] Rename of typography font weight raw tokens
 - [Library] Remove web-specific grid tokens, keep compact/regular widths ([#147](https://github.com/Orange-OpenSource/ouds-ios/pull/147))
+- [Library] Rename of typography font weight raw tokens
 - [Library] Rename dimension semantic tokens to apply T-Shirt size rules ([#130](https://github.com/Orange-OpenSource/ouds-ios/issues/130))
 - [Library] Rename `SizingCompositeSemanticToken` to `MultipleSizingSemanticToken` to keep "composite" word for *Figma* design system
 - [Library] Rename `ColorCompositeSemanticToken` to `MultipleColorRawToken` to keep "composite" word for *Figma* design system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [Library] Rename of typography font weight raw tokens
+- [Library] Remove web-specific grid tokens, keep compact/regular widths ([#147](https://github.com/Orange-OpenSource/ouds-ios/pull/147))
 - [Library] Rename dimension semantic tokens to apply T-Shirt size rules ([#130](https://github.com/Orange-OpenSource/ouds-ios/issues/130))
 - [Library] Rename `SizingCompositeSemanticToken` to `MultipleSizingSemanticToken` to keep "composite" word for *Figma* design system
 - [Library] Rename `ColorCompositeSemanticToken` to `MultipleColorRawToken` to keep "composite" word for *Figma* design system
@@ -43,7 +44,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Improve documentation about raw and semantic tokens definitions ([#127](https://github.com/Orange-OpenSource/ouds-ios/issues/127))
 - [Library] Rename some sizing semantic tokens ([#122](https://github.com/Orange-OpenSource/ouds-ios/issues/122))
 - [Library] Replace "adaptable" word by "scaled" in space semantic tokens, "fix" by "fixed" and remove "layout" ([#117](https://github.com/Orange-OpenSource/ouds-ios/issues/117))
-- [Library] Remove web-specific grid tokens, keep compact/regular widths ([#147](https://github.com/Orange-OpenSource/ouds-ios/pull/147))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Improve documentation about raw and semantic tokens definitions ([#127](https://github.com/Orange-OpenSource/ouds-ios/issues/127))
 - [Library] Rename some sizing semantic tokens ([#122](https://github.com/Orange-OpenSource/ouds-ios/issues/122))
 - [Library] Replace "adaptable" word by "scaled" in space semantic tokens, "fix" by "fixed" and remove "layout" ([#117](https://github.com/Orange-OpenSource/ouds-ios/issues/117))
+- [Library] Remove web-specific grid tokens, keep compact/regular widths ([#147](https://github.com/Orange-OpenSource/ouds-ios/pull/147))
 
 ### Removed
 

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
@@ -40,12 +40,9 @@ extension OUDSTheme: GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
+    @objc open var gridRegularMinWidth: GridRegularSemanticToken { GridRawTokens.gridMinWidthRegular }
+    @objc open var gridRegularMaxWidth: GridRegularSemanticToken { GridRawTokens.gridMaxWidthRegular }
     @objc open var gridRegularMargin: GridRegularSemanticToken { GridRawTokens.gridMargin500 }
     @objc open var gridRegularColumnGap: GridRegularSemanticToken { GridRawTokens.gridColumnGap300 }
     @objc open var gridRegularColumnCount: GridRegularSemanticToken { GridRawTokens.gridColumnCount600 }
-    
-    // MARK: Semantic token - Grid - iOS Medium
-
-    @objc open var gridMediumMinWidth: GridMediumSemanticToken { GridRawTokens.gridMinWidthMedium }
-    @objc open var gridMediumMaxWidth: GridRegularSemanticToken { GridRawTokens.gridMaxWidthMedium }
 }

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
@@ -24,7 +24,6 @@ extension OUDSTheme: GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Extra compact
 
-    @objc open var gridExtraCompactWidth: GridExtraCompactSemanticToken { GridRawTokens.gridWidth100 }
     @objc open var gridExtraCompactMinWidth: GridExtraCompactSemanticToken { GridRawTokens.gridMinWidthExtraCompact }
     @objc open var gridExtraCompactMaxWidth: GridExtraCompactSemanticToken { GridRawTokens.gridMaxWidthExtraCompact }
     @objc open var gridExtraCompactMargin: GridExtraCompactSemanticToken { GridRawTokens.gridMargin100 }
@@ -33,7 +32,6 @@ extension OUDSTheme: GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Compact
 
-    @objc open var gridCompactWidth: GridExtraCompactSemanticToken { GridRawTokens.gridWidth200 }
     @objc open var gridCompactMinWidth: GridCompactSemanticToken { GridRawTokens.gridMinWidthCompact }
     @objc open var gridCompactMaxWidth: GridCompactSemanticToken { GridRawTokens.gridMaxWidthCompact }
     @objc open var gridCompactMargin: GridCompactSemanticToken { GridRawTokens.gridMargin300 }
@@ -42,7 +40,6 @@ extension OUDSTheme: GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
-    @objc open var gridRegularWidth: GridExtraCompactSemanticToken { GridRawTokens.gridWidth400 }
     @objc open var gridRegularMinWidth: GridRegularSemanticToken { GridRawTokens.gridMinWidthRegular }
     @objc open var gridRegularMaxWidth: GridRegularSemanticToken { GridRawTokens.gridMaxWidthRegular }
     @objc open var gridRegularMargin: GridRegularSemanticToken { GridRawTokens.gridMargin500 }

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+GridSemanticTokens.swift
@@ -40,9 +40,12 @@ extension OUDSTheme: GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
-    @objc open var gridRegularMinWidth: GridRegularSemanticToken { GridRawTokens.gridMinWidthRegular }
-    @objc open var gridRegularMaxWidth: GridRegularSemanticToken { GridRawTokens.gridMaxWidthRegular }
     @objc open var gridRegularMargin: GridRegularSemanticToken { GridRawTokens.gridMargin500 }
     @objc open var gridRegularColumnGap: GridRegularSemanticToken { GridRawTokens.gridColumnGap300 }
     @objc open var gridRegularColumnCount: GridRegularSemanticToken { GridRawTokens.gridColumnCount600 }
+    
+    // MARK: Semantic token - Grid - iOS Medium
+
+    @objc open var gridMediumMinWidth: GridMediumSemanticToken { GridRawTokens.gridMinWidthMedium }
+    @objc open var gridMediumMaxWidth: GridRegularSemanticToken { GridRawTokens.gridMaxWidthMedium }
 }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+GridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+GridSemanticTokens.swift
@@ -31,10 +31,9 @@ extension MockTheme {
     override var gridCompactColumnGap: GridCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactColumnCount: GridCompactSemanticToken { Self.mockThemeGridRawToken }
 
+    override var gridRegularMinWidth: GridRegularSemanticToken { Self.mockThemeGridRawToken }
+    override var gridRegularMaxWidth: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularMargin: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularColumnGap: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularColumnCount: GridRegularSemanticToken { Self.mockThemeGridRawToken }
-    
-    override var gridMediumMinWidth: GridMediumSemanticToken { Self.mockThemeGridRawToken }
-    override var gridMediumMaxWidth: GridMediumSemanticToken { Self.mockThemeGridRawToken }
 }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+GridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+GridSemanticTokens.swift
@@ -19,24 +19,22 @@ extension MockTheme {
 
     static let mockThemeGridRawToken: GridRawToken = 3630
 
-    override var gridExtraCompactWidth: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridExtraCompactMinWidth: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridExtraCompactMaxWidth: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridExtraCompactMargin: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridExtraCompactColumnGap: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridExtraCompactColumnCount: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
 
-    override var gridCompactWidth: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactMinWidth: GridCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactMaxWidth: GridCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactMargin: GridCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactColumnGap: GridCompactSemanticToken { Self.mockThemeGridRawToken }
     override var gridCompactColumnCount: GridCompactSemanticToken { Self.mockThemeGridRawToken }
 
-    override var gridRegularWidth: GridExtraCompactSemanticToken { Self.mockThemeGridRawToken }
-    override var gridRegularMinWidth: GridRegularSemanticToken { Self.mockThemeGridRawToken }
-    override var gridRegularMaxWidth: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularMargin: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularColumnGap: GridRegularSemanticToken { Self.mockThemeGridRawToken }
     override var gridRegularColumnCount: GridRegularSemanticToken { Self.mockThemeGridRawToken }
+    
+    override var gridMediumMinWidth: GridMediumSemanticToken { Self.mockThemeGridRawToken }
+    override var gridMediumMaxWidth: GridMediumSemanticToken { Self.mockThemeGridRawToken }
 }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfGridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfGridSemanticTokens.swift
@@ -28,11 +28,6 @@ final class TestThemeOverrideOfGridSemanticTokens: XCTestCase {
         inheritedTheme = MockTheme()
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSExtraCompactDesignWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridExtraCompactWidth, abstractTheme.gridExtraCompactWidth)
-        XCTAssertTrue(inheritedTheme.gridExtraCompactWidth == MockTheme.mockThemeGridRawToken)
-    }
-
     func testInheritedThemeCanOverrideSemanticTokenGridIOSExtraCompactMinWidth() throws {
         XCTAssertNotEqual(inheritedTheme.gridExtraCompactMinWidth, abstractTheme.gridExtraCompactMinWidth)
         XCTAssertTrue(inheritedTheme.gridExtraCompactMinWidth == MockTheme.mockThemeGridRawToken)
@@ -56,11 +51,6 @@ final class TestThemeOverrideOfGridSemanticTokens: XCTestCase {
     func testInheritedThemeCanOverrideSemanticTokenGridIOSExtraCompactColumnCount() throws {
         XCTAssertNotEqual(inheritedTheme.gridExtraCompactColumnCount, abstractTheme.gridExtraCompactColumnCount)
         XCTAssertTrue(inheritedTheme.gridExtraCompactColumnCount == MockTheme.mockThemeGridRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSCompactDesignWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridCompactWidth, abstractTheme.gridCompactWidth)
-        XCTAssertTrue(inheritedTheme.gridCompactWidth == MockTheme.mockThemeGridRawToken)
     }
 
     func testInheritedThemeCanOverrideSemanticTokenGridIOSCompactMinWidth() throws {
@@ -88,19 +78,14 @@ final class TestThemeOverrideOfGridSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.gridCompactColumnCount == MockTheme.mockThemeGridRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularDesignWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridRegularWidth, abstractTheme.gridRegularWidth)
-        XCTAssertTrue(inheritedTheme.gridRegularWidth == MockTheme.mockThemeGridRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenGridIOSMediumMinWidth() throws {
+        XCTAssertNotEqual(inheritedTheme.gridMediumMinWidth, abstractTheme.gridMediumMinWidth)
+        XCTAssertTrue(inheritedTheme.gridMediumMinWidth == MockTheme.mockThemeGridRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMinWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridRegularMinWidth, abstractTheme.gridRegularMinWidth)
-        XCTAssertTrue(inheritedTheme.gridRegularMinWidth == MockTheme.mockThemeGridRawToken)
-    }
-
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMaxWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridRegularMaxWidth, abstractTheme.gridRegularMaxWidth)
-        XCTAssertTrue(inheritedTheme.gridRegularMaxWidth == MockTheme.mockThemeGridRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenGridIOSMediumMaxWidth() throws {
+        XCTAssertNotEqual(inheritedTheme.gridMediumMaxWidth, abstractTheme.gridMediumMaxWidth)
+        XCTAssertTrue(inheritedTheme.gridMediumMaxWidth == MockTheme.mockThemeGridRawToken)
     }
 
     func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMargin() throws {

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfGridSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfGridSemanticTokens.swift
@@ -78,14 +78,14 @@ final class TestThemeOverrideOfGridSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.gridCompactColumnCount == MockTheme.mockThemeGridRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSMediumMinWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridMediumMinWidth, abstractTheme.gridMediumMinWidth)
-        XCTAssertTrue(inheritedTheme.gridMediumMinWidth == MockTheme.mockThemeGridRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMinWidth() throws {
+        XCTAssertNotEqual(inheritedTheme.gridRegularMinWidth, abstractTheme.gridRegularMinWidth)
+        XCTAssertTrue(inheritedTheme.gridRegularMinWidth == MockTheme.mockThemeGridRawToken)
     }
 
-    func testInheritedThemeCanOverrideSemanticTokenGridIOSMediumMaxWidth() throws {
-        XCTAssertNotEqual(inheritedTheme.gridMediumMaxWidth, abstractTheme.gridMediumMaxWidth)
-        XCTAssertTrue(inheritedTheme.gridMediumMaxWidth == MockTheme.mockThemeGridRawToken)
+    func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMaxWidth() throws {
+        XCTAssertNotEqual(inheritedTheme.gridRegularMaxWidth, abstractTheme.gridRegularMaxWidth)
+        XCTAssertTrue(inheritedTheme.gridRegularMaxWidth == MockTheme.mockThemeGridRawToken)
     }
 
     func testInheritedThemeCanOverrideSemanticTokenGridIOSRegularMargin() throws {

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
@@ -24,13 +24,13 @@ extension GridRawTokens {
 
     public static let gridMinWidthExtraCompact: GridRawToken = 320
     public static let gridMinWidthCompact: GridRawToken = 390
-    public static let gridMinWidthMedium: GridRawToken = 600
+    public static let gridMinWidthRegular: GridRawToken = 736
 
     // MARK: Primitive token - Grid - Max width
 
     public static let gridMaxWidthExtraCompact: GridRawToken = 389
-    public static let gridMaxWidthCompact: GridRawToken = 599
-    public static let gridMaxWidthMedium: GridRawToken = 1200
+    public static let gridMaxWidthCompact: GridRawToken = 852
+    public static let gridMaxWidthRegular: GridRawToken = 1336
 
     // MARK: Primitive token - Grid - Margin
 
@@ -80,7 +80,6 @@ extension GridRawTokens {
     public static let gridCompactMargin: GridRawToken = gridMargin300
     public static let gridCompactColumnGap: GridRawToken = gridColumnGap100
 
-    
     // MARK: Primitive token - Grid - Composite - iOS Regular
 
     public static let gridRegularMinWidth: GridRawToken = gridMinWidthCompact

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
@@ -20,42 +20,14 @@ extension GridRawTokens {
     /// Double type because used below for computations with Double values, output of the parser
     public static let dimensionBase: Double = 4
 
-    // MARK: Primitive token - Grid - Design width
-
-    public static let gridWidth100: GridRawToken = 320
-    public static let gridWidth200: GridRawToken = 390
-    public static let gridWidth300: GridRawToken = 480
-    public static let gridWidth400: GridRawToken = 768
-    public static let gridWidth500: GridRawToken = 1024
-    public static let gridWidth600: GridRawToken = 1440
-    public static let gridWidth700: GridRawToken = 1680
-    public static let gridWidth800: GridRawToken = 1920
-
     // MARK: Primitive token - Grid - Min width
 
-    public static let gridMinWidth100: GridRawToken = 1
-    public static let gridMinWidth200: GridRawToken = 390
-    public static let gridMinWidth300: GridRawToken = 480
-    public static let gridMinWidth400: GridRawToken = 736
-    public static let gridMinWidth500: GridRawToken = 1024
-    public static let gridMinWidth600: GridRawToken = 1320
-    public static let gridMinWidth700: GridRawToken = 1640
-    public static let gridMinWidth800: GridRawToken = 1880
     public static let gridMinWidthExtraCompact: GridRawToken = 320
     public static let gridMinWidthCompact: GridRawToken = 390
     public static let gridMinWidthRegular: GridRawToken = 736
 
     // MARK: Primitive token - Grid - Max width
 
-    public static let gridMaxWidth100: GridRawToken = 389
-    public static let gridMaxWidth200: GridRawToken = 479
-    public static let gridMaxWidth300: GridRawToken = 735
-    public static let gridMaxWidth400: GridRawToken = 1023
-    public static let gridMaxWidth500: GridRawToken = 1339
-    public static let gridMaxWidth600: GridRawToken = 1639
-    public static let gridMaxWidth650: GridRawToken = 1680
-    public static let gridMaxWidth700: GridRawToken = 1879
-    public static let gridMaxWidth800: GridRawToken = 1920
     public static let gridMaxWidthExtraCompact: GridRawToken = 389
     public static let gridMaxWidthCompact: GridRawToken = 852
     public static let gridMaxWidthRegular: GridRawToken = 1336
@@ -110,7 +82,6 @@ extension GridRawTokens {
 
     // MARK: Primitive token - Grid - Composite - iOS Regular
 
-    public static let gridRegularWidth: GridRawToken = gridWidth400
     public static let gridRegularMinWidth: GridRawToken = gridMinWidthCompact
     public static let gridRegularMaxWidth: GridRawToken = gridMaxWidthCompact
     public static let gridRegularMargin: GridRawToken = gridMargin500

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/GridRawTokens+Values.swift
@@ -24,13 +24,13 @@ extension GridRawTokens {
 
     public static let gridMinWidthExtraCompact: GridRawToken = 320
     public static let gridMinWidthCompact: GridRawToken = 390
-    public static let gridMinWidthRegular: GridRawToken = 736
+    public static let gridMinWidthMedium: GridRawToken = 600
 
     // MARK: Primitive token - Grid - Max width
 
     public static let gridMaxWidthExtraCompact: GridRawToken = 389
-    public static let gridMaxWidthCompact: GridRawToken = 852
-    public static let gridMaxWidthRegular: GridRawToken = 1336
+    public static let gridMaxWidthCompact: GridRawToken = 599
+    public static let gridMaxWidthMedium: GridRawToken = 1200
 
     // MARK: Primitive token - Grid - Margin
 
@@ -80,6 +80,7 @@ extension GridRawTokens {
     public static let gridCompactMargin: GridRawToken = gridMargin300
     public static let gridCompactColumnGap: GridRawToken = gridColumnGap100
 
+    
     // MARK: Primitive token - Grid - Composite - iOS Regular
 
     public static let gridRegularMinWidth: GridRawToken = gridMinWidthCompact

--- a/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
@@ -27,12 +27,12 @@ final class GridRawTokensTests: XCTestCase {
         XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthCompact)
     }
 
-    func testGridRawTokenGridMinWidthExtraCompactLessThanGridMinWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthRegular)
+    func testGridRawTokenGridMinWidthExtraCompactLessThanGridMinWidthMedium() throws {
+        XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthMedium)
     }
 
     func testGridRawTokenGridMinWidthCompactLessThanGridMinWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidthCompact, GridRawTokens.gridMinWidthRegular)
+        XCTAssertLessThan(GridRawTokens.gridMinWidthCompact, GridRawTokens.gridMinWidthMedium)
     }
 
     // MARK: - Primitive token - Grid - Max width
@@ -42,11 +42,11 @@ final class GridRawTokensTests: XCTestCase {
     }
 
     func testGridRawTokenGridMaxWidthExtraCompactLessThanGridMaxWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthRegular)
+        XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthMedium)
     }
 
     func testGridRawTokenGridMaxWidthCompactLessThanGridMaxWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidthCompact, GridRawTokens.gridMaxWidthRegular)
+        XCTAssertLessThan(GridRawTokens.gridMaxWidthCompact, GridRawTokens.gridMaxWidthMedium)
     }
 
     // MARK: - Primitive token - Grid - Margin

--- a/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
@@ -37,7 +37,6 @@ final class GridRawTokensTests: XCTestCase {
 
     // MARK: - Primitive token - Grid - Max width
 
-    
     func testGridRawTokenGridMaxWidthExtraCompactLessThanGridMaxWidthCompact() throws {
         XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthCompact)
     }

--- a/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
@@ -27,26 +27,27 @@ final class GridRawTokensTests: XCTestCase {
         XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthCompact)
     }
 
-    func testGridRawTokenGridMinWidthExtraCompactLessThanGridMinWidthMedium() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthMedium)
+    func testGridRawTokenGridMinWidthExtraCompactLessThanGridMinWidthRegular() throws {
+        XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthRegular)
     }
 
     func testGridRawTokenGridMinWidthCompactLessThanGridMinWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidthCompact, GridRawTokens.gridMinWidthMedium)
+        XCTAssertLessThan(GridRawTokens.gridMinWidthCompact, GridRawTokens.gridMinWidthRegular)
     }
 
     // MARK: - Primitive token - Grid - Max width
 
+    
     func testGridRawTokenGridMaxWidthExtraCompactLessThanGridMaxWidthCompact() throws {
         XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthCompact)
     }
 
     func testGridRawTokenGridMaxWidthExtraCompactLessThanGridMaxWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthMedium)
+        XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthRegular)
     }
 
     func testGridRawTokenGridMaxWidthCompactLessThanGridMaxWidthRegular() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidthCompact, GridRawTokens.gridMaxWidthMedium)
+        XCTAssertLessThan(GridRawTokens.gridMaxWidthCompact, GridRawTokens.gridMaxWidthRegular)
     }
 
     // MARK: - Primitive token - Grid - Margin

--- a/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/GridRawTokensTests.swift
@@ -23,88 +23,6 @@ final class GridRawTokensTests: XCTestCase {
 
     // MARK: - Primitive token - Grid - Design Width
 
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth200() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth200)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth300() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth300)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth400() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth400)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth500() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth500)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth600() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth600)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth700() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth700)
-    }
-
-    func testGridRawTokenGridDesignWidth100LessThanGridDesignWidth800() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth100, GridRawTokens.gridWidth800)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth300() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth300)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth400() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth400)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth500() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth500)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth600() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth600)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth700() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth700)
-    }
-
-    func testGridRawTokenGridDesignWidth200LessThanGridDesignWidth800() throws {
-        XCTAssertLessThan(GridRawTokens.gridWidth200, GridRawTokens.gridWidth800)
-    }
-
-    // MARK: - Primitive token - Grid - Min width
-
-    func testGridRawTokenGridMinWidth100LessThanGridMinWidth200() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth100, GridRawTokens.gridMinWidth200)
-    }
-
-    func testGridRawTokenGridMinWidth200LessThanGridMinWidth300() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth200, GridRawTokens.gridMinWidth300)
-    }
-
-    func testGridRawTokenGridMinWidth300LessThanGridMinWidth400() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth300, GridRawTokens.gridMinWidth400)
-    }
-
-    func testGridRawTokenGridMinWidth400LessThanGridMinWidth500() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth400, GridRawTokens.gridMinWidth500)
-    }
-
-    func testGridRawTokenGridMinWidth500LessThanGridMinWidth600() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth500, GridRawTokens.gridMinWidth600)
-    }
-
-    func testGridRawTokenGridMinWidth600LessThanGridMinWidth700() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth600, GridRawTokens.gridMinWidth700)
-    }
-
-    func testGridRawTokenGridMinWidth700LessThanGridMinWidth800() throws {
-        XCTAssertLessThan(GridRawTokens.gridMinWidth700, GridRawTokens.gridMinWidth800)
-    }
-
     func testGridRawTokenGridMinWidthExtraCompactLessThanGridMinWidthCompact() throws {
         XCTAssertLessThan(GridRawTokens.gridMinWidthExtraCompact, GridRawTokens.gridMinWidthCompact)
     }
@@ -118,38 +36,6 @@ final class GridRawTokensTests: XCTestCase {
     }
 
     // MARK: - Primitive token - Grid - Max width
-
-    func testGridRawTokenGridMaxWidth100LessThanGridMaxWidth200() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth100, GridRawTokens.gridMaxWidth200)
-    }
-
-    func testGridRawTokenGridMaxWidth200LessThanGridMaxWidth300() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth200, GridRawTokens.gridMaxWidth300)
-    }
-
-    func testGridRawTokenGridMaxWidth300LessThanGridMaxWidth400() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth300, GridRawTokens.gridMaxWidth400)
-    }
-
-    func testGridRawTokenGridMaxWidth400LessThanGridMaxWidth500() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth400, GridRawTokens.gridMaxWidth500)
-    }
-
-    func testGridRawTokenGridMaxWidth500LessThanGridMaxWidth600() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth500, GridRawTokens.gridMaxWidth600)
-    }
-
-    func testGridRawTokenGridMaxWidth600LessThanGridMaxWidth650() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth600, GridRawTokens.gridMaxWidth650)
-    }
-
-    func testGridRawTokenGridMaxWidth650LessThanGridMaxWidth700() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth650, GridRawTokens.gridMaxWidth700)
-    }
-
-    func testGridRawTokenGridMaxWidth700LessThanGridMaxWidth800() throws {
-        XCTAssertLessThan(GridRawTokens.gridMaxWidth700, GridRawTokens.gridMaxWidth800)
-    }
 
     func testGridRawTokenGridMaxWidthExtraCompactLessThanGridMaxWidthCompact() throws {
         XCTAssertLessThan(GridRawTokens.gridMaxWidthExtraCompact, GridRawTokens.gridMaxWidthCompact)

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/GridSemanticTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/GridSemanticTokens+Aliases.swift
@@ -21,3 +21,6 @@ public typealias GridCompactSemanticToken = GridRawToken
 
 /// Basically a grid semantic token for iOS Regulard values is a grid raw token, to keep grammar clean and clear with design system grammar.
 public typealias GridRegularSemanticToken = GridRawToken
+
+/// Basically a grid semantic token for iOS Medium values is a grid raw token, to keep grammar clean and clear with design system grammar.
+public typealias GridMediumSemanticToken = GridRawToken

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/GridSemanticTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/GridSemanticTokens+Aliases.swift
@@ -21,6 +21,3 @@ public typealias GridCompactSemanticToken = GridRawToken
 
 /// Basically a grid semantic token for iOS Regulard values is a grid raw token, to keep grammar clean and clear with design system grammar.
 public typealias GridRegularSemanticToken = GridRawToken
-
-/// Basically a grid semantic token for iOS Medium values is a grid raw token, to keep grammar clean and clear with design system grammar.
-public typealias GridMediumSemanticToken = GridRawToken

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
@@ -38,9 +38,12 @@ public protocol GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
-    var gridRegularMinWidth: GridRegularSemanticToken { get }
-    var gridRegularMaxWidth: GridRegularSemanticToken { get }
     var gridRegularMargin: GridRegularSemanticToken { get }
     var gridRegularColumnGap: GridRegularSemanticToken { get }
     var gridRegularColumnCount: GridRegularSemanticToken { get }
+    
+    // MARK: Semantic token - Grid - iOS Medium
+
+    var gridMediumMinWidth: GridMediumSemanticToken { get }
+    var gridMediumMaxWidth: GridMediumSemanticToken { get }
 }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
@@ -22,7 +22,6 @@ public protocol GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Extra compact
 
-    var gridExtraCompactWidth: GridExtraCompactSemanticToken { get }
     var gridExtraCompactMinWidth: GridExtraCompactSemanticToken { get }
     var gridExtraCompactMaxWidth: GridExtraCompactSemanticToken { get }
     var gridExtraCompactMargin: GridExtraCompactSemanticToken { get }
@@ -31,7 +30,6 @@ public protocol GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Compact
 
-    var gridCompactWidth: GridCompactSemanticToken { get }
     var gridCompactMinWidth: GridCompactSemanticToken { get }
     var gridCompactMaxWidth: GridCompactSemanticToken { get }
     var gridCompactMargin: GridCompactSemanticToken { get }
@@ -40,7 +38,6 @@ public protocol GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
-    var gridRegularWidth: GridRegularSemanticToken { get }
     var gridRegularMinWidth: GridRegularSemanticToken { get }
     var gridRegularMaxWidth: GridRegularSemanticToken { get }
     var gridRegularMargin: GridRegularSemanticToken { get }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/GridSemanticTokens.swift
@@ -38,12 +38,9 @@ public protocol GridSemanticTokens {
 
     // MARK: Semantic token - Grid - iOS Regular
 
+    var gridRegularMinWidth: GridRegularSemanticToken { get }
+    var gridRegularMaxWidth: GridRegularSemanticToken { get }
     var gridRegularMargin: GridRegularSemanticToken { get }
     var gridRegularColumnGap: GridRegularSemanticToken { get }
     var gridRegularColumnCount: GridRegularSemanticToken { get }
-    
-    // MARK: Semantic token - Grid - iOS Medium
-
-    var gridMediumMinWidth: GridMediumSemanticToken { get }
-    var gridMediumMaxWidth: GridMediumSemanticToken { get }
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#139 

### Description

<!-- Describe your changes in detail -->

Remove useless tokens

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Keep the stack updated and aligned with *Figma*

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
