### PR TITLE
[#554] Fix code sample alignment for RTL mode in Design Toolbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [DesignToolbox] In RTL mode code sample text not aligned on the left ([#554](https://github.com/Orange-OpenSource/ouds-ios/issues/554))
 - [DesignToolbox] Broken wording in radio button page
 - [DesignToolbox] Update Checkbox and Radio button assets on the screen of component list ([#519](https://github.com/Orange-OpenSource/ouds-ios/issues/519))
 

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCode.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCode.swift
@@ -17,16 +17,16 @@ import SwiftUI
 
 struct DesignToolboxCode: View {
 
-    // MARK: Environment properties
+    // MARK: Stored properties
+
+    let code: String
+    let titleText: LocalizedStringKey
+
+    @State private var isCodeVisible = false
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
-
-    // MARK: Stored properties
-
-    @State private var isCodeVisible = false
-    let code: String
-    let titleText: LocalizedStringKey
+    @Environment(\.layoutDirection) private var layoutDirection
 
     // MARK: Body
 
@@ -71,6 +71,8 @@ struct DesignToolboxCode: View {
                 .font(.system(.body, design: .monospaced))
                 .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
                 .padding(.vertical, theme.spaces.spacePaddingInlineShort)
+                .multilineTextAlignment(layoutDirection == .rightToLeft ? .trailing : .leading)
+            // As the source code sample is written in english, keep text aligned on the left
 
             Spacer(minLength: theme.spaces.spacePaddingBlockMedium)
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->

#554 

### Description

<!-- Describe your changes in detail -->

For source code sample text alignment tothe left as written in english

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Support RTL

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [ ] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
