### PR TITLE
[#177] Add color semantic tolens (update of October, 8th) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [Library] Add color semantic tokens `colorContentTransparentDefault`, `colorBorderTransparentDefault` and `colorBackgroundTransparentDefault` (October 8th) ([#177](https://github.com/Orange-OpenSource/ouds-ios/issues/177))
 - [DemoApp] On opacity screen, add a border around the view showing the opacity ([#157](https://github.com/Orange-OpenSource/ouds-ios/issues/157))
 
 ### Changed

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+ColorSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSTheme+SemanticTokens/OUDSTheme+ColorSemanticTokens.swift
@@ -224,6 +224,10 @@ extension OUDSTheme: ColorSemanticTokens {
 
     @objc open var colorBackgroundAlwaysInformation: ColorSemanticToken? { MultipleColorTokens(sysColorBrandInformationDefault) }
 
+    // MARK: Semantic token - Colors - Background - Transparent
+
+    @objc open var colorBackgroundTransparentDefault: ColorSemanticToken? { MultipleColorTokens(ColorRawTokens.colorTransparentBlack0) }
+
     // MARK: Semantic token - Colors - Content
 
     @objc open var colorContentDefault: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandNeutralEmphasizedBlack, dark: sysColorBrandNeutralMutedLower) }
@@ -249,6 +253,24 @@ extension OUDSTheme: ColorSemanticTokens {
     @objc open var colorContentStatusPositive: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandPositiveDefault, dark: sysColorBrandPositiveDefault) }
 
     @objc open var colorContentStatusInformation: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandInformationDefault, dark: sysColorBrandInformationDefault) }
+
+    @objc open var colorContentActionEnabled: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandNeutralEmphasizedBlack, dark: sysColorBrandNeutralMutedLower) }
+
+    @objc open var colorContentActionEnabledOnBackgroundEmphasized: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedLower) }
+
+    @objc open var colorContentActionEnabledOnBackgroundStatusExcNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedBlack) }
+
+    @objc open var colorContentActionEnabledOnBackgroundStatusNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedWhite) }
+
+    @objc open var colorContentActionHover: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandNeutralEmphasizedLowest, dark: sysColorBrandNeutralMutedMedium) }
+
+    @objc open var colorContentActionHoverOnBackgroundEmphasized: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedMedium) }
+
+    @objc open var colorContentActionHoverOnBackgroundStatusExcNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedLow) }
+
+    @objc open var colorContentActionHoverOnBackgroundStatusNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedBlack) }
+
+    @objc open var colorContentTransparentDefault: ColorSemanticToken? { MultipleColorTokens(ColorRawTokens.colorTransparentBlack0) }
 
     // MARK: Semantic token - Colors - Border
 
