### PR TITLE
[#212] Fix missing accessibility labels for images in demo app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DemoApp] Add missing accessibility label for images ([#212](https://github.com/Orange-OpenSource/ouds-ios/issues/212))
 - [DemoApp] Fix text sizes when dynamic type is used (a11y) ([#247](https://github.com/Orange-OpenSource/ouds-ios/issues/247))
 
 ## [0.5.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.4.1...0.5.0) - 2024-10-31
@@ -27,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [Demo App] [Bug] A11y Dynamic Type Text ([#247](https://github.com/Orange-OpenSource/ouds-ios/issues/247))
 - [Library] Update `ElevationSemanticTokens` (tokenator *20241031125053*)
 - [Library] Update `OrangeBrandColorRawTokens` (tokenator *20241030132734*)
 - [Library] Update `BorderSemanticTokens` (tokenator *20241025110844*)
@@ -62,7 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [DemoApp] Added Missing Accessibility Label to Image ([#212](https://github.com/Orange-OpenSource/ouds-ios/issues/212))
 - [DemoApp] Update typography screen to use right color on token name ([#213](https://github.com/Orange-OpenSource/ouds-ios/issues/213))
 - [DemoApp] Remove duplicated section in color page for content on background values ([#236](https://github.com/Orange-OpenSource/ouds-ios/issues/236))
 - [DemoApp] Hide from Voice Over decorative image in theme selector (a11y)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Demo App] [Bug] A11y Dynamic Type Text ([#247](https://github.com/Orange-OpenSource/ouds-ios/issues/247))
 - [Library] Update `ElevationSemanticTokens` (tokenator *20241031125053*)
 - [Library] Update `OrangeBrandColorRawTokens` (tokenator *20241030132734*)
 - [Library] Update `BorderSemanticTokens` (tokenator *20241025110844*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DemoApp] Added Missing Accessibility Label to Image ([#212](https://github.com/Orange-OpenSource/ouds-ios/issues/212))
 - [DemoApp] Update typography screen to use right color on token name ([#213](https://github.com/Orange-OpenSource/ouds-ios/issues/213))
 - [DemoApp] Remove duplicated section in color page for content on background values ([#236](https://github.com/Orange-OpenSource/ouds-ios/issues/236))
 - [DemoApp] Hide from Voice Over decorative image in theme selector (a11y)

--- a/Showcase/Showcase/Pages/ThemeSelection/ThemeSelection.swift
+++ b/Showcase/Showcase/Pages/ThemeSelection/ThemeSelection.swift
@@ -116,9 +116,10 @@ struct ThemeSelectionButton: View {
                 }
             }
             .pickerStyle(.automatic)
-            .accessibilityLabel("app_topBar_theme_button_a11y")
         } label: {
-            Image(systemName: "paintpalette").accessibilityHidden(true)
+            Image(systemName: "paintpalette")
+                .accessibilityLabel("app_topBar_theme_button_a11y")
+                .accessibilityHint("app_topBar_theme_button_hint_a11y")
         }
         .foregroundColor(themeProvider.currentTheme.colorContentBrandPrimary.color(for: colorScheme))
     }

--- a/Showcase/Showcase/Resources/en.lproj/Localizable.strings
+++ b/Showcase/Showcase/Resources/en.lproj/Localizable.strings
@@ -17,6 +17,7 @@
 "app_bottomBar_tokens_label" = "Tokens";
 "app_bottomBar_about_label" = "About";
 "app_topBar_theme_button_a11y" = "Change theme";
+"app_topBar_theme_button_hint_a11y" = "Tap to change the theme of the app";
 
 // MARK: - About Screen
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [x] Design review has been done
- [x] Accessibiltiy review has been done
- [x] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [x] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
