### PR TITLE
[#293] Remove some warnings while documentation generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.6.0...develop)
 
+### Fixed
+
+- [Library] Warning issues for DocC catalogs ([#293](https://github.com/Orange-OpenSource/ouds-ios/issues/293))
+
 ## [0.6.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.5.0...0.6.0) - 2024-11-15
 
 ### Added

--- a/OUDS/Core/OUDS/Sources/OUDSUserInterfaceSizeClass.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSUserInterfaceSizeClass.swift
@@ -32,7 +32,7 @@ extension EnvironmentValues {
     ///
     /// You receive a ``OUDSUserInterfaceSizeClass`` value when you read this environment value.
     /// The value tells you about the amount of horizontal space available to the view that reads it.
-    /// You can read this size class like any other of the ``EnvironmentValues``, by creating a property with the ``Environment`` property wrapper:
+    /// You can read this size class like any other of the ``EnvironmentValues``, by creating a property with the `Environment` property wrapper:
     ///
     ///     @Environment(\.oudsHorizontalSizeClass) private var horizontalSizeClass
     ///
@@ -49,7 +49,7 @@ extension EnvironmentValues {
     ///
     /// You receive a ``OUDSUserInterfaceSizeClass`` value when you read this environment value.
     /// The value tells you about the amount of vertical space available to the view that reads it.
-    /// You can read this size class like any other of the ``EnvironmentValues``, by creating a property with the ``Environment`` property wrapper:
+    /// You can read this size class like any other of the ``EnvironmentValues``, by creating a property with the `Environment` property wrapper:
     ///
     ///     @Environment(\.oudsVerticalSizeClass) private var verticalSizeClass
     ///

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Components.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Components.md
@@ -1,6 +1,6 @@
 # Components
   
-_Components_ are defined in the [OUDSComponents](https://ios.unified-design-system.orange.com/documentation/oudstokenscomponent/) target and can be integrated in applications.
+_Components_ are defined in the `OUDSComponents` target and can be integrated in applications.
 
 ❗**More details coming soon.**❗
 
@@ -20,3 +20,5 @@ Of course you must use in your root view the <doc:/OUDS/OUDSThemeableView> with 
         
     }
 ``` 
+
+You can get more details about _Components_ with the [OUDSComponents documentation](https://ios.unified-design-system.orange.com/documentation/oudstokenscomponent/).

--- a/OUDS/Core/Tokens/ComponentTokens/Sources/_OUDSTokensComponent.docc/OUDSTokensComponent.md
+++ b/OUDS/Core/Tokens/ComponentTokens/Sources/_OUDSTokensComponent.docc/OUDSTokensComponent.md
@@ -14,6 +14,3 @@ We don't have any *component token* implemented yet.
 ## Topics
 
 ### Group
-
-- ``FormsTextInputComponentTokens``
-

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorTokens.swift
@@ -78,7 +78,7 @@ public final class MultipleColorTokens: NSObject, Sendable {
     /// Returns the right color according to the `colorScheme`.
     /// - Parameter colorScheme: The color scheme
     /// - Returns: The right color raw token
-    public func color(for colorSheme: ColorScheme) -> Color {
-        (colorSheme == .light ? light : dark).color
+    public func color(for colorScheme: ColorScheme) -> Color {
+        (colorScheme == .light ? light : dark).color
     }
 }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationTokens.swift
@@ -55,7 +55,7 @@ public final class MultipleElevationTokens: NSObject, Sendable {
     /// Returns the right elevation according to the `colorScheme`.
     /// - Parameter colorScheme: The color scheme
     /// - Returns: The right elevation raw token
-    public func elevation(for colorSheme: ColorScheme) -> ElevationCompositeRawToken {
-        (colorSheme == .light ? light : dark)
+    public func elevation(for colorScheme: ColorScheme) -> ElevationCompositeRawToken {
+        (colorScheme == .light ? light : dark)
     }
 }

--- a/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
+++ b/OUDS/Foundations/Sources/Extensions/String+SwiftUI.swift
@@ -26,9 +26,7 @@ extension String {
 
     /// Forges the font name which is expected for the given weight.
     /// Beware, the function does not check if the font exists.
-    /// - Parameters:
-    ///    - name: The font family name (e.g. "Menlo")
-    ///    - weight: The weight to apply (e.g. "bold", "italic")
+    /// - Parameter weight: The weight to apply (e.g. "bold", "italic")
     /// - Returns String: The full name of the font to use (e.g. "Menlo-Bold" or "Menlo-Italic")
     public func compose(withFont weight: String) -> String {
         guard !self.isEmpty else {


### PR DESCRIPTION
### Related issues

#293 

### Description

<!-- Describe your changes in detail -->

Just to fix some warnings in the documentation

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Remove warnings and have better documentation 

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
