### PR TITLE
[#477] Fixes for checkbox component

### DIFF
--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
@@ -197,7 +197,7 @@ struct ButtonConfiguration: View {
             }
 
             if model.layout == .iconAndText || model.layout == .textOnly {
-                DesignToolboxTextField(text: $model.text, prompt: "app_component_common_userText_prompt")
+                DesignToolboxTextField(text: $model.text, prompt: "app_components_common_userText_prompt".localized())
             }
         }
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
@@ -167,7 +167,7 @@ struct LinkConfiguration: View {
                 }
             }
 
-            DesignToolboxTextField(text: $model.text, prompt: "app_component_common_userText_prompt")
+            DesignToolboxTextField(text: $model.text, prompt: "app_components_common_userText_prompt")
         }
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
@@ -33,7 +33,6 @@ struct DesignToolboxVariantElement: View {
             } label: {
                 HStack {
                     Text(LocalizedStringKey(element.name))
-                        .multilineTextAlignment(.leading)
                         .typeHeadingMedium(theme)
                         .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
                         .padding(.vertical, theme.spaces.spaceFixedShorter)

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
@@ -33,6 +33,7 @@ struct DesignToolboxVariantElement: View {
             } label: {
                 HStack {
                     Text(LocalizedStringKey(element.name))
+                        .multilineTextAlignment(.leading)
                         .typeHeadingMedium(theme)
                         .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
                         .padding(.vertical, theme.spaces.spaceFixedShorter)

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
@@ -100,8 +100,9 @@ public struct OUDSCheckbox: View {
         let stateDescription = isEnabled ?
         "core_checkbox_enabled_a11y".localized()
         : "core_checkbox_disabled_a11y".localized()
+        let errorDescription = isError ? "core_checkbox_error_a11y".localized() : ""
 
-        let result = "\(selectorDescription), \(stateDescription)"
+        let result = "\(selectorDescription), \(stateDescription), \(errorDescription)"
         return result
     }
 }

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
@@ -158,24 +158,23 @@ public struct OUDSCheckboxItem: View {
                 $selectorState.wrappedValue.toggle()
             }
         }
-        .accessibilityLabel(a11yLabel(isReadOnly: layoutData.isReadOnly, isEnabled: isEnabled, labelText: layoutData.labelText, helperText: layoutData.helperText))
+        .accessibilityLabel(a11yLabel(layoutData: layoutData))
         .buttonStyle(ControlItemStyle(selectorType: .checkBox($selectorState), layoutData: layoutData))
     }
 
-    /// Forges a string to vocalize with *Voice Over* describing the component state
+    /// Forges a string to vocalize with *Voice Over* describing the component state.
     /// - Parameters:
-    ///    - isReadOnly: True if component is in read only mode, false otherwise
-    ///    - isEnabled: True if component is enabled, false otherwise
-    ///    - labelText: The text of the label if any
-    ///    - helperText: The text of the helper if any
-    private func a11yLabel(isReadOnly: Bool, isEnabled: Bool, labelText: String? = nil, helperText: String? = nil) -> String {
+    ///     - layoutData: All data of the layout used to forge the string.
+    private func a11yLabel(layoutData: ControlItemLabel.LayoutData) -> String {
         let selectorDescription: String = selectorState.a11yDescription.localized()
-        let stateDescription: String = isReadOnly
+        let stateDescription: String = layoutData.isReadOnly
         ? "core_checkbox_readOnly_a11y".localized()
         : (isEnabled
            ? "core_checkbox_enabled_a11y".localized()
            : "core_checkbox_disabled_a11y".localized())
-        let result = "\(selectorDescription), \(stateDescription), \(labelText ?? ""), \(helperText ?? "")"
+        let errorDescription = layoutData.isError ? "core_checkbox_error_a11y".localized() : ""
+
+        let result = "\(selectorDescription), \(stateDescription), \(layoutData.labelText), \(layoutData.helperText ?? "") \(errorDescription)"
         return result
     }
 }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemStyle.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemStyle.swift
@@ -33,7 +33,7 @@ struct ControlItemStyle: ButtonStyle {
     // MARK: Body
 
     func makeBody(configuration: Configuration) -> some View {
-        HStack(alignment: .center, spacing: theme.listItem.listItemSpaceColumnGap) {
+        HStack(alignment: .top, spacing: theme.listItem.listItemSpaceColumnGap) {
             switch layoutData.orientation {
             case .default:
                 selector(isPressed: configuration.isPressed)

--- a/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
@@ -40,6 +40,24 @@
         }
       }
     },
+    "core_checkbox_error_a11y" : {
+      "comment" : "Checkbox",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "is on errror"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "en erreur"
+          }
+        }
+      }
+    },
     "core_checkbox_readOnly_a11y" : {
       "comment" : "Checkbox",
       "extractionState" : "manual",


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [X] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
