### PR TITLE
[#361] Update show code text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.8.0...develop)
 
+### Changed
+
+- [DemoApp] Update show code text ([#361](https://github.com/Orange-OpenSource/ouds-ios/issues/361))
+
 ## [0.8.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.7.0...0.8.0) - 2024-12-18
 
 ### Added

--- a/Showcase/Podfile.lock
+++ b/Showcase/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - SwiftFormat/CLI (0.55.3)
-  - SwiftLint (0.57.0)
+  - SwiftLint (0.57.1)
 
 DEPENDENCIES:
   - SwiftFormat/CLI (= 0.55.3)
-  - SwiftLint (= 0.57.0)
+  - SwiftLint (= 0.57.1)
 
 SPEC REPOS:
   trunk:
@@ -13,8 +13,8 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   SwiftFormat: 2f3558ca02842dcd3fd970360d2d4054bd21624a
-  SwiftLint: eb47480d47c982481592c195c221d11013a679cc
+  SwiftLint: 92196976e597b9afec5dbe374810103e6c1d9d7c
 
-PODFILE CHECKSUM: 48af44a98a1ebfa588f530c218eac9369a4515bf
+PODFILE CHECKSUM: c4ad93a479bf732e918b4e92f458ff72333a85fc
 
 COCOAPODS: 1.16.2

--- a/Showcase/Showcase/Pages/Components/Utils/ComponentPage.swift
+++ b/Showcase/Showcase/Pages/Components/Utils/ComponentPage.swift
@@ -52,7 +52,7 @@ struct ComponentConfigurationView<Component, Configuration>: View where Componen
             }
             .padding(.horizontal, theme.spaces.spaceFixedMedium)
 
-            ShowcaseCode(code: configuration.code)
+            ShowcaseCode(code: configuration.code, titleText: "app_components_common_viewCodeExample_label")
                 .padding(.horizontal, theme.spaces.spaceFixedMedium)
         }
         .padding(.bottom, theme.spaces.spaceFixedMedium)

--- a/Showcase/Showcase/Pages/Tokens/Border/BorderTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Border/BorderTokenPage.swift
@@ -24,7 +24,7 @@ struct BorderTokenPage: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Section {
                 VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
-                    ShowcaseCode(code: "theme.borders.borderWidthDefault")
+                    ShowcaseCode(code: "theme.borders.borderWidthDefault", titleText: "app_tokens_common_viewCodeExample_label")
                 }
             }
             Section {

--- a/Showcase/Showcase/Pages/Tokens/Color/ColorTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Color/ColorTokenPage.swift
@@ -26,7 +26,7 @@ struct ColorTokenPage: View {
     var body: some View {
         Group {
             Section {
-                ShowcaseCode(code: "theme.colors.colorBgPrimary.color(for: colorScheme)")
+                ShowcaseCode(code: "theme.colors.colorBgPrimary.color(for: colorScheme)", titleText: "app_tokens_common_viewCodeExample_label")
             }
             Section { illustrationForAction() } header: { header("Action") }
             Section { illustrationForAlways() } header: { header("Always") }

--- a/Showcase/Showcase/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
@@ -22,7 +22,7 @@ struct SizeTokenPage: View {
     var body: some View {
         Group {
             Section {
-                ShowcaseCode(code: "theme.sizeIconWithHeadingXLargeShort.dimension(for: horizontalSizeClass ?? .regular)")
+                ShowcaseCode(code: "theme.sizeIconWithHeadingXLargeShort.dimension(for: horizontalSizeClass ?? .regular)", titleText: "app_tokens_common_viewCodeExample_label")
             }
             Section {
                 ForEach(NamedSize.IconDecorative.allCases, id: \.rawValue) { namedSize in

--- a/Showcase/Showcase/Pages/Tokens/Dimension/Space/SpaceTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Dimension/Space/SpaceTokenPage.swift
@@ -28,7 +28,7 @@ struct SpaceTokenPage: View {
     var body: some View {
         Group {
             Section {
-                ShowcaseCode(code: "theme.spaceScaledMedium.dimension(for: horizontalSizeClass ?? .regular)")
+                ShowcaseCode(code: "theme.spaceScaledMedium.dimension(for: horizontalSizeClass ?? .regular)", titleText: "app_tokens_common_viewCodeExample_label")
             }
             // Basic Space Tokens
             Section { ScaledSpaceProperty() } header: {

--- a/Showcase/Showcase/Pages/Tokens/Elevation/ElevationTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Elevation/ElevationTokenPage.swift
@@ -26,7 +26,7 @@ struct ElevationTokenPage: View {
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
             Section {
-                ShowcaseCode(code: "theme.elevations.elevationNone.elevation(for: colorScheme)")
+                ShowcaseCode(code: "theme.elevations.elevationNone.elevation(for: colorScheme)", titleText: "app_tokens_common_viewCodeExample_label")
             }
 
             Spacer().frame(height: theme.spaces.spaceFixedMedium)

--- a/Showcase/Showcase/Pages/Tokens/Font/FontTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Font/FontTokenPage.swift
@@ -26,7 +26,7 @@ struct FontTokenPage: View {
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
             Section {
-                ShowcaseCode(code: "theme.typeBodyStrongLarge(theme)")
+                ShowcaseCode(code: "theme.typeBodyStrongLarge(theme)", titleText: "app_tokens_common_viewCodeExample_label")
             }
 
             Spacer()

--- a/Showcase/Showcase/Pages/Tokens/Grid/GrisTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Grid/GrisTokenPage.swift
@@ -42,7 +42,7 @@ struct GridTokenPage: View {
             }
 
             Section {
-                ShowcaseCode(code: "theme.gridColumnCount(for: horizontalSizeClass)")
+                ShowcaseCode(code: "theme.gridColumnCount(for: horizontalSizeClass)", titleText: "app_tokens_common_viewCodeExample_label")
             }
 
             Section { illustrationForGridTokens() } header: {

--- a/Showcase/Showcase/Pages/Tokens/Opacity/OpacityTokenPage.swift
+++ b/Showcase/Showcase/Pages/Tokens/Opacity/OpacityTokenPage.swift
@@ -25,7 +25,7 @@ struct OpacityTokenPage: View {
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
             Section {
-                ShowcaseCode(code: "theme.opacities.opacityInvisible")
+                ShowcaseCode(code: "theme.opacities.opacityInvisible", titleText: "app_tokens_common_viewCodeExample_label")
             }
 
             Spacer() .frame(height: theme.spaces.spaceFixedMedium)

--- a/Showcase/Showcase/Pages/Utils/ShowcaseCode.swift
+++ b/Showcase/Showcase/Pages/Utils/ShowcaseCode.swift
@@ -26,6 +26,7 @@ struct ShowcaseCode: View {
 
     @State private var isCodeVisible = false
     let code: String
+    let titleText: LocalizedStringKey
 
     // MARK: Body
 
@@ -44,7 +45,7 @@ struct ShowcaseCode: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
             Button(action: toggle) {
                 HStack {
-                    Text("app_tokens_code_title_label")
+                    Text(titleText)
                         .typeBodyStrongLarge(theme)
                         .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
                         .padding(.vertical, theme.spaces.spacePaddingInlineShort)
@@ -55,7 +56,7 @@ struct ShowcaseCode: View {
                         .foregroundColor(theme.colors.colorSurfaceBrandPrimary.color(for: colorScheme))
                         .frame(width: 20, height: 20)
                         .padding(.trailing, theme.spaces.spacePaddingInlineMedium)
-                        .accessibilityLabel("app_tokens_code_visibility_button_a11y")
+                        .accessibilityLabel("app_common_viewCodeExample_label_a11y")
                 }
             }
             .buttonStyle(PlainButtonStyle())
@@ -85,7 +86,7 @@ struct ShowcaseCode: View {
                         .frame(width: 24, height: 24)
                         .padding(.trailing, theme.spaces.spacePaddingInlineMedium)
                         .alignmentGuide(.firstTextBaseline) { $0[.bottom] * 0.7 }
-                        .accessibilityLabel("app_tokens_code_copy_button_a11y")
+                        .accessibilityLabel("app_common_copyCode_a11y")
                 }
             })
         }
@@ -94,7 +95,7 @@ struct ShowcaseCode: View {
         .padding(.leading, theme.spaces.spacePaddingInlineMedium)
         .background(theme.colors.colorBgSecondary.color(for: colorScheme))
         .accessibilityElement(children: .combine)
-        .accessibilityHint("app_tokens_code_copy_button_a11y")
+        .accessibilityHint("app_common_copyCode_a11y")
         .overlay(
             Rectangle()
                 .opacity(theme.opacities.opacityInvisible)

--- a/Showcase/Showcase/Resources/en.lproj/Localizable.strings
+++ b/Showcase/Showcase/Resources/en.lproj/Localizable.strings
@@ -11,6 +11,10 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
+// MARK: - Common
+"app_common_viewCodeExample_label_a11y" = "Toggle code visibility";
+"app_common_copyCode_a11y" = "Copy code";
+
 // MARK: - bottomBar
 
 "app_bottomBar_components_label" = "Components";
@@ -26,6 +30,8 @@
 "app_about_accessibilityStatement_label" = "Accessibility statement";
 
 // MARK: - Tokens Screen
+
+"app_tokens_common_viewCodeExample_label" = "View token code example";
 
 "app_tokens_border_label" = "Border";
 "app_tokens_border_width_label" = "Width";
@@ -70,11 +76,9 @@
 "app_tokens_typography_label" = "Font";
 "app_tokens_typography_description_text" = "Font is our system of fonts and text styles. They enhance communication and reinforce the brand style.";
 
-"app_tokens_code_title_label" = "View token code example";
-"app_tokens_code_visibility_button_a11y" = "Toggle code visibility";
-"app_tokens_code_copy_button_a11y" = "Copy code to clipboard";
-
 // MARK: - Component Screen
+
+"app_components_common_viewCodeExample_label" = "View component code example";
 
 "app_component_emptyContent_text" = "No content";
 "app_component_emptyContent_description_text" = "This content is under construction and will be available very soon";


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [x] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
