### PR TITLE
[#51] Update typography tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] Update typography tokens (rename of font weight raw tokens)
 - [Library] Rename dimension semantic tokens to apply T-Shirt size rules ([#130](https://github.com/Orange-OpenSource/ouds-ios/issues/130))
 - [Library] Rename `SizingCompositeSemanticToken` to `MultipleSizingSemanticToken` to keep "composite" word for *Figma* design system
 - [Library] Rename `ColorCompositeSemanticToken` to `MultipleColorRawToken` to keep "composite" word for *Figma* design system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Library] Add typography semantic tokens for font letter spacing
 - [Library] Unit tests for multiple tokens
 - [Library] Add color semantic composite tokens embeding light and dark modes values
 - [Library] Add spacing semantic tokens "huge" and "jumbo"
@@ -18,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Library] Update typography tokens (rename of font weight raw tokens)
+- [Library] Rename of typography font weight raw tokens
 - [Library] Rename dimension semantic tokens to apply T-Shirt size rules ([#130](https://github.com/Orange-OpenSource/ouds-ios/issues/130))
 - [Library] Rename `SizingCompositeSemanticToken` to `MultipleSizingSemanticToken` to keep "composite" word for *Figma* design system
 - [Library] Rename `ColorCompositeSemanticToken` to `MultipleColorRawToken` to keep "composite" word for *Figma* design system

--- a/OUDS/Core/Components/Sources/ViewModifiers/CustomFontModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/CustomFontModifier.swift
@@ -41,10 +41,10 @@ struct CustomFontModifier: ViewModifier {
 
     /// The weight to apply on the font, like "Bold" or "BoldItalic"
     private var weight: String {
-        sizeClass == .compact ? token.compact.weight : token.regular.weight
+        sizeClass == .compact ? "\(token.compact.weight.fontWeight)" : "\(token.regular.weight.fontWeight)"
     }
 
-    @Environment(\.horizontalSizeClass) private var sizeClass // TODO: reguar / comapct mode util
+    @Environment(\.horizontalSizeClass) private var sizeClass // TODO: regular / compact mode util
 
     // MARK: - Body
 

--- a/OUDS/Core/Components/Sources/ViewModifiers/TypographyModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/TypographyModifier.swift
@@ -65,10 +65,17 @@ struct TypographyModifier: ViewModifier {
     /// Applies to the `Content` the *adaptive font* (i.e. *font family*, *font weight*, *font size* and the *line height*
     /// depending to the current `MultipleTypographyTokens`
     func body(content: Content) -> some View {
-        content
-            .font(adaptiveFont())
-            .lineSpacing(adaptiveTypography.lineHeight)
-            // .tracking() for letter spacing
+        if #available(iOS 16.0, *) {
+            content
+                .font(adaptiveFont())
+                .lineSpacing(adaptiveTypography.lineHeight)
+                .tracking(adaptiveTypography.letterSpacing)
+        } else {
+            content
+                .font(adaptiveFont())
+                .lineSpacing(adaptiveTypography.lineHeight)
+            // tracking() and kerning() only available for iOS 16+
+        }
     }
 }
 // swiftlint:enable line_length

--- a/OUDS/Core/Components/Sources/ViewModifiers/TypographyModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/TypographyModifier.swift
@@ -54,7 +54,7 @@ struct TypographyModifier: ViewModifier {
     /// According to the current `OUDSTheme` and if a custom font is applied or not, returns the suitable `View`
     private func adaptiveFont() -> Font {
         if let fontFamilyName = customFontFamily {
-            let composedFontFamily = fontFamilyName.compose(withFont: adaptiveTypography.weight)
+            let composedFontFamily = fontFamilyName.compose(withFont: "\(adaptiveTypography.weight.fontWeight)")
             let customFont: Font = .custom(composedFontFamily, size: adaptiveTypography.size)
             return customFont
         } else {

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -47,9 +47,9 @@ MultipleTypographyTokens(compact: TypographyRawTokens.typeBold750, regular: Typo
 }
 
 // And here are the raw tokebs definitions:
-public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeight700)
+public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeightBold)
 
-public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeight700)
+public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeightBold)
 ```
 
 However the _theme_ must know which _font family_ to apply, and this font family can be a _custom one_ or the _system one_.

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
@@ -114,7 +114,7 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
 
     // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
-    
+
     @objc open var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing850 }
     @objc open var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing750 }
     @objc open var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing650 }
@@ -125,9 +125,9 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
     @objc open var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
     @objc open var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
-        
-        // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
-        
+
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
+
     @objc open var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing1450 }
     @objc open var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing1050 }
     @objc open var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing850 }
@@ -138,8 +138,8 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
     @objc open var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
     @objc open var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
-        
-        // MARK: - Semantic token - Typography - Font - Letter spacing - Others
+
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Others
 
     @objc open var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing300 }
     @objc open var fontLetterSpacingLabelLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
@@ -147,7 +147,7 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
     @objc open var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
     @objc open var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
-        
+
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     @objc open var typeDisplayLarge: MultipleTypographyTokens { MultipleTypographyTokens(compact: TypographyRawTokens.typeBold850, regular: TypographyRawTokens.typeBold1450) }

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
@@ -33,15 +33,15 @@ extension OUDSTheme: TypographySemanticTokens {
 
     // MARK: Semantic token - Typography - Font - Weight
 
-    @objc open var fontWeightDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
-    @objc open var fontWeightStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightDisplay: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightHeading: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightBodyDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
-    @objc open var fontWeightBodyStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightLabelDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
-    @objc open var fontWeightLabelStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight700 }
-    @objc open var fontWeightCode: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeight400 }
+    @objc open var fontWeightDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightRegular }
+    @objc open var fontWeightStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightBold }
+    @objc open var fontWeightDisplay: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightBold }
+    @objc open var fontWeightHeading: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightBold }
+    @objc open var fontWeightBodyDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightRegular }
+    @objc open var fontWeightBodyStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightBold }
+    @objc open var fontWeightLabelDefault: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightRegular }
+    @objc open var fontWeightLabelStrong: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightBold }
+    @objc open var fontWeightCode: TypographyFontWeightSemanticToken { TypographyRawTokens.fontWeightRegular }
 
     // MARK: Semantic token - Typography - Font - Size - Mobile
 

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+TypographySemanticTokens.swift
@@ -113,6 +113,41 @@ extension OUDSTheme: TypographySemanticTokens {
     @objc open var fontLineHeightCodeMedium: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight350 }
     @objc open var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { TypographyRawTokens.fontLineHeight250 }
 
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
+    
+    @objc open var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing850 }
+    @objc open var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing750 }
+    @objc open var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing650 }
+    @objc open var fontLetterSpacingMobileHeadingXLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing550 }
+    @objc open var fontLetterSpacingMobileHeadingLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing450 }
+    @objc open var fontLetterSpacingMobileHeadingMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing350 }
+    @objc open var fontLetterSpacingMobileHeadingSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing300 }
+    @objc open var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
+    @objc open var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
+    @objc open var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
+        
+        // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
+        
+    @objc open var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing1450 }
+    @objc open var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing1050 }
+    @objc open var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing850 }
+    @objc open var fontLetterSpacingTabletHeadingXLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing750 }
+    @objc open var fontLetterSpacingTabletHeadingLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing550 }
+    @objc open var fontLetterSpacingTabletHeadingMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing450 }
+    @objc open var fontLetterSpacingTabletHeadingSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing350 }
+    @objc open var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
+    @objc open var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
+    @objc open var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
+        
+        // MARK: - Semantic token - Typography - Font - Letter spacing - Others
+
+    @objc open var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing300 }
+    @objc open var fontLetterSpacingLabelLarge: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing250 }
+    @objc open var fontLetterSpacingLabelMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
+    @objc open var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
+    @objc open var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing200 }
+    @objc open var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { TypographyRawTokens.fontLetterSpacing150 }
+        
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     @objc open var typeDisplayLarge: MultipleTypographyTokens { MultipleTypographyTokens(compact: TypographyRawTokens.typeBold850, regular: TypographyRawTokens.typeBold1450) }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+TypographySemanticTokens.swift
@@ -115,7 +115,7 @@ extension MockTheme {
     override var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeTypographyFontLineHeightRawToken }
 
     // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
-    
+
     override var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
@@ -126,9 +126,9 @@ extension MockTheme {
     override var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
-        
-        // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
-        
+
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
+
     override var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
@@ -139,8 +139,8 @@ extension MockTheme {
     override var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
-        
-        // MARK: - Semantic token - Typography - Font - Letter spacing - Others
+
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Others
 
     override var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingLabelLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
@@ -148,7 +148,7 @@ extension MockTheme {
     override var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
     override var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
-    
+
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     override var typeDisplayLarge: MultipleTypographyTokens { Self.mockThemeMultipleTypographyTokens }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+TypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+TypographySemanticTokens.swift
@@ -19,9 +19,10 @@ import OUDSTokensSemantic
 extension MockTheme {
 
     static let mockThemeTypographyFontFamilyRawToken: TypographyFontFamilyRawToken = "o°xXSkyBl0GF0ntxXx°o"
-    static let mockThemeTypographyFontWeightRawToken: TypographyFontWeightRawToken = "stiicckkyyyy"
+    static let mockThemeTypographyFontWeightRawToken: TypographyFontWeightRawToken = 888
     static let mockThemeTypographyFontSizeRawToken: TypographyFontSizeRawToken = 666
     static let mockThemeTypographyFontLineHeightRawToken: TypographyFontLineHeightRawToken = 321
+    static let mockThemeTypographyFontLetterSpacingRawToken: TypographyFontLetterSpacingRawToken = 21_092_024
     static let mockThemeMultipleTypographyTokens: MultipleTypographyTokens = MultipleTypographyTokens(compact: TypographyRawTokens.typeBold1850, regular: TypographyRawTokens.typeBold1850)
 
     // MARK: Semantic token - Typography - Font - Family
@@ -113,6 +114,41 @@ extension MockTheme {
     override var fontLineHeightCodeMedium: TypographyFontLineHeightSemanticToken { Self.mockThemeTypographyFontLineHeightRawToken }
     override var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { Self.mockThemeTypographyFontLineHeightRawToken }
 
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
+    
+    override var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileHeadingXLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileHeadingLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileHeadingMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileHeadingSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+        
+        // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
+        
+    override var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletHeadingXLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletHeadingLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletHeadingMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletHeadingSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+        
+        // MARK: - Semantic token - Typography - Font - Letter spacing - Others
+
+    override var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingLabelLarge: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingLabelMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    override var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { Self.mockThemeTypographyFontLetterSpacingRawToken }
+    
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     override var typeDisplayLarge: MultipleTypographyTokens { Self.mockThemeMultipleTypographyTokens }

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfTypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfTypographySemanticTokens.swift
@@ -235,6 +235,141 @@ final class TestThemeOverrideOfTypographySemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.fontSizeCodeSmall == MockTheme.mockThemeTypographyFontSizeRawToken)
     }
 
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile
+    
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileDisplayLarge, abstractTheme.fontLetterSpacingMobileDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileDisplayLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileDisplayMedium, abstractTheme.fontLetterSpacingMobileDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileDisplayMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileDisplaySmall, abstractTheme.fontLetterSpacingMobileDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileDisplaySmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileHeadingXLarge, abstractTheme.fontLetterSpacingMobileHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileHeadingXLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileHeadingLarge, abstractTheme.fontLetterSpacingMobileHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileHeadingLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileHeadingMedium, abstractTheme.fontLetterSpacingMobileHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileHeadingMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileHeadingSmall, abstractTheme.fontLetterSpacingMobileHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileHeadingSmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileBodyLarge, abstractTheme.fontLetterSpacingMobileBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileBodyLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileBodyMedium, abstractTheme.fontLetterSpacingMobileBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileBodyMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileBodySmall, abstractTheme.fontLetterSpacingMobileBodySmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileBodySmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet
+    
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletDisplayLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletDisplayLarge, abstractTheme.fontLetterSpacingTabletDisplayLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletDisplayLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletDisplayMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletDisplayMedium, abstractTheme.fontLetterSpacingTabletDisplayMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletDisplayMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletDisplaySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletDisplaySmall, abstractTheme.fontLetterSpacingTabletDisplaySmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletDisplaySmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletHeadingXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletHeadingXLarge, abstractTheme.fontLetterSpacingTabletHeadingXLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletHeadingXLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletHeadingLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletHeadingLarge, abstractTheme.fontLetterSpacingTabletHeadingLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletHeadingLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletHeadingMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletHeadingMedium, abstractTheme.fontLetterSpacingTabletHeadingMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletHeadingMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletHeadingSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletHeadingSmall, abstractTheme.fontLetterSpacingTabletHeadingSmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletHeadingSmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletBodyLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletBodyLarge, abstractTheme.fontLetterSpacingTabletBodyLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletBodyLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletBodyMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletBodyMedium, abstractTheme.fontLetterSpacingTabletBodyMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletBodyMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletBodySmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletBodySmall, abstractTheme.fontLetterSpacingTabletBodySmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletBodySmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingLabelXLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingLabelXLarge, abstractTheme.fontLetterSpacingLabelXLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingLabelXLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingLabelLarge() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingLabelLarge, abstractTheme.fontLetterSpacingLabelLarge)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingLabelLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingLabelMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingLabelMedium, abstractTheme.fontLetterSpacingLabelMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingLabelMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingLabelSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingLabelSmall, abstractTheme.fontLetterSpacingLabelSmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingLabelSmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingCodeMedium() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingCodeMedium, abstractTheme.fontLetterSpacingCodeMedium)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingCodeMedium == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingCodeSmall() throws {
+        XCTAssertNotEqual(inheritedTheme.fontLetterSpacingCodeSmall, abstractTheme.fontLetterSpacingCodeSmall)
+        XCTAssertTrue(inheritedTheme.fontLetterSpacingCodeSmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
+    }
+
+    
     // MARK: - Semantic token - Typography - Font - Line height - Mobile
 
     func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileDisplayLarge() throws {

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfTypographySemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfTypographySemanticTokens.swift
@@ -236,7 +236,7 @@ final class TestThemeOverrideOfTypographySemanticTokens: XCTestCase {
     }
 
     // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile
-    
+
     func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingMobileDisplayLarge() throws {
         XCTAssertNotEqual(inheritedTheme.fontLetterSpacingMobileDisplayLarge, abstractTheme.fontLetterSpacingMobileDisplayLarge)
         XCTAssertTrue(inheritedTheme.fontLetterSpacingMobileDisplayLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
@@ -288,7 +288,7 @@ final class TestThemeOverrideOfTypographySemanticTokens: XCTestCase {
     }
 
     // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet
-    
+
     func testInheritedThemeCanOverrideSemanticTokenFontLetterSpacingTabletDisplayLarge() throws {
         XCTAssertNotEqual(inheritedTheme.fontLetterSpacingTabletDisplayLarge, abstractTheme.fontLetterSpacingTabletDisplayLarge)
         XCTAssertTrue(inheritedTheme.fontLetterSpacingTabletDisplayLarge == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
@@ -369,7 +369,6 @@ final class TestThemeOverrideOfTypographySemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.fontLetterSpacingCodeSmall == MockTheme.mockThemeTypographyFontLetterSpacingRawToken)
     }
 
-    
     // MARK: - Semantic token - Typography - Font - Line height - Mobile
 
     func testInheritedThemeCanOverrideSemanticTokenFontLineHeightMobileDisplayLarge() throws {

--- a/OUDS/Core/Tokens/RawTokens/Sources/TypeAliases/TypographyRawTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/TypeAliases/TypographyRawTokens+Aliases.swift
@@ -16,8 +16,8 @@ import Foundation
 /// In the global design system tool, *font family* raw tokens are basically `String` values, to keep grammar clean and clear with design system grammar.
 public typealias TypographyFontFamilyRawToken = String
 
-/// In the global design system tool, *font weight* raw tokens are basically `String` values, to keep grammar clean and clear with design system grammar.
-public typealias TypographyFontWeightRawToken = String
+/// In the global design system tool, *font weight* raw tokens are basically `Int` values, to keep grammar clean and clear with design system grammar.
+public typealias TypographyFontWeightRawToken = Int
 
 /// In the global design system tool, *font size* raw tokens are basically `CGFloat` values, to keep grammar clean and clear with design system grammar.
 public typealias TypographyFontSizeRawToken = CGFloat

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Composites.swift
@@ -47,7 +47,7 @@ extension TypographyRawTokens {
 
     public static let typeBold650 = TypographyCompositeRawToken(size: fontSize650, lineHeight: fontLineHeight750, weight: fontWeightBold, letterSpacing: fontLetterSpacing650)
 
-    public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeight700, letterSpacing: fontLetterSpacing750)
+    public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeightBold, letterSpacing: fontLetterSpacing750)
 
     public static let typeBold850 = TypographyCompositeRawToken(size: fontSize850, lineHeight: fontLineHeight950, weight: fontWeightBold, letterSpacing: fontLetterSpacing850)
 

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Composites.swift
@@ -21,45 +21,45 @@ extension TypographyRawTokens {
 
     // MARK: Primitive token - Typography - Composite
 
-    public static let typeRegular150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing150)
+    public static let typeRegular150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeightRegular, letterSpacing: fontLetterSpacing150)
 
-    public static let typeRegular175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing175)
+    public static let typeRegular175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeightRegular, letterSpacing: fontLetterSpacing175)
 
-    public static let typeRegular200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight400, letterSpacing: fontLetterSpacing200)
+    public static let typeRegular200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeightRegular, letterSpacing: fontLetterSpacing200)
 
-    public static let typeRegular250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight400, letterSpacing: fontLetterSpacing250)
+    public static let typeRegular250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeightRegular, letterSpacing: fontLetterSpacing250)
 
-    public static let typeBold150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing150)
+    public static let typeBold150 = TypographyCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeightBold, letterSpacing: fontLetterSpacing150)
 
-    public static let typeBold175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing175)
+    public static let typeBold175 = TypographyCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeightBold, letterSpacing: fontLetterSpacing175)
 
-    public static let typeBold200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing200)
+    public static let typeBold200 = TypographyCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight250, weight: fontWeightBold, letterSpacing: fontLetterSpacing200)
 
-    public static let typeBold250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeight700, letterSpacing: fontLetterSpacing250)
+    public static let typeBold250 = TypographyCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight350, weight: fontWeightBold, letterSpacing: fontLetterSpacing250)
 
-    public static let typeBold300 = TypographyCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeight700, letterSpacing: fontLetterSpacing300)
+    public static let typeBold300 = TypographyCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeightBold, letterSpacing: fontLetterSpacing300)
 
-    public static let typeBold350 = TypographyCompositeRawToken(size: fontSize350, lineHeight: fontLineHeight550, weight: fontWeight700, letterSpacing: fontLetterSpacing350)
+    public static let typeBold350 = TypographyCompositeRawToken(size: fontSize350, lineHeight: fontLineHeight550, weight: fontWeightBold, letterSpacing: fontLetterSpacing350)
 
-    public static let typeBold450 = TypographyCompositeRawToken(size: fontSize450, lineHeight: fontLineHeight550, weight: fontWeight700, letterSpacing: fontLetterSpacing450)
+    public static let typeBold450 = TypographyCompositeRawToken(size: fontSize450, lineHeight: fontLineHeight550, weight: fontWeightBold, letterSpacing: fontLetterSpacing450)
 
-    public static let typeBold550 = TypographyCompositeRawToken(size: fontSize550, lineHeight: fontLineHeight650, weight: fontWeight700, letterSpacing: fontLetterSpacing550)
+    public static let typeBold550 = TypographyCompositeRawToken(size: fontSize550, lineHeight: fontLineHeight650, weight: fontWeightBold, letterSpacing: fontLetterSpacing550)
 
-    public static let typeBold650 = TypographyCompositeRawToken(size: fontSize650, lineHeight: fontLineHeight750, weight: fontWeight700, letterSpacing: fontLetterSpacing650)
+    public static let typeBold650 = TypographyCompositeRawToken(size: fontSize650, lineHeight: fontLineHeight750, weight: fontWeightBold, letterSpacing: fontLetterSpacing650)
 
     public static let typeBold750 = TypographyCompositeRawToken(size: fontSize750, lineHeight: fontLineHeight850, weight: fontWeight700, letterSpacing: fontLetterSpacing750)
 
-    public static let typeBold850 = TypographyCompositeRawToken(size: fontSize850, lineHeight: fontLineHeight950, weight: fontWeight700, letterSpacing: fontLetterSpacing850)
+    public static let typeBold850 = TypographyCompositeRawToken(size: fontSize850, lineHeight: fontLineHeight950, weight: fontWeightBold, letterSpacing: fontLetterSpacing850)
 
-    public static let typeBold950 = TypographyCompositeRawToken(size: fontSize950, lineHeight: fontLineHeight1050, weight: fontWeight700, letterSpacing: fontLetterSpacing950)
+    public static let typeBold950 = TypographyCompositeRawToken(size: fontSize950, lineHeight: fontLineHeight1050, weight: fontWeightBold, letterSpacing: fontLetterSpacing950)
 
-    public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeight700, letterSpacing: fontLetterSpacing1050)
+    public static let typeBold1050 = TypographyCompositeRawToken(size: fontSize1050, lineHeight: fontLineHeight1150, weight: fontWeightBold, letterSpacing: fontLetterSpacing1050)
 
-    public static let typeBold1150 = TypographyCompositeRawToken(size: fontSize1150, lineHeight: fontLineHeight1250, weight: fontWeight700, letterSpacing: fontLetterSpacing1150)
+    public static let typeBold1150 = TypographyCompositeRawToken(size: fontSize1150, lineHeight: fontLineHeight1250, weight: fontWeightBold, letterSpacing: fontLetterSpacing1150)
 
-    public static let typeBold1250 = TypographyCompositeRawToken(size: fontSize1250, lineHeight: fontLineHeight1350, weight: fontWeight700, letterSpacing: fontLetterSpacing1250)
+    public static let typeBold1250 = TypographyCompositeRawToken(size: fontSize1250, lineHeight: fontLineHeight1350, weight: fontWeightBold, letterSpacing: fontLetterSpacing1250)
 
-    public static let typeBold1450 = TypographyCompositeRawToken(size: fontSize1450, lineHeight: fontLineHeight1450, weight: fontWeight700, letterSpacing: fontLetterSpacing1450)
+    public static let typeBold1450 = TypographyCompositeRawToken(size: fontSize1450, lineHeight: fontLineHeight1450, weight: fontWeightBold, letterSpacing: fontLetterSpacing1450)
 
-    public static let typeBold1850 = TypographyCompositeRawToken(size: fontSize1850, lineHeight: fontLineHeight1850, weight: fontWeight700, letterSpacing: fontLetterSpacing1850)
+    public static let typeBold1850 = TypographyCompositeRawToken(size: fontSize1850, lineHeight: fontLineHeight1850, weight: fontWeightBold, letterSpacing: fontLetterSpacing1850)
 }

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Values.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/TypographyRawTokens+Values.swift
@@ -99,12 +99,16 @@ extension TypographyRawTokens {
 
     // MARK: Primitive token - Typography - Font weight
 
-    public static let fontWeight100: TypographyFontWeightRawToken = "thin"
-    public static let fontWeight200: TypographyFontWeightRawToken = "ultraLight"
-    public static let fontWeight300: TypographyFontWeightRawToken = "light"
-    public static let fontWeight400: TypographyFontWeightRawToken = "regular"
-    public static let fontWeight500: TypographyFontWeightRawToken = "medium"
-    public static let fontWeight600: TypographyFontWeightRawToken = "semibold"
-    public static let fontWeight700: TypographyFontWeightRawToken = "bold"
-    public static let fontWeight900: TypographyFontWeightRawToken = "heavy"
+    // WARNING: Some tokens will be useless (extra light, extra bold, extra black)
+    // But need to keep the Figma logic and use our conversion algorithm
+    public static let fontWeightThin: TypographyFontWeightRawToken = 100
+    public static let fontWeightExtraLight: TypographyFontWeightRawToken = 200
+    public static let fontWeightLight: TypographyFontWeightRawToken = 300
+    public static let fontWeightRegular: TypographyFontWeightRawToken = 400
+    public static let fontWeightMedium: TypographyFontWeightRawToken = 500
+    public static let fontWeightSemiBold: TypographyFontWeightRawToken = 600
+    public static let fontWeightBold: TypographyFontWeightRawToken = 700
+    public static let fontWeightExtraBold: TypographyFontWeightRawToken = 800
+    public static let fontWeightBlack: TypographyFontWeightRawToken = 900
+    public static let fontWeightExtraBlack: TypographyFontWeightRawToken = 950
 }

--- a/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/TypographyRawTokensTests.swift
@@ -272,40 +272,40 @@ final class TypographyRawTokensTests: XCTestCase {
     // MARK: - Primitive token - Typography - Font weight
 
     func testTypographyRawTokensFontWeightsAreAllDifferent() throws {
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight200)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight300)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight400)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight500)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight600)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight100, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightExtraLight)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightLight)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightRegular)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightMedium)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightSemiBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightThin, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight300)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight400)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight500)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight600)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight200, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightLight)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightRegular)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightMedium)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightSemiBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightExtraLight, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight300, TypographyRawTokens.fontWeight400)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight300, TypographyRawTokens.fontWeight500)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight300, TypographyRawTokens.fontWeight600)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight300, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight300, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightLight, TypographyRawTokens.fontWeightRegular)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightLight, TypographyRawTokens.fontWeightMedium)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightLight, TypographyRawTokens.fontWeightSemiBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightLight, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightLight, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight400, TypographyRawTokens.fontWeight500)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight400, TypographyRawTokens.fontWeight600)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight400, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight400, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightRegular, TypographyRawTokens.fontWeightMedium)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightRegular, TypographyRawTokens.fontWeightSemiBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightRegular, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightRegular, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight500, TypographyRawTokens.fontWeight600)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight500, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight500, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightMedium, TypographyRawTokens.fontWeightSemiBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightMedium, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightMedium, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight600, TypographyRawTokens.fontWeight700)
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight600, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightSemiBold, TypographyRawTokens.fontWeightBold)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightSemiBold, TypographyRawTokens.fontWeightExtraBold)
 
-        XCTAssertNotEqual(TypographyRawTokens.fontWeight700, TypographyRawTokens.fontWeight900)
+        XCTAssertNotEqual(TypographyRawTokens.fontWeightBold, TypographyRawTokens.fontWeightExtraBold)
     }
 
     // MARK: - Primitive token - Typography - Composite

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/TypographySemanticTokens+Aliases.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/TypeAliases/TypographySemanticTokens+Aliases.swift
@@ -24,3 +24,6 @@ public typealias TypographyFontSizeSemanticToken = TypographyFontSizeRawToken
 
 /// The global design system tools uses verbs of semantic token for font line height, which is basically a raw token for font line height
 public typealias TypographyFontLineHeightSemanticToken = TypographyFontLineHeightRawToken
+
+/// The global design system tools uses verbs of semantic token for font letter spacing, which is basically a raw token for font letter spacing
+public typealias TypographyFontLetterSpacingSemanticToken = TypographyFontLetterSpacingRawToken

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/SizingSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/SizingSemanticTokens.swift
@@ -76,7 +76,7 @@ public protocol SizingSemanticTokens {
 
     var sizeIconWithTypeLabelXLargeShort: SizingSemanticToken { get }
     var sizeIconWithTypeLabelXLargeMedium: SizingSemanticToken { get }
-    var sizeIconWithTypeLabelXLargeTall: SizingSemanticToken { get } // TODO: #122: Unit test to add
+    var sizeIconWithTypeLabelXLargeTall: SizingSemanticToken { get }
 
     // MARK: - Semantic token - Sizing - Max width typography
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/TypographySemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/TypographySemanticTokens.swift
@@ -115,7 +115,7 @@ public protocol TypographySemanticTokens {
     var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { get }
 
     // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
-    
+
     var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { get }
@@ -126,9 +126,9 @@ public protocol TypographySemanticTokens {
     var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { get }
-    
+
     // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
-    
+
     var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { get }
@@ -139,7 +139,7 @@ public protocol TypographySemanticTokens {
     var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { get }
-    
+
     // MARK: - Semantic token - Typography - Font - Letter spacing - Others
 
     var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { get }
@@ -148,7 +148,7 @@ public protocol TypographySemanticTokens {
     var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { get }
     var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { get }
-    
+
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     var typeDisplayLarge: MultipleTypographyTokens { get }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/TypographySemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/TypographySemanticTokens.swift
@@ -25,8 +25,6 @@ public protocol TypographySemanticTokens {
 
     // MARK: - Semantic token - Typography - Font - Family
 
-    // TODO: Should we suffix our tokens names by "iOS"?
-
     var fontFamily: TypographyFontFamilyRawToken { get }
     var fontFamilyDisplay: TypographyFontFamilySemanticToken { get }
     var fontFamilyHeading: TypographyFontFamilySemanticToken { get }
@@ -116,9 +114,41 @@ public protocol TypographySemanticTokens {
     var fontLineHeightCodeMedium: TypographyFontLineHeightSemanticToken { get }
     var fontLineHeightCodeSmall: TypographyFontLineHeightSemanticToken { get }
 
-    // MARK: - Semantic token - Typography - Font - Letter spacing
-    // TODO: Missing details about the types of the associated raw tokens
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Mobile (extra-compact/compact)
+    
+    var fontLetterSpacingMobileDisplayLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileDisplayMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileDisplaySmall: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileHeadingXLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileHeadingLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileHeadingMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileHeadingSmall: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileBodyLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileBodyMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingMobileBodySmall: TypographyFontLetterSpacingSemanticToken { get }
+    
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Tablet (regular/medium)
+    
+    var fontLetterSpacingTabletDisplayLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletDisplayMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletDisplaySmall: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletHeadingXLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletHeadingLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletHeadingMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletHeadingSmall: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletBodyLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletBodyMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingTabletBodySmall: TypographyFontLetterSpacingSemanticToken { get }
+    
+    // MARK: - Semantic token - Typography - Font - Letter spacing - Others
 
+    var fontLetterSpacingLabelXLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingLabelLarge: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingLabelMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingLabelSmall: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingCodeMedium: TypographyFontLetterSpacingSemanticToken { get }
+    var fontLetterSpacingCodeSmall: TypographyFontLetterSpacingSemanticToken { get }
+    
     // MARK: - Semantic tokens - Typography - Composites - Display
 
     var typeDisplayLarge: MultipleTypographyTokens { get }

--- a/OUDS/Foundations/Sources/Extensions/Font+extensions.swift
+++ b/OUDS/Foundations/Sources/Extensions/Font+extensions.swift
@@ -1,0 +1,44 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import SwiftUI
+
+extension Font.Weight: CustomStringConvertible {
+
+    /// Computes from the current `self` value a description of the object which can be used later
+    /// for example for font loading by appending this value to the font name.
+    public var description: String {
+        switch self {
+        case .ultraLight:
+            return "Ultra-Light"
+        case .thin:
+            return "Thin"
+        case .light:
+            return "Light"
+        case .regular:
+            return "Regular"
+        case .medium:
+            return "Medium"
+        case .semibold:
+            return "Semi-Bold"
+        case .bold:
+            return "Bold"
+        case .heavy:
+            return "Heavy"
+        case .black:
+            return "Black"
+        default:
+            return ""
+        }
+    }
+}

--- a/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
@@ -1,0 +1,33 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+extension Int {
+    
+    /// `Int` extension to get `Font.Weight` of *SwiftUI* from its integer representation.
+    public var fontWeight: Font.Weight {
+        if self <= 100 { return Font.Weight.thin }
+        if self <= 200 { return Font.Weight.ultraLight }
+        if self <= 300 { return Font.Weight.light }
+        if self <= 400 { return Font.Weight.regular }
+        if self <= 500 { return Font.Weight.medium }
+        if self <= 600 { return Font.Weight.semibold }
+        if self <= 700 { return Font.Weight.bold }
+        // No Font.Weight.extraBold for 800
+        // No Font.Weight.extraBlack for 950
+        // From 701 to 950, assume it is the only higher value, i.e. black
+        if self <= 950 { return Font.Weight.black }
+        return Font.Weight.regular
+    }
+}

--- a/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
@@ -17,6 +17,7 @@ extension Int {
 
     /// `Int` extension to get `Font.Weight` of *SwiftUI* from its integer representation.
     public var fontWeight: Font.Weight {
+        if self < 0 { return Font.Weight.regular }
         if self <= 100 { return Font.Weight.thin }
         if self <= 200 { return Font.Weight.ultraLight }
         if self <= 300 { return Font.Weight.light }

--- a/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/Int+SwiftUI.swift
@@ -14,7 +14,7 @@
 import SwiftUI
 
 extension Int {
-    
+
     /// `Int` extension to get `Font.Weight` of *SwiftUI* from its integer representation.
     public var fontWeight: Font.Weight {
         if self <= 100 { return Font.Weight.thin }

--- a/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
@@ -20,39 +20,4 @@ extension String {
     public var color: Color! {
         Color(hexadecimalCode: self)
     }
-
-    /// `String` extension to get `Font.Weight` of *SwiftUI* from its string representation.
-    public var fontWeight: Font.Weight {
-        if self == "thin" { return Font.Weight.thin }
-        if self == "ultraLight" { return Font.Weight.ultraLight }
-        if self == "light" { return Font.Weight.light }
-        if self == "regular" { return Font.Weight.regular }
-        if self == "medium" { return Font.Weight.medium }
-        if self == "semibold" { return Font.Weight.semibold }
-        if self == "bold" { return Font.Weight.bold }
-        if self == "heavy" { return Font.Weight.heavy }
-        return Font.Weight.regular
-    }
-
-    /// Forges the font name which is expected for the given weight.
-    /// Beware, the function does not check if the font exists.
-    /// - Parameters:
-    ///    - name: The font family name (e.g. "Menlo")
-    ///    - weight: The weight to apply (e.g. "bold", "italic")
-    /// - Returns String: The full name of the font to use (e.g. "Menlo-Bold" or "Menlo-Italic")
-    public func compose(withFont weight: String) -> String {
-        guard !self.isEmpty else {
-            OUDSLogger.error("No font family to compose with weight")
-            return self
-        }
-        var characters = Array(weight)
-        guard characters.count > 0, let formattedFirst = characters[0].uppercased().first else {
-            OUDSLogger.error("The given weight cannot be parsed to compose a font family")
-            return self
-        }
-        characters[0] = formattedFirst
-        let formattedWeight = String(characters)
-        return self + "-" + formattedWeight
-        // TODO: String manipulation can be costly, add values in Cache
-    }
 }

--- a/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
@@ -20,4 +20,23 @@ extension String {
     public var color: Color! {
         Color(hexadecimalCode: self)
     }
+    
+    /// Forges the font name which is expected for the given weight.
+    /// Beware, the function does not check if the font exists.
+    /// - Parameters:
+    ///    - name: The font family name (e.g. "Menlo")
+    ///    - weight: The weight to apply (e.g. "bold", "italic")
+    /// - Returns String: The full name of the font to use (e.g. "Menlo-Bold" or "Menlo-Italic")
+    public func compose(withFont weight: String) -> String {
+        guard !self.isEmpty else {
+            OUDSLogger.error("No font family to compose with weight")
+            return self
+        }
+        if !weight.isEmpty {
+            return self + "-" + weight
+        } else {
+            return self
+        }
+        // TODO: String manipulation can be costly, add values in Cache
+    }
 }

--- a/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
@@ -20,7 +20,7 @@ extension String {
     public var color: Color! {
         Color(hexadecimalCode: self)
     }
-    
+
     /// Forges the font name which is expected for the given weight.
     /// Beware, the function does not check if the font exists.
     /// - Parameters:

--- a/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
@@ -18,7 +18,7 @@ import XCTest
 
 /// Class to test `Font` extensions related to `SwiftUI`
 final class TestFont_SwiftUI: XCTestCase {
-    
+
     /// Tests description values of font weight
     func testFontWeightDescription() throws {
         XCTAssertTrue(Font.Weight.ultraLight == "Ultra-Light")

--- a/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
@@ -1,0 +1,34 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+import OUDSFoundations
+import SwiftUI
+import XCTest
+
+/// Class to test `Font` extensions related to `SwiftUI`
+final class TestFont_SwiftUI: XCTestCase {
+    
+    /// Tests description values of font weight
+    func testFontWeightDescription() throws {
+        XCTAssertTrue(Font.Weight.ultraLight == "Ultra-Light")
+        XCTAssertTrue(Font.Weight.thin == "Thin")
+        XCTAssertTrue(Font.Weight.light == "Light")
+        XCTAssertTrue(Font.Weight.regular == "Regular")
+        XCTAssertTrue(Font.Weight.medium == "Medium")
+        XCTAssertTrue(Font.Weight.semibold == "Semi-Bold")
+        XCTAssertTrue(Font.Weight.bold == "Bold")
+        XCTAssertTrue(Font.Weight.heavy == "Heavy")
+        XCTAssertTrue(Font.Weight.black == "Black")
+    }
+}

--- a/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestFont+extensions.swift
@@ -21,14 +21,24 @@ final class TestFont_SwiftUI: XCTestCase {
 
     /// Tests description values of font weight
     func testFontWeightDescription() throws {
-        XCTAssertTrue(Font.Weight.ultraLight == "Ultra-Light")
-        XCTAssertTrue(Font.Weight.thin == "Thin")
-        XCTAssertTrue(Font.Weight.light == "Light")
-        XCTAssertTrue(Font.Weight.regular == "Regular")
-        XCTAssertTrue(Font.Weight.medium == "Medium")
-        XCTAssertTrue(Font.Weight.semibold == "Semi-Bold")
-        XCTAssertTrue(Font.Weight.bold == "Bold")
-        XCTAssertTrue(Font.Weight.heavy == "Heavy")
-        XCTAssertTrue(Font.Weight.black == "Black")
+        XCTAssertTrue(Font.Weight.ultraLight.description == "Ultra-Light")
+        XCTAssertTrue(Font.Weight.thin.description == "Thin")
+        XCTAssertTrue(Font.Weight.light.description == "Light")
+        XCTAssertTrue(Font.Weight.regular.description == "Regular")
+        XCTAssertTrue(Font.Weight.medium.description == "Medium")
+        XCTAssertTrue(Font.Weight.semibold.description == "Semi-Bold")
+        XCTAssertTrue(Font.Weight.bold.description == "Bold")
+        XCTAssertTrue(Font.Weight.heavy.description == "Heavy")
+        XCTAssertTrue(Font.Weight.black.description == "Black")
+
+        XCTAssertTrue("\(Font.Weight.ultraLight)" == "Ultra-Light")
+        XCTAssertTrue("\(Font.Weight.thin)" == "Thin")
+        XCTAssertTrue("\(Font.Weight.light)" == "Light")
+        XCTAssertTrue("\(Font.Weight.regular)" == "Regular")
+        XCTAssertTrue("\(Font.Weight.medium)" == "Medium")
+        XCTAssertTrue("\(Font.Weight.semibold)" == "Semi-Bold")
+        XCTAssertTrue("\(Font.Weight.bold)" == "Bold")
+        XCTAssertTrue("\(Font.Weight.heavy)" == "Heavy")
+        XCTAssertTrue("\(Font.Weight.black)" == "Black")
     }
 }

--- a/OUDS/Foundations/Tests/Extensions/TestInt+SwiftUI.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestInt+SwiftUI.swift
@@ -18,43 +18,43 @@ import XCTest
 
 /// Class to test `Int` extensions related to `SwiftUI`
 final class TestInt_SwiftUI: XCTestCase {
-    
+
     /// Tests values of font weight
-    func testFontWeightValues() {
+    func testFontWeightValues() throws {
 
         // Expected values
         XCTAssertTrue(0.fontWeight == Font.Weight.thin)
         XCTAssertTrue(1.fontWeight == Font.Weight.thin)
         XCTAssertTrue(99.fontWeight == Font.Weight.thin)
         XCTAssertTrue(100.fontWeight == Font.Weight.thin)
-        
+
         XCTAssertTrue(101.fontWeight == Font.Weight.ultraLight)
         XCTAssertTrue(200.fontWeight == Font.Weight.ultraLight)
-        
+
         XCTAssertTrue(201.fontWeight == Font.Weight.light)
         XCTAssertTrue(300.fontWeight == Font.Weight.light)
-        
+
         XCTAssertTrue(301.fontWeight == Font.Weight.regular)
         XCTAssertTrue(400.fontWeight == Font.Weight.regular)
-        
+
         XCTAssertTrue(401.fontWeight == Font.Weight.medium)
         XCTAssertTrue(500.fontWeight == Font.Weight.medium)
-        
+
         XCTAssertTrue(501.fontWeight == Font.Weight.semibold)
         XCTAssertTrue(600.fontWeight == Font.Weight.semibold)
-        
+
         XCTAssertTrue(601.fontWeight == Font.Weight.bold)
         XCTAssertTrue(700.fontWeight == Font.Weight.bold)
-        
+
         XCTAssertTrue(701.fontWeight == Font.Weight.black)
         XCTAssertTrue(800.fontWeight == Font.Weight.black)
         XCTAssertTrue(801.fontWeight == Font.Weight.black)
         XCTAssertTrue(900.fontWeight == Font.Weight.black)
         XCTAssertTrue(901.fontWeight == Font.Weight.black)
         XCTAssertTrue(950.fontWeight == Font.Weight.black)
-        
+
         XCTAssertTrue(951.fontWeight == Font.Weight.regular)
-        
+
         // Other default cases
         XCTAssertTrue(1000.fontWeight == Font.Weight.regular)
         XCTAssertTrue((-1).fontWeight == Font.Weight.regular)

--- a/OUDS/Foundations/Tests/Extensions/TestInt+SwiftUI.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestInt+SwiftUI.swift
@@ -1,0 +1,62 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+import OUDSFoundations
+import SwiftUI
+import XCTest
+
+/// Class to test `Int` extensions related to `SwiftUI`
+final class TestInt_SwiftUI: XCTestCase {
+    
+    /// Tests values of font weight
+    func testFontWeightValues() {
+
+        // Expected values
+        XCTAssertTrue(0.fontWeight == Font.Weight.thin)
+        XCTAssertTrue(1.fontWeight == Font.Weight.thin)
+        XCTAssertTrue(99.fontWeight == Font.Weight.thin)
+        XCTAssertTrue(100.fontWeight == Font.Weight.thin)
+        
+        XCTAssertTrue(101.fontWeight == Font.Weight.ultraLight)
+        XCTAssertTrue(200.fontWeight == Font.Weight.ultraLight)
+        
+        XCTAssertTrue(201.fontWeight == Font.Weight.light)
+        XCTAssertTrue(300.fontWeight == Font.Weight.light)
+        
+        XCTAssertTrue(301.fontWeight == Font.Weight.regular)
+        XCTAssertTrue(400.fontWeight == Font.Weight.regular)
+        
+        XCTAssertTrue(401.fontWeight == Font.Weight.medium)
+        XCTAssertTrue(500.fontWeight == Font.Weight.medium)
+        
+        XCTAssertTrue(501.fontWeight == Font.Weight.semibold)
+        XCTAssertTrue(600.fontWeight == Font.Weight.semibold)
+        
+        XCTAssertTrue(601.fontWeight == Font.Weight.bold)
+        XCTAssertTrue(700.fontWeight == Font.Weight.bold)
+        
+        XCTAssertTrue(701.fontWeight == Font.Weight.black)
+        XCTAssertTrue(800.fontWeight == Font.Weight.black)
+        XCTAssertTrue(801.fontWeight == Font.Weight.black)
+        XCTAssertTrue(900.fontWeight == Font.Weight.black)
+        XCTAssertTrue(901.fontWeight == Font.Weight.black)
+        XCTAssertTrue(950.fontWeight == Font.Weight.black)
+        
+        XCTAssertTrue(951.fontWeight == Font.Weight.regular)
+        
+        // Other default cases
+        XCTAssertTrue(1000.fontWeight == Font.Weight.regular)
+        XCTAssertTrue((-1).fontWeight == Font.Weight.regular)
+    }
+}

--- a/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
@@ -12,32 +12,13 @@
 //
 
 import Foundation
-import XCTest
-import SwiftUI
 import OUDSFoundations
+import SwiftUI
+import XCTest
 
 /// Class to test `String` extensions related to `SwiftUI`
 final class TestString_SwiftUI: XCTestCase {
-
-    /// Tests values of font weight
-    func testFontWeightValues() {
-
-        // Expected values
-        XCTAssertTrue("thin".fontWeight == Font.Weight.thin)
-        XCTAssertTrue("ultraLight".fontWeight == Font.Weight.ultraLight)
-        XCTAssertTrue("light".fontWeight == Font.Weight.light)
-        XCTAssertTrue("regular".fontWeight == Font.Weight.regular)
-        XCTAssertTrue("medium".fontWeight == Font.Weight.medium)
-        XCTAssertTrue("semibold".fontWeight == Font.Weight.semibold)
-        XCTAssertTrue("bold".fontWeight == Font.Weight.bold)
-        XCTAssertTrue("heavy".fontWeight == Font.Weight.heavy)
-
-        // Other default cases
-        XCTAssertTrue("".fontWeight == Font.Weight.regular)
-        XCTAssertTrue("42".fontWeight == Font.Weight.regular)
-        XCTAssertTrue("Yowzah!".fontWeight == Font.Weight.regular)
-    }
-
+    
     /// Tests the font family values created using a font amily name and a weight
     func testComposeWithFonts() {
 

--- a/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
@@ -24,31 +24,57 @@ final class TestString_SwiftUI: XCTestCase {
 
         var result: String
 
-        // Expected values
+        // Expected values - use string scription of Font.Weight
 
-        result = "Menlo".compose(withFont: "thin")
+        result = "Menlo".compose(withFont: Font.Weight.thin.description)
         XCTAssertTrue(result == "Menlo-Thin", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "ultraLight")
-        XCTAssertTrue(result == "Menlo-UltraLight", "Current value is '\(result)")
+        result = "Menlo".compose(withFont: Font.Weight.ultraLight.description)
+        XCTAssertTrue(result == "Menlo-Ultra-Light", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "light")
+        result = "Menlo".compose(withFont: Font.Weight.light.description)
         XCTAssertTrue(result == "Menlo-Light", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "regular")
+        result = "Menlo".compose(withFont: Font.Weight.regular.description)
         XCTAssertTrue(result == "Menlo-Regular", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "medium")
+        result = "Menlo".compose(withFont: Font.Weight.medium.description)
         XCTAssertTrue(result == "Menlo-Medium", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "semibold")
-        XCTAssertTrue(result == "Menlo-Semibold", "Current value is '\(result)")
+        result = "Menlo".compose(withFont: Font.Weight.semibold.description)
+        XCTAssertTrue(result == "Menlo-Semi-Bold", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "bold")
+        result = "Menlo".compose(withFont: Font.Weight.bold.description)
         XCTAssertTrue(result == "Menlo-Bold", "Current value is '\(result)")
 
-        result = "Menlo".compose(withFont: "heavy")
+        result = "Menlo".compose(withFont: Font.Weight.heavy.description)
         XCTAssertTrue(result == "Menlo-Heavy", "Current value is '\(result)")
+
+        // Expected values - no uper case if raw string given
+
+        result = "Menlo".compose(withFont: "thin")
+        XCTAssertTrue(result == "Menlo-thin", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "ultraLight")
+        XCTAssertTrue(result == "Menlo-ultraLight", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "light")
+        XCTAssertTrue(result == "Menlo-light", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "regular")
+        XCTAssertTrue(result == "Menlo-regular", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "medium")
+        XCTAssertTrue(result == "Menlo-medium", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "semibold")
+        XCTAssertTrue(result == "Menlo-semibold", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "bold")
+        XCTAssertTrue(result == "Menlo-bold", "Current value is '\(result)")
+
+        result = "Menlo".compose(withFont: "heavy")
+        XCTAssertTrue(result == "Menlo-heavy", "Current value is '\(result)")
 
         // Edge cases
 

--- a/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
+++ b/OUDS/Foundations/Tests/Extensions/TestString+SwiftUI.swift
@@ -18,7 +18,7 @@ import XCTest
 
 /// Class to test `String` extensions related to `SwiftUI`
 final class TestString_SwiftUI: XCTestCase {
-    
+
     /// Tests the font family values created using a font amily name and a weight
     func testComposeWithFonts() {
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

Clsoes #51 

### Description

<!-- Describe your changes in detail -->

- Update font weight tokens
- Update tests


### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

- Keep stack updated

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
