### PR TITLE
[#519]  Update Checkbox and Radio button assets on the screen of components list 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.12.0...develop)
 
+### Fixed
+
+- [DesignToolbox] Update Checkbox and Radio button assets on the screen of component list ([#519](https://github.com/Orange-OpenSource/ouds-ios/issues/519))
+
 ## [0.12.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.11.0...0.12.0) - 2025-03-20
 
 ### Added

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxElement.swift
@@ -21,7 +21,7 @@ struct CheckboxElement: DesignToolboxElement {
 
     init() {
         name = "app_components_checkbox_twoStates_indicatorOnly_label"
-        image = Image(decorative: "il_component_checkbox").renderingMode(.template)
+        image = Image(decorative: "il_component_checkbox").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateElement.swift
@@ -21,7 +21,7 @@ struct CheckboxIndeterminateElement: DesignToolboxElement {
 
     init() {
         name = "app_components_checkbox_threeStates_indicatorOnly_label"
-        image = Image(decorative: "il_component_checkbox").renderingMode(.template)
+        image = Image(decorative: "il_component_checkbox").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxElements.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxElements.swift
@@ -30,10 +30,10 @@ struct CheckboxElements: DesignToolboxElement {
         ]
 
         name = "app_components_checkbox_label"
-        image = Image(decorative: "il_component_checkbox").renderingMode(.template)
+        image = Image(decorative: "il_component_checkbox").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
-            image: Image(decorative: "il_component_checkbox").renderingMode(.template),
+            image: Image(decorative: "il_component_checkbox").renderingMode(.original),
             description: "app_components_checkbox_description_text",
             illustration: AnyView(DesignToolboxVariantElement(elements: variants))))
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemElement.swift
@@ -21,7 +21,7 @@ struct CheckboxItemElement: DesignToolboxElement {
 
     init() {
         name = "app_components_checkbox_twoStates_controlItem_label"
-        image = Image(decorative: "il_component_checkbox_controlItem").renderingMode(.template)
+        image = Image(decorative: "il_component_checkbox_controlItem").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateElement.swift
@@ -21,7 +21,7 @@ struct CheckboxItemIndeterminateElement: DesignToolboxElement {
 
     init() {
         name = "app_components_checkbox_threeStates_controlItem_label"
-        image = Image(decorative: "il_component_checkbox_controlItem").renderingMode(.template)
+        image = Image(decorative: "il_component_checkbox_controlItem").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioElement.swift
@@ -20,7 +20,7 @@ struct RadioElement: DesignToolboxElement {
 
     init() {
         name = "app_components_radio_selectorOnly_label"
-        image = Image(decorative: "il_component_radio").renderingMode(.template)
+        image = Image(decorative: "il_component_radio").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioElements.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioElements.swift
@@ -28,10 +28,10 @@ struct RadioElements: DesignToolboxElement {
         ]
 
         name = "app_components_radio_label"
-        image = Image(decorative: "il_component_radio").renderingMode(.template)
+        image = Image(decorative: "il_component_radio").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
-            image: Image(decorative: "il_component_radio").renderingMode(.template),
+            image: Image(decorative: "il_component_radio").renderingMode(.original),
             description: "app_components_radio_description_text",
             illustration: AnyView(DesignToolboxVariantElement(elements: variants))))
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RaioItemElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RaioItemElement.swift
@@ -20,7 +20,7 @@ struct RadioItemElement: DesignToolboxElement {
 
     init() {
         name = "app_components_radio_controlItem_label"
-        image = Image(decorative: "il_component_radio_controlItem").renderingMode(.template)
+        image = Image(decorative: "il_component_radio_controlItem").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#519

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [ ] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
