### PR TITLE
[#488] Improve a11y and vocalization of `checkbox` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [Library] Checkbox status not properly rendered ([#488](https://github.com/Orange-OpenSource/ouds-ios/issues/488))
 - [DesignToolbox] Miscellaneous improvements ([#479](https://github.com/Orange-OpenSource/ouds-ios/issues/479))
 - [Library] Fixes for checkbox component ([#477](https://github.com/Orange-OpenSource/ouds-ios/issues/477))
 - [Library] Fix radius on button ([#472](https://github.com/Orange-OpenSource/ouds-ios/issues/472))


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#488 

### Description

<!-- Describe your changes in detail -->

- [ ] use toggle trait
- [ ] _unselected_ and _undeterminated_ states in english language revered
- [ ] remove _enabled_ and _disabled_ status
- [ ] add hint for double tap

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Be compliant with a11y guidelines

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [ ] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [ ] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [ ] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- [ ] Accessibiltiy review has been done
- [ ] Q/A team has tested the evolution
- [ ] Documentation has been updated if relevant
- [ ] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [ ] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
