### PR TITLE
[#484] Apply Figma categories to order and group components in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] Group components by category in documentation ([#484](https://github.com/Orange-OpenSource/ouds-ios/issues/484))
 - [Tool] Update `json` RubyGem from 2.9.0 to 2.10.1
 - [Tool] Update `SwiftFormat/CLI` pod from v0.55.3 to v0.55.5
 - [Tool] Update `SwiftLint` pod from v0.57.1 to v0.58.1

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
@@ -17,6 +17,7 @@ import SwiftUI
 // MARK: - OUDS Checkbox Item
 
 /// The ``OUDSCheckboxItem`` proposes layouts to add in your views some checkboxes components.
+/// If you want to use a checkbox with only a selector, prefer instead ``OUDSCheckbox``.
 ///
 /// ## Layouts
 ///
@@ -24,8 +25,6 @@ import SwiftUI
 ///
 /// - **default**: the component has a leading selector, a label and optional helper texts, and an optional trailing decorative icon
 /// - **inverse**: like the *default* layout but with a trailing checkbox seelctor and a leading optional image
-///
-/// If you want to use a checkbox with only the selector, prefer instead ``OUDSCheckbox``.
 ///
 /// ## Selector states
 ///

--- a/OUDS/Core/Components/Sources/ViewModifiers/DividerModifier/DividerModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/DividerModifier/DividerModifier.swift
@@ -15,7 +15,7 @@ import OUDSTokensSemantic
 import SwiftUI
 
 /// A `ViewModifier` which will apply a specific divider under a `View` using color semantic token.
-
+///
 /// - Since: 0.12.0
 public struct DividerModifier: ViewModifier {
 

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
@@ -1,0 +1,21 @@
+# Actions
+
+Some components can be used for **actions**.
+
+## Overview
+
+### Buttons
+
+The ``OUDSButton`` propose layout with text only, icon only or text and icon. 
+Four hierarchies are proposed for all layouts: *default*, *strong*, *minimal* and *negative*.
+Two style are available: *default* and *loading*.
+If button is placed on colored surface using `OUDSColoredSurface`, the default colors (content, background and border) are automatically adjusted to switch to monochrom.
+A button with `OUDSButton.Hierarchy.Negative` hierarchy is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
+
+```swift
+     // Icon only with default hierarchy
+     OUDSButton(hierarchy: .default, icon: Image("ic_heart")) {}
+
+     // Text only with negative hierarchy
+     OUDSButton(hierarchy: .negative, text: "Delete") {}
+```

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Input.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Input.md
@@ -1,0 +1,35 @@
+# Input
+
+Some components can be used for **inputs**.
+
+## Overview
+
+### Checkbox
+
+The library proposes layout to add in your views some checkboxes components, even if this type of component is not iOS-native one.
+You can use a simple checkbox without any labels and images.
+
+```swift
+     // A simple checkbox, with only a selector
+     OUDSCheckbox(state: $state)
+```
+
+### Checkbox item
+
+The library proposes also a checkbox which has in its layout some labels and icons.
+The selector can be leading or trailing.
+
+```swift
+     // A leading checkbox with a label
+     OUDSCheckboxItem(state: $state, label: "Hello world")
+
+     // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error
+     // with an inverse layout
+     OUDSCheckboxItem(state: $state,
+                      labelText: "We live in a fabled world",
+                      helperText: "Of dreaming boys and wide-eyed girls",
+                      icon: Image(decorative: "ic_heart"),
+                      isInversed: true,
+                      isError: true,
+                      hasDivider: true)
+```

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigation.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigation.md
@@ -1,0 +1,22 @@
+# Navigation
+
+Some components can be used for **navigation**.
+
+## Overview
+
+### Links
+
+The ``OUDSLink`` proposes layout with text only or text with icon.
+It also proposes layout to navigate forward or backward.
+The link can be displayed in `small` or `medium` size.
+
+```swift
+    // Text only in small size
+    OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
+
+    // Text and icon in medium size
+    OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .medium) { /* the action to process */ }
+
+    // Navigate to previous page with link in a medium size
+    OUDSLink(text: "Back", arrow: .back, size: .medium) { /* the action to process */ }
+```

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -2,63 +2,6 @@
 
 The catalog of all components provided by OUDS. It contains also `View` extensions and `ViewModifiers` to apply tokens and styles on components and higher-level views.
 
-## Overview
-
-### Buttons
-
-The ``OUDSButton`` propose layout with text only, icon only or text and icon. 
-Four hierarchies are proposed for all layouts: *default*, *strong*, *minimal* and *negative*.
-Two style are available: *default* and *loading*.
-If button is placed on colored surface using `OUDSColoredSurface`, the default colors (content, background and border) are automatically adjusted to switch to monochrom.
-A button with `OUDSButton.Hierarchy.Negative` hierarchy is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
-
-```swift
-     // Icon only with default hierarchy
-     OUDSButton(hierarchy: .default, icon: Image("ic_heart")) {}
-
-     // Text only with negative hierarchy
-     OUDSButton(hierarchy: .negative, text: "Delete") {}
-```
-
-### Links
-
-The ``OUDSLink`` proposes layout with text only or text with icon.
-It also proposes layout to navigate forward or backward.
-The link can be displayed in `small` or `medium` size.
-
-```swift
-    // Text only in small size
-    OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
-
-    // Text and icon in medium size
-    OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .medium) { /* the action to process */ }
-
-    // Navigate to previous page with link in a medium size
-    OUDSLink(text: "Back", arrow: .back, size: .medium) { /* the action to process */ }
-```
-
-### Checkbox
-
-The library proposes layout to add in your views some checkboxes components, even if this type of component is not iOS-native one. 
-
-```swift
-     // A simple checkbox, with only a selector
-     OUDSCheckbox(state: $state)
-
-     // A leading checkbox with a label
-     OUDSCheckboxItem(state: $state, label: "Hello world")
-
-     // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error
-     // with an inverse layout
-     OUDSCheckboxItem(state: $state,
-                      labelText: "We live in a fabled world",
-                      helperText: "Of dreaming boys and wide-eyed girls",
-                      icon: Image(decorative: "ic_heart"),
-                      isInversed: true,
-                      isError: true,
-                      hasDivider: true)
-```
-
 ## Customize components
 
 ### Apply a specific shadow effect (elevation tokens)
@@ -135,9 +78,8 @@ The helper is available through `View`, and tokens through the provider of the t
 
 ## Topics
 
-### Group
+### Essentials
 
-- ``OUDSButton``
-- ``OUDSCheckbox``
-- ``OUDSCheckboxItem``
-- ``OUDSLink``
+- <doc:Actions>
+- <doc:Navigation>
+- <doc:Input>

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -78,7 +78,7 @@ The helper is available through `View`, and tokens through the provider of the t
 
 ## Topics
 
-### Essentials
+### Components categories
 
 - <doc:Actions>
 - <doc:Navigation>

--- a/OUDS/Core/OUDS/Sources/_OUDS.docc/Components.md
+++ b/OUDS/Core/OUDS/Sources/_OUDS.docc/Components.md
@@ -20,18 +20,3 @@ Of course you must use in your root view the <doc:/OUDS/OUDSThemeableView> with 
 ``` 
 
 You can get more details about _Components_ with the [OUDSComponents documentation](https://ios.unified-design-system.orange.com/documentation/oudstokenscomponent/).
-
-## Available components
-
-### Button
-
-```swift
-     // Icon only with default hierarchy
-     OUDSButton(hierarchy: .default, icon: Image("ic_heart")) {}
-
-     // Text only with negative hierarchy
-     OUDSButton(hierarchy: .negative, text: "Delete") {}
-
-     // Text and icon with strong hierarchy
-     OUDSButton(hierarchy: .strong, icon: Image("ic_heart"), text: "Validate") {}
-```


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#484 

### Description

<!-- Describe your changes in detail -->
Update of markdown

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
To apply the same order as Figma noone will never read.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [ ] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibiltiy review has been done
- (NA) Q/A team has tested the evolution
- [ ] Documentation has been updated if relevant
- [ ] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [ ] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