@@ -284,21 +306,7 @@ extension OUDSTheme: ColorSemanticTokens {
 
     @objc open var colorBorderBrandStatusInformation: ColorSemanticToken? { nil }
 
-    @objc open var colorContentActionEnabled: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandNeutralEmphasizedBlack, dark: sysColorBrandNeutralMutedLower) }
-
-    @objc open var colorContentActionEnabledOnBackgroundEmphasized: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedLower) }
-
-    @objc open var colorContentActionEnabledOnBackgroundStatusExcNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedBlack) }
-
-    @objc open var colorContentActionEnabledOnBackgroundStatusNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedWhite) }
-
-    @objc open var colorContentActionHover: ColorSemanticToken? { MultipleColorTokens(light: sysColorBrandNeutralEmphasizedLowest, dark: sysColorBrandNeutralMutedMedium) }
-
-    @objc open var colorContentActionHoverOnBackgroundEmphasized: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralMutedMedium) }
-
-    @objc open var colorContentActionHoverOnBackgroundStatusExcNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedLow) }
-
-    @objc open var colorContentActionHoverOnBackgroundStatusNegative: ColorSemanticToken? { MultipleColorTokens(sysColorBrandNeutralEmphasizedBlack) }
+    @objc open var colorBorderTransparentDefault: ColorSemanticToken? { MultipleColorTokens(ColorRawTokens.colorTransparentBlack0) }
 
     // TODO: #124 - Add missing colorBorderActionEnabled*
     // TODO: #124 - Add missing colorBorderActionHover*

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+ColorSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/MockTheme/MockTheme+ColorSemanticTokens.swift
@@ -124,117 +124,121 @@ extension MockTheme {
 
     // MARK: Semantic token - Colors - Background
 
-    override var colorBackgroundDefaultPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundDefaultPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundDefaultSecondary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundDefaultSecondary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundDefaultTertiary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundDefaultTertiary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundEmphasizedPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundEmphasizedPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundBrandPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundBrandPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundBrandSecondary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundBrandSecondary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundBrandTertiary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundBrandTertiary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusNeutral: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusNeutral: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusNeutralOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusNeutralOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusAttractiveMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusAttractiveMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusAttractiveEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusAttractiveEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusWarningMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusWarningMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusWarningMutedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusWarningMutedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusWarningEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusWarningEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusNegativeMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusNegativeMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusNegativeMutedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusNegativeMutedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusNegativeEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusNegativeEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusPositiveMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusPositiveMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusPositiveMutedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusPositiveMutedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusPositiveEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusPositiveEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusInformationMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusInformationMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusInformationMutedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusInformationMutedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundStatusInformationEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundStatusInformationEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     // MARK: Semantic token - Colors - Background - Action
 
-    override var colorBackgroundActionEnabled: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionEnabled: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionEnabledOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionEnabledOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionEnabledOnBackgroundStatusExcNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionEnabledOnBackgroundStatusExcNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionEnabledOnBackgroundStatusNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionEnabledOnBackgroundStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionPressed: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionPressed: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionPressedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionPressedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionPressedOnBackgroundStatusExcNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionPressedOnBackgroundStatusExcNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionPressedOnBackgroundStautsNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionPressedOnBackgroundStautsNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionDisabled: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionDisabled: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionDisabledOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionDisabledOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionDisabledOnBackgroundStatusExcNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionDisabledOnBackgroundStatusExcNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionDisabledOnBackgroundStatusNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionDisabledOnBackgroundStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionFocus: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionFocus: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionFocusOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionFocusOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionFocusOnBackgroundStatusExcNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionFocusOnBackgroundStatusExcNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBackgroundActionFocusOnBackgroundStatusNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBackgroundActionFocusOnBackgroundStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
+
+    // MARK: Semantic token - Colors - Background - Transparent
+
+    override var colorBackgroundTransparentDefault: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     // MARK: Semantic token - Colors - Content
 
-    override var colorContentDefault: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentDefault: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentDefaultOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentDefaultOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentDefaultOnBackgroundBrandPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentDefaultOnBackgroundBrandPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentMuted: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentMuted: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentMutedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentMutedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     override var colorContentDisabled: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     override var colorContentDisabledOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentBrandPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentBrandPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentBrandPrimaryOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentBrandPrimaryOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentBrandSecondary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentBrandSecondary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentBrandTertiary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentBrandTertiary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentStatusAttractive: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentStatusAttractive: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentStatusNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentStatusPositive: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentStatusPositive: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorContentStatusInformation: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorContentStatusInformation: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     override var colorContentActionEnabled: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
@@ -252,6 +256,8 @@ extension MockTheme {
 
     override var colorContentActionHoverOnBackgroundStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
+    override var colorContentTransparentDefault: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
+
     // TODO: #124 - Add missing colorContentActionPressed* tokens
     // TODO: #124 - Add missing colorContentActionDisabled* tokens
     // TODO: #124 - Add missing colorContentActionFocus* tokens
@@ -265,35 +271,37 @@ extension MockTheme {
 
     // MARK: Semantic token - Colors - Border
 
-    override var colorBorderDefault: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderDefault: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderDefaultOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderDefaultOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     // TODO: #124 - Add missing colorBorderDefaultOnBackgroundBrandPrimary
     // TODO: #124 - Add missing colorBorderDefaultOnBackgroundBrandSecondary
     // TODO: #124 - Add missing colorBorderDefaultOnBackgroundBrandTertiary
 
-    override var colorBorderEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderEmphasizedOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderEmphasizedOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandPrimary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandPrimary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandPrimaryOnBackgroundEmphasized: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandPrimaryOnBackgroundEmphasized: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandSecondary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandSecondary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandTertiary: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandTertiary: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandStatusAttractive: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandStatusAttractive: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandStatusWarning: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandStatusWarning: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandStatusNegative: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandStatusNegative: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandStatusPositive: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandStatusPositive: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
-    override var colorBorderBrandStatusInformation: ColorSemanticToken! { Self.mockThemeMultipleColorTokens }
+    override var colorBorderBrandStatusInformation: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
+
+    override var colorBorderTransparentDefault: ColorSemanticToken? { Self.mockThemeMultipleColorTokens }
 
     // TODO: #124 - Add missing colorBorderActionEnabled*
     // TODO: #124 - Add missing colorBorderActionHover*

--- a/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfColorSemanticTokens.swift
+++ b/OUDS/Core/OUDS/Tests/OUDSTheme/TestThemeOverrideOfColorSemanticTokens.swift
@@ -878,6 +878,16 @@ final class TestThemeOverrideOfColorSemanticTokens: XCTestCase {
         XCTAssertTrue(inheritedTheme.colorContentActionHoverOnBackgroundStatusNegative?.dark == MockTheme.mockThemeColorRawToken)
     }
 
+    func testInheritedThemeCanOverrideSemanticTokenColorContentTransparentDefaultLight() throws {
+        XCTAssertNotEqual(inheritedTheme.colorContentTransparentDefault?.light, abstractTheme.colorContentTransparentDefault?.light)
+        XCTAssertTrue(inheritedTheme.colorContentTransparentDefault?.light == MockTheme.mockThemeColorRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenColorContentTransparentDefaultDark() throws {
+        XCTAssertNotEqual(inheritedTheme.colorContentTransparentDefault?.dark, abstractTheme.colorContentTransparentDefault?.dark)
+        XCTAssertTrue(inheritedTheme.colorContentTransparentDefault?.dark == MockTheme.mockThemeColorRawToken)
+    }
+
     // TODO: #124 - Add missing colorContentActionPressed* tokens
     // TODO: #124 - Add missing colorContentActionDisabled* tokens
     // TODO: #124 - Add missing colorContentActionFocus* tokens
@@ -1023,6 +1033,16 @@ final class TestThemeOverrideOfColorSemanticTokens: XCTestCase {
     func testInheritedThemeCanOverrideSemanticTokenColorBorderBrandStatusInformationDark() throws {
         XCTAssertNotEqual(inheritedTheme.colorBorderBrandStatusInformation?.dark, abstractTheme.colorBorderBrandStatusInformation?.dark)
         XCTAssertTrue(inheritedTheme.colorBorderBrandStatusInformation?.dark == MockTheme.mockThemeColorRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenColorBorderTransparentDefaultLight() throws {
+        XCTAssertNotEqual(inheritedTheme.colorBorderTransparentDefault?.light, abstractTheme.colorBorderTransparentDefault?.light)
+        XCTAssertTrue(inheritedTheme.colorBorderTransparentDefault?.light == MockTheme.mockThemeColorRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenColorBorderTransparentDefaultDark() throws {
+        XCTAssertNotEqual(inheritedTheme.colorBorderTransparentDefault?.dark, abstractTheme.colorBorderTransparentDefault?.dark)
+        XCTAssertTrue(inheritedTheme.colorBorderTransparentDefault?.dark == MockTheme.mockThemeColorRawToken)
     }
 
     func testInheritedThemeCanOverrideSemanticTokenColorBackgroundActionEnabledLight() throws {
@@ -1253,6 +1273,16 @@ final class TestThemeOverrideOfColorSemanticTokens: XCTestCase {
     func testInheritedThemeCanOverrideSemanticTokenColorBackgroundAlwaysInformationDark() throws {
         XCTAssertNotEqual(inheritedTheme.colorBackgroundAlwaysInformation?.dark, abstractTheme.colorBackgroundAlwaysInformation?.dark)
         XCTAssertTrue(inheritedTheme.colorBackgroundAlwaysInformation?.dark == MockTheme.mockThemeColorRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenColorBackgroundTransparentDefaultLight() throws {
+        XCTAssertNotEqual(inheritedTheme.colorBackgroundTransparentDefault?.light, abstractTheme.colorBackgroundTransparentDefault?.light)
+        XCTAssertTrue(inheritedTheme.colorBackgroundTransparentDefault?.light == MockTheme.mockThemeColorRawToken)
+    }
+
+    func testInheritedThemeCanOverrideSemanticTokenColorBackgroundTransparentDefaultDark() throws {
+        XCTAssertNotEqual(inheritedTheme.colorBackgroundTransparentDefault?.dark, abstractTheme.colorBackgroundTransparentDefault?.dark)
+        XCTAssertTrue(inheritedTheme.colorBackgroundTransparentDefault?.dark == MockTheme.mockThemeColorRawToken)
     }
 
     // TODO: #124 - Add missing colorBorderActionEnabled*

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorSemanticTokens.swift
@@ -223,6 +223,10 @@ public protocol ColorSemanticTokens {
 
     var colorBackgroundAlwaysInformation: ColorSemanticToken? { get }
 
+    // MARK: Semantic token - Colors - Background - Transparent
+
+    var colorBackgroundTransparentDefault: ColorSemanticToken? { get }
+
     // MARK: Semantic token - Colors - Content
 
     var colorContentDefault: ColorSemanticToken? { get }
@@ -271,6 +275,8 @@ public protocol ColorSemanticTokens {
 
     var colorContentActionHoverOnBackgroundStatusNegative: ColorSemanticToken? { get }
 
+    var colorContentTransparentDefault: ColorSemanticToken? { get }
+
     // TODO: #124 - Add missing colorContentActionPressed* tokens
     // TODO: #124 - Add missing colorContentActionDisabled* tokens
     // TODO: #124 - Add missing colorContentActionFocus* tokens
@@ -313,6 +319,8 @@ public protocol ColorSemanticTokens {
     var colorBorderBrandStatusPositive: ColorSemanticToken? { get }
 
     var colorBorderBrandStatusInformation: ColorSemanticToken? { get }
+
+    var colorBorderTransparentDefault: ColorSemanticToken? { get }
 
     // TODO: #124 - Add missing colorBorderActionEnabled*
     // TODO: #124 - Add missing colorBorderActionHover*


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#177 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
