### PR TITLE
[#553] Fix direction of navigation link chevron in RTL mode for Design Toolbox (#553)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DesignToolbox] Chevron for navigation link pointing to bad direction in RTL mode ([#553](https://github.com/Orange-OpenSource/ouds-ios/issues/553))
 - [DesignToolbox] Broken wording in radio button page
 - [DesignToolbox] Update Checkbox and Radio button assets on the screen of component list ([#519](https://github.com/Orange-OpenSource/ouds-ios/issues/519))
 

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
@@ -19,6 +19,7 @@ struct DesignToolboxVariantElement: View {
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.layoutDirection) private var layoutDirection
 
     // MARK: Stored properties
 
@@ -41,8 +42,9 @@ struct DesignToolboxVariantElement: View {
                     Spacer()
                     Image(systemName: "chevron.right")
                         .foregroundColor(theme.colors.colorContentDefault.color(for: colorScheme))
-                        .padding(.trailing, theme.spaces.spaceFixedMedium)
+                        .padding(layoutDirection == .rightToLeft ? .leading : .trailing, theme.spaces.spaceFixedMedium)
                         .accessibilityHidden(true)
+                        .scaleEffect(layoutDirection == .rightToLeft ? -1 : 1, anchor: .center)
                 }
             }
         }


### PR DESCRIPTION

_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#553 

### Description

<!-- Describe your changes in detail -->

If RTL mode mirrores the chevron of navigation link for Design System Toolbox

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Support RTL layout

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA)  My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A eam has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
