### PR TITLE
[#460] Add accessibility label to vocalize the IconOnly style of button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Rename *selector* to *indicator* for control item absed components ([#496](https://github.com/Orange-OpenSource/ouds-ios/issues/496))
 - [Library] Checkbox component v2 ([#486](https://github.com/Orange-OpenSource/ouds-ios/issues/486))
 - [Library] Group components by category in documentation ([#484](https://github.com/Orange-OpenSource/ouds-ios/issues/484))
+- [Library] Add accessibility label to vocalize the IconOnly style ([#460](https://github.com/Orange-OpenSource/ouds-ios/issues/460))
 - [Tool] Update `json` RubyGem from 2.9.0 to 2.10.1
 - [Tool] Update `SwiftFormat/CLI` pod from v0.55.3 to v0.55.5
 - [Tool] Update `SwiftLint` pod from v0.57.1 to v0.58.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Library] Add accessibility label to vocalize the IconOnly button style ([#460](https://github.com/Orange-OpenSource/ouds-ios/issues/460))
 - [Library] Chevron for link component pointing to bad direction in RTL mode ([#557](https://github.com/Orange-OpenSource/ouds-ios/issues/557))
 - [Library] Remove divider if outline effect is active in RadioItem component ([#564](https://github.com/Orange-OpenSource/ouds-ios/issues/564))
 - [DesignToolbox] In RTL mode code sample text not aligned on the left ([#554](https://github.com/Orange-OpenSource/ouds-ios/issues/554))
@@ -52,7 +53,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Rename *selector* to *indicator* for control item absed components ([#496](https://github.com/Orange-OpenSource/ouds-ios/issues/496))
 - [Library] Checkbox component v2 ([#486](https://github.com/Orange-OpenSource/ouds-ios/issues/486))
 - [Library] Group components by category in documentation ([#484](https://github.com/Orange-OpenSource/ouds-ios/issues/484))
-- [Library] Add accessibility label to vocalize the IconOnly style ([#460](https://github.com/Orange-OpenSource/ouds-ios/issues/460))
 - [Tool] Update `json` RubyGem from 2.9.0 to 2.10.1
 - [Tool] Update `SwiftFormat/CLI` pod from v0.55.3 to v0.55.5
 - [Tool] Update `SwiftLint` pod from v0.57.1 to v0.58.1

--- a/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/DesignToolbox/DesignToolbox.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "b444594f79844b0d6d76d70fbfb3f7f71728f938",
-        "version" : "1.5.1"
+        "revision" : "39de59b2d47f7ef3ca88a039dff3084688fe27f4",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonPage.swift
@@ -83,11 +83,19 @@ private struct ButtonDemo: View {
             } else {
                 switch model.layout {
                 case .iconOnly:
-                    OUDSButton(icon: Image(decorative: "ic_heart"), accessibilityLabel: "app_components_button_icon_a11y", hierarchy: model.hierarchy, style: model.style) {}
+                    OUDSButton(icon: Image(decorative: "ic_heart"),
+                               accessibilityLabel: "app_components_button_icon_a11y".localized(),
+                               hierarchy: model.hierarchy,
+                               style: model.style) {}
                 case .textOnly:
-                    OUDSButton(text: model.text, hierarchy: model.hierarchy, style: model.style) {}
+                    OUDSButton(text: model.text,
+                               hierarchy: model.hierarchy,
+                               style: model.style) {}
                 case .iconAndText:
-                    OUDSButton(icon: Image(decorative: "ic_heart"), text: model.text, hierarchy: model.hierarchy, style: model.style) {}
+                    OUDSButton(icon: Image(decorative: "ic_heart"),
+                               text: model.text,
+                               hierarchy: model.hierarchy,
+                               style: model.style) {}
                 }
             }
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonPage.swift
@@ -83,7 +83,7 @@ private struct ButtonDemo: View {
             } else {
                 switch model.layout {
                 case .iconOnly:
-                    OUDSButton(icon: Image(decorative: "ic_heart"), hierarchy: model.hierarchy, style: model.style) {}
+                    OUDSButton(icon: Image(decorative: "ic_heart"), accessibilityLabel: "app_components_button_icon_a11y", hierarchy: model.hierarchy, style: model.style) {}
                 case .textOnly:
                     OUDSButton(text: model.text, hierarchy: model.hierarchy, style: model.style) {}
                 case .iconAndText:

--- a/DesignToolbox/DesignToolboxSnapshotsTests/__Snapshots__/Components/OUDSButtonUITests.swift
+++ b/DesignToolbox/DesignToolboxSnapshotsTests/__Snapshots__/Components/OUDSButtonUITests.swift
@@ -181,7 +181,7 @@ private struct ButtonTest: View {
         case .textAndIcon:
             OUDSButton(icon: Image(decorative: "ic_heart"), text: "Button", hierarchy: hierarchy, style: style) {}
         case .icon:
-            OUDSButton(icon: Image(decorative: "ic_heart"), hierarchy: hierarchy, style: style) {}
+            OUDSButton(icon: Image(decorative: "ic_heart"), accessibilityLabel: "Icon", hierarchy: hierarchy, style: style) {}
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -77,7 +77,7 @@ public struct OUDSButton: View {
 
     private enum `Type` {
         case text(String)
-        case icon(Image)
+        case icon(Image, String)
         case textAndIcon(text: String, icon: Image)
     }
 
@@ -123,11 +123,12 @@ public struct OUDSButton: View {
     ///
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
+    ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the button action
     ///    - hierarchy: The button hierarchy
     ///    - style: The button style
     ///    - action: The action to perform when the user triggers the button
-    public init(icon: Image, hierarchy: Hierarchy, style: Style, action: @escaping () -> Void) {
-        self.type = .icon(icon)
+    public init(icon: Image, accessibilityLabel: String, hierarchy: Hierarchy, style: Style, action: @escaping () -> Void) {
+        self.type = .icon(icon, accessibilityLabel)
         self.hierarchy = hierarchy
         self.style = style
         self.action = action
@@ -158,7 +159,7 @@ public struct OUDSButton: View {
 
         Button(action: action) {
             switch type {
-            case let .icon(icon):
+            case let .icon(icon, _):
                 ButtonIcon(icon: icon)
             case let .text(text):
                 ButtonText(text: text)
@@ -167,6 +168,21 @@ public struct OUDSButton: View {
             }
         }
         .buttonStyle(OUDSButtonStyle(hierarchy: hierarchy, style: style))
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// Forges a string to vocalize with *Voice Over* describing the button style `loading`
+    /// or the text according to the button type. For iconOnly the `accessibilityLabel` is used,
+    /// else the button text is used.
+    private var accessibilityLabel: String {
+        if style == .loading {
+            return "core_button_loading_a11y"
+        } else {
+            switch type {
+            case .text(let text), .textAndIcon(let text, _), .icon(_, let text):
+                return text
+            }
+        }
     }
 }
 

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -176,7 +176,7 @@ public struct OUDSButton: View {
     /// else the button text is used.
     private var accessibilityLabel: String {
         if style == .loading {
-            return "core_button_loading_a11y"
+            return "core_button_loading_a11y".localized()
         } else {
             switch type {
             case .text(let text), .textAndIcon(let text, _), .icon(_, let text):

--- a/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
@@ -1,10 +1,19 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "" : {
+      "shouldTranslate" : false
+    },
     "core_button_loading_a11y" : {
       "comment" : "Button",
       "extractionState" : "manual",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحميل"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -163,13 +172,8 @@
         }
       }
     },
-<<<<<<< HEAD
     "core_common_enabled_a11y" : {
       "comment" : "Common",
-=======
-    "lib_components_checkbox_componentEnabled_a11y" : {
-      "comment" : "Checkbox",
->>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -192,7 +196,6 @@
         }
       }
     },
-<<<<<<< HEAD
     "core_common_onError_a11y" : {
       "comment" : "Common",
       "extractionState" : "manual",
@@ -219,10 +222,6 @@
     },
     "core_common_selected_a11y" : {
       "comment" : "Common",
-=======
-    "lib_components_checkbox_componentReadOnly_a11y" : {
-      "comment" : "Checkbox",
->>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -231,21 +230,6 @@
             "value" : "مُختار"
           }
         },
-<<<<<<< HEAD
-=======
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lecture seule"
-          }
-        }
-      }
-    },
-    "lib_components_checkbox_selectorSelected_a11y" : {
-      "comment" : "Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
->>>>>>> 8dfa077e0 (Add accessibility label)
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -260,13 +244,8 @@
         }
       }
     },
-<<<<<<< HEAD
     "core_common_unselected_a11y" : {
       "comment" : "Common",
-=======
-    "lib_components_checkbox_selectorUndeterminate_a11y" : {
-      "comment" : "Checkbox",
->>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -289,13 +268,8 @@
         }
       }
     },
-<<<<<<< HEAD
     "core_radio_hint_a11y" : {
       "comment" : "Radio",
-=======
-    "lib_components_checkbox_selectorUnselected_a11y" : {
-      "comment" : "Checkbox",
->>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -313,7 +287,6 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-<<<<<<< HEAD
             "value" : "Taper deux fois pour rendre %@"
           }
         }
@@ -345,12 +318,6 @@
     },
     "TODO: Add switch indicator here" : {
       "shouldTranslate" : false
-=======
-            "value" : "Non sélectionné"
-          }
-        }
-      }
->>>>>>> 8dfa077e0 (Add accessibility label)
     }
   },
   "version" : "1.0"

--- a/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/Resources/Localizable.xcstrings
@@ -1,8 +1,23 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    "" : {
-      "shouldTranslate" : false
+    "core_button_loading_a11y" : {
+      "comment" : "Button",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chargement"
+          }
+        }
+      }
     },
     "core_checkbox_checked_a11y" : {
       "comment" : "Checkbox",
@@ -148,8 +163,13 @@
         }
       }
     },
+<<<<<<< HEAD
     "core_common_enabled_a11y" : {
       "comment" : "Common",
+=======
+    "lib_components_checkbox_componentEnabled_a11y" : {
+      "comment" : "Checkbox",
+>>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -172,6 +192,7 @@
         }
       }
     },
+<<<<<<< HEAD
     "core_common_onError_a11y" : {
       "comment" : "Common",
       "extractionState" : "manual",
@@ -198,6 +219,10 @@
     },
     "core_common_selected_a11y" : {
       "comment" : "Common",
+=======
+    "lib_components_checkbox_componentReadOnly_a11y" : {
+      "comment" : "Checkbox",
+>>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -206,6 +231,21 @@
             "value" : "مُختار"
           }
         },
+<<<<<<< HEAD
+=======
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lecture seule"
+          }
+        }
+      }
+    },
+    "lib_components_checkbox_selectorSelected_a11y" : {
+      "comment" : "Checkbox",
+      "extractionState" : "manual",
+      "localizations" : {
+>>>>>>> 8dfa077e0 (Add accessibility label)
         "en" : {
           "stringUnit" : {
             "state" : "translated",
@@ -220,8 +260,13 @@
         }
       }
     },
+<<<<<<< HEAD
     "core_common_unselected_a11y" : {
       "comment" : "Common",
+=======
+    "lib_components_checkbox_selectorUndeterminate_a11y" : {
+      "comment" : "Checkbox",
+>>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -239,13 +284,18 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Non sélectionné"
+            "value" : "Undéterminé"
           }
         }
       }
     },
+<<<<<<< HEAD
     "core_radio_hint_a11y" : {
       "comment" : "Radio",
+=======
+    "lib_components_checkbox_selectorUnselected_a11y" : {
+      "comment" : "Checkbox",
+>>>>>>> 8dfa077e0 (Add accessibility label)
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -263,6 +313,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
+<<<<<<< HEAD
             "value" : "Taper deux fois pour rendre %@"
           }
         }
@@ -294,6 +345,12 @@
     },
     "TODO: Add switch indicator here" : {
       "shouldTranslate" : false
+=======
+            "value" : "Non sélectionné"
+          }
+        }
+      }
+>>>>>>> 8dfa077e0 (Add accessibility label)
     }
   },
   "version" : "1.0"


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#460

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [X] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [X] My change follows accessibility good practices

#### Design

- [X] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [X] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [X] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [X] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- [x] Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [] Documentation has been updated if relevant
- [X] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [X] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
