### PR TITLE
[#146] Less use of color sheme utilities for use of colors and elevations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Library] `BulletList` component tokens (tokens library v0.9.0)
 - [Library] `Chip` component tokens (tokens library v0.9.0)
+- [Library] Use of color scheme to apply elevation effects ([#146](https://github.com/Orange-OpenSource/ouds-ios/issues/146)) 
 - [Library] Remove UI test cases on colored surface for radio button and checkbox ([#523](https://github.com/Orange-OpenSource/ouds-ios/issues/523)) 
 - [Library] Rafactor the interal interation state used by radio and checkbox components ([#560](https://github.com/Orange-OpenSource/ouds-ios/issues/560)) 
 - [Library] Font family, font weight semantic tokens (tokens library v0.8.0) ([#529](https://github.com/Orange-OpenSource/ouds-ios/issues/529))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] New public API to use less color scheme to apply elevation and colors ([#146](https://github.com/Orange-OpenSource/ouds-ios/issues/146)) 
 - [Library] `BulletList` component tokens (tokens library v0.9.0)
 - [Library] `Chip` component tokens (tokens library v0.9.0)
-- [Library] Use of color scheme to apply elevation effects ([#146](https://github.com/Orange-OpenSource/ouds-ios/issues/146)) 
 - [Library] Remove UI test cases on colored surface for radio button and checkbox ([#523](https://github.com/Orange-OpenSource/ouds-ios/issues/523)) 
 - [Library] Rafactor the interal interation state used by radio and checkbox components ([#560](https://github.com/Orange-OpenSource/ouds-ios/issues/560)) 
 - [Library] Font family, font weight semantic tokens (tokens library v0.8.0) ([#529](https://github.com/Orange-OpenSource/ouds-ios/issues/529))

--- a/DesignToolbox/DesignToolbox/MainView.swift
+++ b/DesignToolbox/DesignToolbox/MainView.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct MainView: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         TabView {
@@ -35,7 +34,7 @@ struct MainView: View {
                     Label("app_bottomBar_about_label", image: "ic_info")
                 }
         }
-        .accentColor(theme.colors.colorContentBrandPrimary.color(for: colorScheme))
+        .oudsAccentColor(theme.colors.colorContentBrandPrimary)
     }
 }
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
@@ -163,7 +163,6 @@ extension OUDSButton.Hierarchy: @retroactive CaseIterable, @retroactive CustomSt
 struct ButtonConfiguration: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     @StateObject var model: ButtonConfigurationModel
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonConfiguration.swift
@@ -171,12 +171,12 @@ struct ButtonConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.style != .`default`)
 
             Toggle("app_components_common_onColoredBackground_label", isOn: $model.onColoredSurface)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_button_hierarchy_label", selection: $model.hierarchy) {
                 ForEach(OUDSButton.Hierarchy.allCases, id: \.id) { hierarchy in

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxConfiguration.swift
@@ -80,17 +80,17 @@ struct CheckboxConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled)
 
             Toggle("app_components_checkbox_selection_label", isOn: $model.indicatorState)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled)
         }
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxConfiguration.swift
@@ -74,7 +74,6 @@ struct CheckboxConfiguration: View {
     @ObservedObject var model: CheckboxConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateConfiguration.swift
@@ -80,12 +80,12 @@ struct CheckboxIndeterminateConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled)
 
             DesignToolboxChoicePicker(title: "app_components_checkbox_selection_label", selection: $model.indicatorState) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateConfiguration.swift
@@ -74,7 +74,6 @@ struct CheckboxIndeterminateConfiguration: View {
     @ObservedObject var model: CheckboxIndeterminateConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
@@ -125,7 +125,6 @@ struct CheckboxItemConfiguration: View {
     @ObservedObject var model: CheckboxItemConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
@@ -132,34 +132,34 @@ struct CheckboxItemConfiguration: View {
 
             Toggle("app_components_checkbox_selection_label", isOn: $model.indicatorState)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError || model.isReadOnly)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isReadOnly)
 
             Toggle("app_components_common_readOnly_label", isOn: $model.isReadOnly)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isError)
 
             Toggle("app_components_common_helperText_label", isOn: $model.helperText)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_icon_label", isOn: $model.icon)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_common_orientation_label", selection: $model.layoutOrientation) {
                 ForEach(DesignToolboxLayoutOrientation.allCases, id: \.id) { orientation in

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
@@ -142,30 +142,30 @@ struct CheckboxItemIndeterminateConfiguration: View {
 
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError || model.isReadOnly)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isReadOnly)
 
             Toggle("app_components_common_readOnly_label", isOn: $model.isReadOnly)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isError)
 
             Toggle("app_components_common_helperText_label", isOn: $model.helperText)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_icon_label", isOn: $model.icon)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_common_orientation_label", selection: $model.layoutOrientation) {
                 ForEach(DesignToolboxLayoutOrientation.allCases, id: \.id) { orientation in

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
@@ -129,7 +129,6 @@ struct CheckboxItemIndeterminateConfiguration: View {
     @ObservedObject var model: CheckboxItemIndeterminateConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxlItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxlItemConfiguration.swift
@@ -139,30 +139,30 @@ struct CheckboxItemConfiguration: View {
 
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError || model.isReadOnly)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isReadOnly)
 
             Toggle("app_components_common_readOnly_label", isOn: $model.isReadOnly)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isError)
 
             Toggle("app_components_checkbox_helperText_label", isOn: $model.helperText)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_icon_label", isOn: $model.icon)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_common_orientation_label", selection: $model.layoutOrientation) {
                 ForEach(DesignToolboxLayoutOrientation.allCases, id: \.id) { orientation in

--- a/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
@@ -149,11 +149,11 @@ struct LinkConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_onColoredBackground_label", isOn: $model.onColoredSurface)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_link_size_label", selection: $model.size) {
                 ForEach(OUDSLink.Size.allCases, id: \.id) { size in

--- a/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkConfiguration.swift
@@ -141,7 +141,6 @@ extension OUDSLink.Size: @retroactive CaseIterable, @retroactive CustomStringCon
 struct LinkConfiguration: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     @StateObject var model: LinkConfigurationModel
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioConfiguration.swift
@@ -75,17 +75,17 @@ struct RadioConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_components_radio_selection_label", isOn: $model.selection)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isError)
 
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled)
         }
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/Radio/RadioConfiguration.swift
@@ -69,7 +69,6 @@ struct RadioConfiguration: View {
     @ObservedObject var model: RadioConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
@@ -148,7 +148,6 @@ struct RadioItemConfiguration: View {
     @ObservedObject var model: RadioItemConfigurationModel
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // swiftlint:disable closure_body_length
     var body: some View {

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
@@ -155,43 +155,43 @@ struct RadioItemConfiguration: View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {
             Toggle("app_components_radio_selection_label", isOn: $model.selection)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError || model.isReadOnly)
 
             Toggle("app_common_enabled_label", isOn: $model.enabled)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(model.isError || model.isReadOnly)
 
             Toggle("app_components_common_onError_label", isOn: $model.isError)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isReadOnly)
 
             Toggle("app_components_common_readOnly_label", isOn: $model.isReadOnly)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .disabled(!model.enabled || model.isError)
 
             Toggle("app_components_common_helperText_label", isOn: $model.helperText)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_radio_additionalLabelText_label", isOn: $model.additionalLabelText)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_icon_label", isOn: $model.icon)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_radio_outlined_label", isOn: $model.outlined)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             DesignToolboxChoicePicker(title: "app_components_common_orientation_label", selection: $model.layoutOrientation) {
                 ForEach(DesignToolboxLayoutOrientation.allCases, id: \.id) { orientation in

--- a/DesignToolbox/DesignToolbox/Pages/ThemeSelection/ThemeSelection.swift
+++ b/DesignToolbox/DesignToolbox/Pages/ThemeSelection/ThemeSelection.swift
@@ -106,7 +106,6 @@ extension View {
 struct ThemeSelectionButton: View {
 
     @EnvironmentObject private var themeProvider: ThemeProvider
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         Menu {

--- a/DesignToolbox/DesignToolbox/Pages/ThemeSelection/ThemeSelection.swift
+++ b/DesignToolbox/DesignToolbox/Pages/ThemeSelection/ThemeSelection.swift
@@ -121,6 +121,6 @@ struct ThemeSelectionButton: View {
                 .accessibilityLabel("app_topBar_theme_button_a11y")
                 .accessibilityHint("app_topBar_theme_button_hint_a11y")
         }
-        .foregroundColor(themeProvider.currentTheme.colors.colorContentBrandPrimary.color(for: colorScheme))
+        .oudsForegroundColor(themeProvider.currentTheme.colors.colorContentBrandPrimary)
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenPage.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct BorderTokenPage: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedMedium) {

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenPage.swift
@@ -37,7 +37,7 @@ struct BorderTokenPage: View {
             } header: {
                 Text("app_tokens_border_width_label")
                     .typeHeadingLarge(theme)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
             }
 
             Section {
@@ -50,7 +50,7 @@ struct BorderTokenPage: View {
             } header: {
                 Text("app_tokens_border_radius_label")
                     .typeHeadingLarge(theme)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
             }
 
             Section {
@@ -63,7 +63,7 @@ struct BorderTokenPage: View {
             } header: {
                 Text("app_tokens_border_style_label")
                     .typeHeadingLarge(theme)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
             }
         }
         .padding(.horizontal, theme.spaces.spaceFixedMedium)

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
@@ -139,7 +139,6 @@ struct SizeTokenPage: View {
     private struct TypographyCategoryHeader: View {
 
         @Environment(\.theme) private var theme
-        @Environment(\.colorScheme) private var colorScheme
         @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
         let namedFont: NamedFont

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenPage.swift
@@ -72,7 +72,7 @@ struct SizeTokenPage: View {
                     Image("ic_token")
                         .resizable()
                         .renderingMode(.template)
-                        .foregroundColor(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorContentStatusInfo)
                         .frame(width: token, height: token, alignment: .center)
                         .accessibilityHidden(true)
                 }
@@ -105,7 +105,7 @@ struct SizeTokenPage: View {
                     Image("ic_token")
                         .resizable()
                         .renderingMode(.template)
-                        .foregroundColor(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorContentStatusInfo)
                         .frame(width: token, height: token, alignment: .center)
                         .accessibilityHidden(true)
                 }
@@ -156,16 +156,16 @@ struct SizeTokenPage: View {
                         .resizable()
                         .renderingMode(.template)
                         .aspectRatio(contentMode: .fit)
-                        .foregroundStyle(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentStatusInfo)
                 }
                 .frame(height: size, alignment: .center)
 
                 illustration(for: namedFont, in: theme)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
             }
             .padding(.all, theme.spaces.spaceFixedMedium)
-            .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+            .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
         }
     }
 

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenCommonIllustration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenCommonIllustration.swift
@@ -85,7 +85,6 @@ struct SpaceTokenVariant<TokenIllustration>: View where TokenIllustration: View 
 struct SpaceCommonIllustration: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     enum Padding {
         case top(SpaceIllustrationIcon.Asset?)
@@ -213,7 +212,6 @@ struct SpaceIllustrationIcon: View {
     }
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let asset: Asset?
 
@@ -238,7 +236,6 @@ struct SpaceIllustrationIcon: View {
 private struct SpaceIllustrationRectangle: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let width: CGFloat?
     let height: CGFloat?
@@ -266,7 +263,6 @@ private struct SpaceIllustrationRectangle: View {
 struct SpaceHeaderDescription: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     private let firstText: LocalizedStringKey
     private let secondText: LocalizedStringKey?

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenCommonIllustration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenCommonIllustration.swift
@@ -114,7 +114,7 @@ struct SpaceCommonIllustration: View {
                 DesignToolboxTokenIllustrationBackground()
                     .padding(.top, dimension)
                     .padding(.leading, dimension)
-                    .background(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                    .oudsBackground(theme.colors.colorContentStatusInfo)
             case .leading(let asset): // ZStack alignment leading
                 HStack(alignment: .center, spacing: theme.spaces.spaceFixedNone) {
                     SpaceIllustrationRectangle(width: dimension)
@@ -223,7 +223,7 @@ struct SpaceIllustrationIcon: View {
                 .resizable()
                 .renderingMode(.template)
                 .aspectRatio(contentMode: .fit)
-                .foregroundColor(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                .oudsForegroundColor(theme.colors.colorContentStatusInfo)
                 .padding(.horizontal, asset.extraPadding)
                 .padding(.vertical, asset.extraPadding)
                 .frame(width: 24)
@@ -255,7 +255,7 @@ private struct SpaceIllustrationRectangle: View {
 
     var body: some View {
         Rectangle()
-            .foregroundColor(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+            .oudsForegroundColor(theme.colors.colorContentStatusInfo)
             .frame(width: width, height: height)
     }
 }
@@ -299,7 +299,7 @@ struct SpaceHeaderDescription: View {
         content
             .oudsBorder(style: theme.borders.borderStyleDrag, width: theme.borders.borderWidthThin, radius: theme.borders.borderRadiusNone, color: theme.colors.colorBgEmphasized)
             .padding(.all, theme.spaces.spaceFixedMedium)
-            .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+            .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
     }
 
     @ViewBuilder private var content: some View {
@@ -317,7 +317,7 @@ struct SpaceHeaderDescription: View {
         case .horizontal:
             HStack(alignment: .center, spacing: theme.spaces.spaceFixedNone) {
                 Text(firstText)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
                     .typeBodyDefaultMedium(theme)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -325,7 +325,7 @@ struct SpaceHeaderDescription: View {
 
                 if let secondText {
                     Text(secondText)
-                        .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentDefault)
                         .typeBodyDefaultMedium(theme)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -333,7 +333,7 @@ struct SpaceHeaderDescription: View {
         case .verical:
             VStack(alignment: .center, spacing: theme.spaces.spaceFixedNone) {
                 Text(firstText)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
                     .typeBodyDefaultMedium(theme)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -341,7 +341,7 @@ struct SpaceHeaderDescription: View {
 
                 if let secondText {
                     Text(secondText)
-                        .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentDefault)
                         .typeBodyDefaultMedium(theme)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -357,7 +357,7 @@ struct SpaceHeaderDescription: View {
 
                 Text(firstText)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
                     .typeBodyDefaultMedium(theme)
 
                 SpaceIllustrationRectangle(height: paddings.bottom)

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
@@ -53,7 +53,7 @@ struct ElevationTokenPage: View {
             DesignToolboxTokenIllustration(tokenName: name, tokenValue: value) {
                 Rectangle()
                     .frame(width: theme.sizes.sizeIconDecorative2xl, height: theme.sizes.sizeIconDecorative2xl)
-                    .foregroundColor(theme.colors.colorBgSecondary.color(for: colorScheme))
+                    .oudsForegroundColor(theme.colors.colorBgSecondary)
                     .shadow(elevation: token)
                     .padding(.bottom, 2)
             }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
@@ -39,15 +39,16 @@ struct ElevationTokenPage: View {
     }
 
     struct IllustrationElevation: View {
-        @Environment(\.theme) private var theme
-        @Environment(\.colorScheme) private var colorScheme
 
         let namedElevation: NamedElevation
 
+        @Environment(\.theme) private var theme
+        @Environment(\.colorScheme) private var colorScheme
+
         var body: some View {
-            let token = namedElevation.token(from: theme).elevation(for: colorScheme)
+            let token = namedElevation.token(from: theme)
             let name = namedElevation.rawValue
-            let value = String(format: "x: %.2f, y: %.2f, radius: %.2f\nColor: %@", token.x, token.y, token.radius, token.color)
+            let value = description(for: token)
 
             DesignToolboxTokenIllustration(tokenName: name, tokenValue: value) {
                 Rectangle()
@@ -56,6 +57,15 @@ struct ElevationTokenPage: View {
                     .shadow(elevation: token)
                     .padding(.bottom, 2)
             }
+        }
+
+        private func description(for token: ElevationCompositeSemanticToken) -> String {
+            let colorBasedToken = colorScheme == .light ? token.light : token.dark
+            let x = colorBasedToken.x
+            let y = colorBasedToken.y
+            let radius = colorBasedToken.radius
+            let color = colorBasedToken.color
+            return String(format: "x: %.2f, y: %.2f, radius: %.2f\nColor: %@", x, y, radius, color)
         }
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenPage.swift
@@ -54,7 +54,7 @@ struct ElevationTokenPage: View {
                 Rectangle()
                     .frame(width: theme.sizes.sizeIconDecorative2xl, height: theme.sizes.sizeIconDecorative2xl)
                     .oudsForegroundColor(theme.colors.colorBgSecondary)
-                    .shadow(elevation: token)
+                    .oudsShadow(token)
                     .padding(.bottom, 2)
             }
         }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenPage.swift
@@ -49,7 +49,6 @@ struct FontTokenPage: View {
         }
 
         @Environment(\.theme) private var theme
-        @Environment(\.colorScheme) private var colorScheme
         @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
         var body: some View {

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenPage.swift
@@ -55,7 +55,7 @@ struct FontTokenPage: View {
         var body: some View {
             VStack(alignment: .leading, spacing: theme.spaces.spaceFixedNone) {
                 illustration(for: namedFont, in: theme)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
 
                 Group {
                     Text(familyText)
@@ -66,7 +66,7 @@ struct FontTokenPage: View {
                 }
                 .typeBodyDefaultMedium(theme)
                 .fixedSize(horizontal: false, vertical: true)
-                .foregroundStyle(theme.colors.colorContentMuted.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentMuted)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, theme.spaces.spaceFixedShorter)

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GrisTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GrisTokenPage.swift
@@ -30,15 +30,15 @@ struct GridTokenPage: View {
                 Image(decorative: "il_tokens_grid_column_margin")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+                    .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
                 Image(decorative: "il_tokens_grid_min_width")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+                    .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
                 Image(decorative: "il_tokens_grid_max_width")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+                    .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
             }
 
             Section {

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GrisTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GrisTokenPage.swift
@@ -20,7 +20,6 @@ struct GridTokenPage: View {
 
     @Environment(\.theme) private var theme
     @Environment(\.oudsHorizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Body
 

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Opacity/OpacityTokenPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Opacity/OpacityTokenPage.swift
@@ -53,7 +53,7 @@ struct OpacityTokenPage: View {
                     Image(decorative: "ic_union")
                         .resizable()
                         .renderingMode(.template)
-                        .foregroundColor(theme.colors.colorContentStatusInfo.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorContentStatusInfo)
                         .frame(width: 48, height: 48)
                         .accessibilityHidden(true)
 

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Utils/DesignToolboxTokenIllustration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Utils/DesignToolboxTokenIllustration.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct DesignToolboxTokenIllustration<TokenIllustration>: View where TokenIllustration: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Stored properties
 

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Utils/DesignToolboxTokenIllustration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Utils/DesignToolboxTokenIllustration.swift
@@ -47,11 +47,11 @@ struct DesignToolboxTokenIllustration<TokenIllustration>: View where TokenIllust
             VStack(alignment: .leading) {
                 Text(tokenName)
                     .typeBodyStrongLarge(theme)
-                    .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                    .oudsForegroundStyle(theme.colors.colorContentDefault)
                 if let tokenValue {
                     Text(tokenValue)
                         .typeBodyDefaultMedium(theme)
-                        .foregroundStyle(theme.colors.colorContentMuted.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentMuted)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
@@ -37,7 +37,7 @@ struct Card: View {
                 .padding(.horizontal, theme.spaces.spaceFixedMedium)
                 .padding(.vertical, theme.spaces.spaceFixedMedium)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
         }
         .background(theme.colors.colorBgPrimary.color(for: colorScheme)
             .shadow(elevation: theme.elevations.elevationRaised))

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
@@ -40,7 +40,7 @@ struct Card: View {
                 .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
         }
         .background(theme.colors.colorBgPrimary.color(for: colorScheme)
-            .shadow(elevation: theme.elevations.elevationRaised.elevation(for: colorScheme)))
+            .shadow(elevation: theme.elevations.elevationRaised))
         .padding(.all, 4)
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Cards/Card.swift
@@ -19,7 +19,6 @@ import SwiftUI
 struct Card: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Stored properties
 
@@ -39,8 +38,8 @@ struct Card: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
         }
-        .background(theme.colors.colorBgPrimary.color(for: colorScheme)
-            .shadow(elevation: theme.elevations.elevationRaised))
+        .oudsBackground(theme.colors.colorBgPrimary)
+        .oudsShadow(theme.elevations.elevationRaised)
         .padding(.all, 4)
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Cards/CardIllustration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Cards/CardIllustration.swift
@@ -16,7 +16,6 @@ import SwiftUI
 struct CardIllustration: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Stored properties
 
@@ -34,8 +33,8 @@ struct CardIllustration: View {
         .accessibilityElement(children: .combine)
         .accessibilityRemoveTraits(.isImage)
         .accessibilityHidden(true)
-        .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
-        .background(theme.colors.colorSurfaceStatusNeutralMuted.color(for: colorScheme))
+        .oudsForegroundStyle(theme.colors.colorContentDefault)
+        .oudsBackground(theme.colors.colorSurfaceStatusNeutralMuted)
     }
 }
 

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxBackgroundModifier.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxBackgroundModifier.swift
@@ -18,15 +18,14 @@ import SwiftUI
 private struct DesignToolboxBackgroundModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let coloredSurface: Bool
 
     func body(content: Content) -> some View {
         if coloredSurface {
-            content.oudsColoredSurface(color: theme.colors.colorSurfaceBrandPrimary.color(for: colorScheme))
+            content.oudsColoredSurface(colors: theme.colors.colorSurfaceBrandPrimary)
         } else {
-            content.background(theme.colors.colorBgSecondary.color(for: colorScheme))
+            content.oudsBackground(theme.colors.colorBgSecondary)
         }
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxChoicePicker.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxChoicePicker.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct DesignToolboxChoicePicker<Content, Selection>: View where Content: View, Selection: Hashable {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let title: String
     let selection: Binding<Selection>
@@ -28,7 +27,7 @@ struct DesignToolboxChoicePicker<Content, Selection>: View where Content: View, 
         VStack(alignment: .leading) {
             Text(LocalizedStringKey(title))
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .accessibilityHidden(true)
 
             Picker(LocalizedStringKey(title), selection: selection) {

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCode.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxCode.swift
@@ -25,7 +25,6 @@ struct DesignToolboxCode: View {
     @State private var isCodeVisible = false
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.layoutDirection) private var layoutDirection
 
     // MARK: Body
@@ -47,13 +46,13 @@ struct DesignToolboxCode: View {
                 HStack {
                     Text(titleText)
                         .typeBodyStrongLarge(theme)
-                        .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentDefault)
                         .padding(.vertical, theme.spaces.spacePaddingInlineShort)
                     Image("ic_chevron-up")
                         .resizable()
                         .renderingMode(.template)
                         .rotationEffect(Angle.degrees(isCodeVisible ? 0 : 180))
-                        .foregroundColor(theme.colors.colorSurfaceBrandPrimary.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorSurfaceBrandPrimary)
                         .frame(width: 20, height: 20)
                         .padding(.trailing, theme.spaces.spacePaddingInlineMedium)
                         .accessibilityLabel("app_common_showCode_text_a11y")
@@ -69,7 +68,7 @@ struct DesignToolboxCode: View {
         HStack(alignment: .firstTextBaseline, spacing: theme.spaces.spacePaddingBlockNone) {
             Text(code)
                 .font(.system(.body, design: .monospaced))
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
                 .padding(.vertical, theme.spaces.spacePaddingInlineShort)
                 .multilineTextAlignment(layoutDirection == .rightToLeft ? .trailing : .leading)
             // As the source code sample is written in english, keep text aligned on the left
@@ -86,7 +85,7 @@ struct DesignToolboxCode: View {
                     Image("ic_copy")
                         .resizable()
                         .renderingMode(.template)
-                        .foregroundColor(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorContentDefault)
                         .frame(width: 24, height: 24)
                         .alignmentGuide(.firstTextBaseline) { $0[.bottom] * 0.7 }
                         .accessibilityLabel("app_common_copyCode_a11y")
@@ -96,7 +95,7 @@ struct DesignToolboxCode: View {
         .frame(minWidth: 72, maxWidth: .infinity, alignment: .leading)
         .padding(.vertical, theme.spaces.spacePaddingInlineShort)
         .padding(.leading, theme.spaces.spacePaddingInlineMedium)
-        .background(theme.colors.colorBgSecondary.color(for: colorScheme))
+        .oudsBackground(theme.colors.colorBgSecondary)
         .accessibilityElement(children: .combine)
         .accessibilityHint("app_common_copyCode_a11y")
         .overlay(

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxColoredBackgroundModifier.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxColoredBackgroundModifier.swift
@@ -20,15 +20,14 @@ import SwiftUI
 struct DesignToolboxColoredBackgroundModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let coloredSurface: Bool
 
     func body(content: Content) -> some View {
         if coloredSurface {
-            content.oudsColoredSurface(color: theme.colors.colorSurfaceBrandPrimary.color(for: colorScheme))
+            content.oudsColoredSurface(colors: theme.colors.colorSurfaceBrandPrimary)
         } else {
-            content.background(theme.colors.colorBgSecondary.color(for: colorScheme))
+            content.oudsBackground(theme.colors.colorBgSecondary)
         }
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxTextField.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/DesignToolboxTextField.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct DesignToolboxTextField: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     let text: Binding<String>
     let prompt: String
@@ -34,7 +33,7 @@ struct DesignToolboxTextField: View {
         VStack(alignment: .leading) {
             Text(LocalizedStringKey(title))
                 .typeHeadingMedium(theme)
-                .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             TextField(text: text) {
                 Text(LocalizedStringKey(prompt))

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementPage.swift
@@ -24,7 +24,6 @@ struct DesignToolboxElementPage: View {
 
     @AccessibilityFocusState private var requestFocus: Bool
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Stored Properties
 
@@ -54,18 +53,18 @@ struct DesignToolboxElementPage: View {
             .listRowSeparator(Visibility.hidden)
             .padding(.horizontal, theme.spaces.spaceFixedNone)
             .padding(.bottom, theme.spaces.spaceFixedMedium)
-            .background(theme.colors.colorBgPrimary.color(for: colorScheme))
+            .oudsBackground(theme.colors.colorBgPrimary)
 
             illustration
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(Visibility.hidden)
                 .padding(.bottom, theme.spaces.spaceFixedMedium)
-                .background(theme.colors.colorBgPrimary.color(for: colorScheme))
+                .oudsBackground(theme.colors.colorBgPrimary)
         }
         .listStyle(.plain)
         .padding(.top, theme.spaces.spaceFixedNone)
         .padding(.horizontal, theme.spaces.spaceFixedNone)
-        .background(theme.colors.colorBgPrimary.color(for: colorScheme))
+        .oudsBackground(theme.colors.colorBgPrimary)
         .navigationTitle(LocalizedStringKey(name))
         .navigationbarMenuForThemeSelection()
         .oudsRequestAccessibleFocus(_requestFocus)

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementsPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementsPage.swift
@@ -21,7 +21,6 @@ struct DesignToolboxElementsPage: View {
 
     @AccessibilityFocusState private var requestFocus: AccessibilityFocusable?
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
 
     // MARK: Stored properties
 
@@ -48,7 +47,7 @@ struct DesignToolboxElementsPage: View {
                 .padding(.all, theme.spaces.spaceFixedMedium)
                 .navigationbarMenuForThemeSelection()
             }
-            .background(theme.colors.colorBgPrimary.color(for: colorScheme))
+            .oudsBackground(theme.colors.colorBgPrimary)
         }
         .navigationViewStyle(.stack)
     }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxVariantElement.swift
@@ -18,7 +18,6 @@ import SwiftUI
 struct DesignToolboxVariantElement: View {
 
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.layoutDirection) private var layoutDirection
 
     // MARK: Stored properties
@@ -36,12 +35,12 @@ struct DesignToolboxVariantElement: View {
                     Text(LocalizedStringKey(element.name))
                         .typeHeadingMedium(theme)
                         .multilineTextAlignment(.leading)
-                        .foregroundStyle(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundStyle(theme.colors.colorContentDefault)
                         .padding(.vertical, theme.spaces.spaceFixedShorter)
                         .padding(.leading, theme.spaces.spaceFixedMedium)
                     Spacer()
                     Image(systemName: "chevron.right")
-                        .foregroundColor(theme.colors.colorContentDefault.color(for: colorScheme))
+                        .oudsForegroundColor(theme.colors.colorContentDefault)
                         .padding(layoutDirection == .rightToLeft ? .leading : .trailing, theme.spaces.spaceFixedMedium)
                         .accessibilityHidden(true)
                         .scaleEffect(layoutDirection == .rightToLeft ? -1 : 1, anchor: .center)

--- a/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+BackgroundModifier.swift
+++ b/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+BackgroundModifier.swift
@@ -31,7 +31,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     // MARK: Body
 
     func body(content: Content) -> some View {
-        content.background(appliedColor.color(for: colorScheme))
+        content.oudsBackground(appliedColor)
     }
 
     // MARK: Private helpers

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicator.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicator.swift
@@ -63,7 +63,7 @@ struct CheckboxIndicator: View {
             .resizable()
             .scaledToFit()
             .accessibilityHidden(true)
-            .foregroundColor(appliedColor.color(for: colorScheme))
+            .oudsForegroundColor(appliedColor)
     }
 
     private var appliedColor: MultipleColorSemanticTokens {

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicatorModifiers.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicatorModifiers.swift
@@ -57,21 +57,21 @@ private struct CheckboxIndicatorForegroundModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .foregroundColor(appliedColor)
+            .oudsForegroundColor(appliedColor)
     }
 
     // MARK: - Colors
 
-    private var appliedColor: Color {
+    private var appliedColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled:
-            return enabledColor.color(for: colorScheme)
+            return enabledColor
         case .hover:
-            return hoverColor.color(for: colorScheme)
+            return hoverColor
         case .pressed:
-            return pressedColor.color(for: colorScheme)
+            return pressedColor
         case .disabled, .readOnly:
-            return disabledColor.color(for: colorScheme)
+            return disabledColor
         }
     }
 

--- a/OUDS/Core/Components/Sources/Extensions/View+Color.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Color.swift
@@ -25,7 +25,7 @@ extension View {
     public func oudsForegroundStyle(_ color: MultipleColorSemanticTokens) -> some View {
         self.modifier(ColorSchemeBasedForegroundStyle(color: color))
     }
-    
+
     /// Applies a **foreground color** on the current view by using the given tokens of colors.
     /// Uses the current color scheme so as to load the suitable color to apply in the end
     /// - Parameter color: The token from which the color to use must be extracted
@@ -33,13 +33,21 @@ extension View {
     public func oudsForegroundColor(_ color: MultipleColorSemanticTokens) -> some View {
         self.modifier(ColorSchemeBasedForegroundColor(color: color))
     }
-    
+
     /// Applies a **background** on the current view by using the given tokens of colors.
     /// Uses the current color scheme so as to load the suitable color to apply in the end
     /// - Parameter color: The token from which the color to use must be extracted
     /// - Returns: The modified `View`
     public func oudsBackground(_ color: MultipleColorSemanticTokens) -> some View {
         self.modifier(ColorSchemeBasedBackgroundColor(color: color))
+    }
+
+    /// Applies an **accent color** on the current view by using the given tokens of colors.
+    /// Uses the current color scheme so as to load the suitable color to apply in the end
+    /// - Parameter color: The token from which the color to use must be extracted
+    /// - Returns: The modified `View`
+    public func oudsAccentColor(_ color: MultipleColorSemanticTokens) -> some View {
+        self.modifier(ColorSchemeBasedAccentColor(color: color))
     }
 }
 
@@ -48,17 +56,13 @@ extension View {
 /// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
 /// `MultipleColorSemanticTokens` object and applies it as **foreground style** on the calling view.
 private struct ColorSchemeBasedForegroundStyle: ViewModifier {
-    
+
     let color: MultipleColorSemanticTokens
-        
-    private var colorSchemeBasedColor: ColorSemanticToken {
-        colorScheme == .light ? color.light : color.dark
-    }
 
     @Environment(\.colorScheme) private var colorScheme
 
     func body(content: Content) -> some View {
-        content.foregroundStyle(colorSchemeBasedColor.color)
+        content.foregroundStyle(color.color(for: colorScheme))
     }
 }
 
@@ -67,17 +71,13 @@ private struct ColorSchemeBasedForegroundStyle: ViewModifier {
 /// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
 /// `MultipleColorSemanticTokens` object and applies it as **foreground color** on the calling view.
 private struct ColorSchemeBasedForegroundColor: ViewModifier {
-    
+
     let color: MultipleColorSemanticTokens
-        
-    private var colorSchemeBasedColor: ColorSemanticToken {
-        colorScheme == .light ? color.light : color.dark
-    }
 
     @Environment(\.colorScheme) private var colorScheme
 
     func body(content: Content) -> some View {
-        content.foregroundColor(colorSchemeBasedColor.color)
+        content.foregroundColor(color.color(for: colorScheme))
     }
 }
 
@@ -86,16 +86,27 @@ private struct ColorSchemeBasedForegroundColor: ViewModifier {
 /// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
 /// `MultipleColorSemanticTokens` object and applies it as **background color** on the calling view.
 private struct ColorSchemeBasedBackgroundColor: ViewModifier {
-    
+
     let color: MultipleColorSemanticTokens
-        
-    private var colorSchemeBasedColor: ColorSemanticToken {
-        colorScheme == .light ? color.light : color.dark
-    }
 
     @Environment(\.colorScheme) private var colorScheme
 
     func body(content: Content) -> some View {
-        content.background(colorSchemeBasedColor.color)
+        content.background(color.color(for: colorScheme))
+    }
+}
+
+// MARK: - Color Scheme Based Accent Color
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **accent color** on the calling view.
+private struct ColorSchemeBasedAccentColor: ViewModifier {
+
+    let color: MultipleColorSemanticTokens
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.accentColor(color.color(for: colorScheme))
     }
 }

--- a/OUDS/Core/Components/Sources/Extensions/View+Color.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Color.swift
@@ -1,0 +1,101 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSTokensSemantic
+import SwiftUI
+
+// MARK: - Extension of View
+
+extension View {
+
+    /// Applies a **foreground style** on the current view by using the given tokens of colors.
+    /// Uses the current color scheme so as to load the suitable color to apply in the end
+    /// - Parameter color: The token from which the color to use must be extracted
+    /// - Returns: The modified `View`
+    public func oudsForegroundStyle(_ color: MultipleColorSemanticTokens) -> some View {
+        self.modifier(ColorSchemeBasedForegroundStyle(color: color))
+    }
+    
+    /// Applies a **foreground color** on the current view by using the given tokens of colors.
+    /// Uses the current color scheme so as to load the suitable color to apply in the end
+    /// - Parameter color: The token from which the color to use must be extracted
+    /// - Returns: The modified `View`
+    public func oudsForegroundColor(_ color: MultipleColorSemanticTokens) -> some View {
+        self.modifier(ColorSchemeBasedForegroundColor(color: color))
+    }
+    
+    /// Applies a **background** on the current view by using the given tokens of colors.
+    /// Uses the current color scheme so as to load the suitable color to apply in the end
+    /// - Parameter color: The token from which the color to use must be extracted
+    /// - Returns: The modified `View`
+    public func oudsBackground(_ color: MultipleColorSemanticTokens) -> some View {
+        self.modifier(ColorSchemeBasedBackgroundColor(color: color))
+    }
+}
+
+// MARK: - Color Scheme Based Foreground Style
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **foreground style** on the calling view.
+private struct ColorSchemeBasedForegroundStyle: ViewModifier {
+    
+    let color: MultipleColorSemanticTokens
+        
+    private var colorSchemeBasedColor: ColorSemanticToken {
+        colorScheme == .light ? color.light : color.dark
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.foregroundStyle(colorSchemeBasedColor.color)
+    }
+}
+
+// MARK: - Color Scheme Based Foreground Color
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **foreground color** on the calling view.
+private struct ColorSchemeBasedForegroundColor: ViewModifier {
+    
+    let color: MultipleColorSemanticTokens
+        
+    private var colorSchemeBasedColor: ColorSemanticToken {
+        colorScheme == .light ? color.light : color.dark
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.foregroundColor(colorSchemeBasedColor.color)
+    }
+}
+
+// MARK: - Color Scheme Based Background Color
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **background color** on the calling view.
+private struct ColorSchemeBasedBackgroundColor: ViewModifier {
+    
+    let color: MultipleColorSemanticTokens
+        
+    private var colorSchemeBasedColor: ColorSemanticToken {
+        colorScheme == .light ? color.light : color.dark
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.background(colorSchemeBasedColor.color)
+    }
+}

--- a/OUDS/Core/Components/Sources/Extensions/View+Shadow.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Shadow.swift
@@ -15,6 +15,8 @@ import OUDSTokensRaw
 import OUDSTokensSemantic
 import SwiftUI
 
+// MARK: - Extension of View
+
 extension View {
 
     /// Wraps the *SwiftUI* `shadow(color:radius:x:y)` method so as to use as `radius` value
@@ -27,6 +29,8 @@ extension View {
         self.modifier(ColorSchemeBasedElevationViewModifier(elevation: elevation))
     }
 }
+
+// MARK: - Color Scheme Based Elevation View Modifier
 
 /// Depending to the current color scheme, will load the expected `ElevationCompositeRawToken` from the given
 /// `MultipleElevationCompositeRawTokens` object and applies its values to draw a shadow effect.

--- a/OUDS/Core/Components/Sources/Extensions/View+Shadow.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Shadow.swift
@@ -25,7 +25,7 @@ extension View {
     ///
     /// - Parameter elevation: The token to give for the shadow / elevation effect depending to the color scheme
     /// - Returns `View`: The current `View` with the shadow / elevation effect
-    public func shadow(elevation: MultipleElevationCompositeRawTokens) -> some View {
+    public func oudsShadow(_ elevation: MultipleElevationCompositeRawTokens) -> some View {
         self.modifier(ColorSchemeBasedElevationViewModifier(elevation: elevation))
     }
 }
@@ -39,7 +39,7 @@ private struct ColorSchemeBasedElevationViewModifier: ViewModifier {
     let elevation: MultipleElevationCompositeRawTokens
 
     private var colorSchemeBasedElevation: ElevationCompositeRawToken {
-        colorScheme == .light ? elevation.light : elevation.dark
+        elevation.elevation(for: colorScheme)
     }
 
     @Environment(\.colorScheme) private var colorScheme

--- a/OUDS/Core/Components/Sources/Extensions/View+Shadows.swift
+++ b/OUDS/Core/Components/Sources/Extensions/View+Shadows.swift
@@ -12,18 +12,38 @@
 //
 
 import OUDSTokensRaw
+import OUDSTokensSemantic
 import SwiftUI
 
 extension View {
 
     /// Wraps the *SwiftUI* `shadow(color:radius:x:y)` method so as to use as `radius` value
-    /// the computed `radius` value of the given `ElevationCompositeRawToken`.
-    /// - Parameter elevation: The token to give for the shadow / elevation effect
+    /// the computed `radius` value of the  `MultipleElevationCompositeRawTokens` to use.
+    /// This token will be choosen from the color scheme in use.
+    ///
+    /// - Parameter elevation: The token to give for the shadow / elevation effect depending to the color scheme
     /// - Returns `View`: The current `View` with the shadow / elevation effect
-    public func shadow(elevation: ElevationCompositeRawToken) -> some View {
-        self.shadow(color: elevation.color.color,
-                    radius: elevation.radius,
-                    x: CGFloat(elevation.x),
-                    y: CGFloat(elevation.y))
+    public func shadow(elevation: MultipleElevationCompositeRawTokens) -> some View {
+        self.modifier(ColorSchemeBasedElevationViewModifier(elevation: elevation))
+    }
+}
+
+/// Depending to the current color scheme, will load the expected `ElevationCompositeRawToken` from the given
+/// `MultipleElevationCompositeRawTokens` object and applies its values to draw a shadow effect.
+private struct ColorSchemeBasedElevationViewModifier: ViewModifier {
+
+    let elevation: MultipleElevationCompositeRawTokens
+
+    private var colorSchemeBasedElevation: ElevationCompositeRawToken {
+        colorScheme == .light ? elevation.light : elevation.dark
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.shadow(color: colorSchemeBasedElevation.color.color,
+                       radius: colorSchemeBasedElevation.radius,
+                       x: CGFloat(colorSchemeBasedElevation.x),
+                       y: CGFloat(colorSchemeBasedElevation.y))
     }
 }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
@@ -51,7 +51,7 @@ struct ControlItemContent: View {
             }
         }
         .padding(.all, theme.controlItem.controlItemSpaceInset)
-        .background(backgroundColor)
+        .oudsBackground(backgroundColor)
         .modifier(ControlItemBordersModifier(interactionState: interactionState, layoutData: layoutData, isOn: isOn))
     }
 
@@ -80,16 +80,16 @@ struct ControlItemContent: View {
         }
     }
 
-    private var backgroundColor: Color {
+    private var backgroundColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled:
-            theme.select.selectColorBgEnabled.color(for: colorScheme)
+            theme.select.selectColorBgEnabled
         case .hover:
-            theme.select.selectColorBgHover.color(for: colorScheme)
+            theme.select.selectColorBgHover
         case .pressed:
-            theme.select.selectColorBgPressed.color(for: colorScheme)
+            theme.select.selectColorBgPressed
         case .disabled, .readOnly:
-            theme.select.selectColorBgDisabled.color(for: colorScheme)
+            theme.select.selectColorBgDisabled
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemIconContainer.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemIconContainer.swift
@@ -11,6 +11,7 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System 
 //
 
+import OUDSTokensSemantic
 import SwiftUI
 
 /// This is the icon container of the ControlItem.
@@ -36,7 +37,7 @@ struct ControlItemIconContainer: View {
                 icon
                     .resizable()
                     .renderingMode(.template)
-                    .foregroundStyle(iconColor)
+                    .oudsForegroundStyle(iconColor)
                     .frame(width: theme.controlItem.controlItemSizeIcon, height: theme.controlItem.controlItemSizeIcon)
             }
             .frame(maxHeight: theme.controlItem.controlItemSizeMaxHeightAssetsContainer, alignment: .center)
@@ -45,12 +46,12 @@ struct ControlItemIconContainer: View {
 
     // MARK: - Colors
 
-    private var iconColor: Color {
+    private var iconColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled, .pressed, .hover, .readOnly:
-            theme.colors.colorContentDefault.color(for: colorScheme)
+            theme.colors.colorContentDefault
         case .disabled:
-            theme.colors.colorContentDisabled.color(for: colorScheme)
+            theme.colors.colorContentDisabled
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemLabel.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemLabel.swift
@@ -58,21 +58,21 @@ struct ControlItemLabel: View {
             Text(LocalizedStringKey(layoutData.labelText))
                 .typeLabelDefaultLarge(theme)
                 .multilineTextAlignment(.leading)
-                .foregroundStyle(labelTextColor)
+                .oudsForegroundStyle(labelTextColor)
                 .frame(maxWidth: .infinity, alignment: .leading)
 
             if let additionalLabelText = layoutData.additionalLabelText {
                 Text(LocalizedStringKey(additionalLabelText))
                     .typeLabelStrongMedium(theme)
                     .multilineTextAlignment(.leading)
-                    .foregroundStyle(additionalLabelTextColor)
+                    .oudsForegroundStyle(additionalLabelTextColor)
             }
 
             if let helperText = layoutData.helperText {
                 Text(LocalizedStringKey(helperText))
                     .typeLabelDefaultMedium(theme)
                     .multilineTextAlignment(.leading)
-                    .foregroundStyle(helperTextColor)
+                    .oudsForegroundStyle(helperTextColor)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -80,15 +80,15 @@ struct ControlItemLabel: View {
 
     // MARK: - Colors
 
-    private var labelTextColor: Color {
+    private var labelTextColor: MultipleColorSemanticTokens {
         if layoutData.isError {
             switch interactionState {
             case .enabled:
-                return theme.colors.colorActionNegativeEnabled.color(for: colorScheme)
+                return theme.colors.colorActionNegativeEnabled
             case .hover:
-                return theme.colors.colorActionNegativeHover.color(for: colorScheme)
+                return theme.colors.colorActionNegativeHover
             case .pressed:
-                return theme.colors.colorActionNegativePressed.color(for: colorScheme)
+                return theme.colors.colorActionNegativePressed
             case .readOnly, .disabled:
                 OL.fatal("An component (checkbox, switch, radio) with a disabled state / read only mode and an error situation has been detected, which is not allowed by design."
                              + " Only non-error situation are allowed to have a disabled state or a read only mode.")
@@ -96,24 +96,23 @@ struct ControlItemLabel: View {
         } else {
             switch interactionState {
             case .enabled, .hover, .pressed, .readOnly:
-                return theme.colors.colorContentDefault.color(for: colorScheme)
+                return theme.colors.colorContentDefault
             case .disabled:
-                return theme.colors.colorContentDisabled.color(for: colorScheme)
+                return theme.colors.colorContentDisabled
             }
         }
     }
 
-    private var helperTextColor: Color {
+    private var helperTextColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled, .pressed, .hover, .readOnly:
-            theme.colors.colorContentMuted.color(for: colorScheme)
+            theme.colors.colorContentMuted
         case .disabled:
-            theme.colors.colorContentDisabled.color(for: colorScheme)
+            theme.colors.colorContentDisabled
         }
     }
 
-    private var additionalLabelTextColor: Color {
-        (interactionState == .disabled ? theme.colors.colorContentDisabled : theme.colors.colorContentDefault)
-        .color(for: colorScheme)
+    private var additionalLabelTextColor: MultipleColorSemanticTokens {
+        interactionState == .disabled ? theme.colors.colorContentDisabled : theme.colors.colorContentDefault
     }
 }

--- a/OUDS/Core/Components/Sources/Link/Internal/LinkColorArrowModifier.swift
+++ b/OUDS/Core/Components/Sources/Link/Internal/LinkColorArrowModifier.swift
@@ -29,21 +29,21 @@ struct LinkColorArrowModifier: ViewModifier {
     // MARK: - Body
 
     func body(content: Content) -> some View {
-        content.foregroundStyle(appliedColor)
+        content.oudsForegroundStyle(appliedColor)
     }
 
     // MARK: - Helpers
 
-    private var appliedColor: Color {
+    private var appliedColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled:
-            enabledColor.color(for: colorScheme)
+            enabledColor
         case .hover:
-            hoverColor.color(for: colorScheme)
+            hoverColor
         case .pressed:
-            pressedColor.color(for: colorScheme)
+            pressedColor
         case .disabled, .readOnly:
-            disabledColor.color(for: colorScheme)
+            disabledColor
         }
     }
 

--- a/OUDS/Core/Components/Sources/Link/Internal/LinkColorContentModifier.swift
+++ b/OUDS/Core/Components/Sources/Link/Internal/LinkColorContentModifier.swift
@@ -29,21 +29,21 @@ struct LinkColorContentModifier: ViewModifier {
     // MARK: - Body
 
     func body(content: Content) -> some View {
-        content.foregroundStyle(appliedColor)
+        content.oudsForegroundStyle(appliedColor)
     }
 
     // MARK: - Helpers
 
-    private var appliedColor: Color {
+    private var appliedColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled:
-            enabledColor.color(for: colorScheme)
+            enabledColor
         case .hover:
-            hoverColor.color(for: colorScheme)
+            hoverColor
         case .pressed:
-            pressedColor.color(for: colorScheme)
+            pressedColor
         case .disabled, .readOnly:
-            disabledColor.color(for: colorScheme)
+            disabledColor
         }
     }
 

--- a/OUDS/Core/Components/Sources/Radio/Internal/RadioIndicatorModifiers.swift
+++ b/OUDS/Core/Components/Sources/Radio/Internal/RadioIndicatorModifiers.swift
@@ -56,21 +56,21 @@ private struct RadioIndicatorForegroundModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .foregroundColor(appliedColor)
+            .oudsForegroundColor(appliedColor)
     }
 
     // MARK: - Colors
 
-    private var appliedColor: Color {
+    private var appliedColor: MultipleColorSemanticTokens {
         switch interactionState {
         case .enabled:
-            return enabledColor.color(for: colorScheme)
+            return enabledColor
         case .hover:
-            return hoverColor.color(for: colorScheme)
+            return hoverColor
         case .pressed:
-            return pressedColor.color(for: colorScheme)
+            return pressedColor
         case .disabled, .readOnly:
-            return disabledColor.color(for: colorScheme)
+            return disabledColor
         }
     }
 

--- a/OUDS/Core/Components/Sources/ViewModifiers/BorderModifiers/BorderModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/BorderModifiers/BorderModifier.swift
@@ -32,11 +32,6 @@ struct BorderModifier: ViewModifier {
     /// The color token used for the border
     private let color: MultipleColorSemanticTokens
 
-    /// Color to apply depending to the `colorScheme`
-    private var colorToApply: Color {
-        color.color(for: colorScheme)
-    }
-
     /// To know if the device is in light mode or in dark mode
     @Environment(\.colorScheme) private var colorScheme
 
@@ -77,7 +72,7 @@ struct BorderModifier: ViewModifier {
     private func solid(_ content: Content) -> some View {
         content
             .clipShape(RoundedRectangle(cornerRadius: radius))
-            .overlay(RoundedRectangle(cornerRadius: radius).stroke(colorToApply, lineWidth: width))
+            .overlay(RoundedRectangle(cornerRadius: radius).stroke(color.color(for: colorScheme), lineWidth: width))
     }
 
     private func dashed(_ content: Content) -> some View {
@@ -85,7 +80,7 @@ struct BorderModifier: ViewModifier {
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(RoundedRectangle(cornerRadius: radius)
                 .stroke(style: StrokeStyle(lineWidth: width, dash: [2, 2]))
-                .foregroundColor(colorToApply)
+                .oudsForegroundColor(color)
             )
     }
 
@@ -94,7 +89,7 @@ struct BorderModifier: ViewModifier {
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(RoundedRectangle(cornerRadius: radius)
                 .stroke(style: StrokeStyle(lineWidth: width, dash: [1, 5]))
-                .foregroundColor(colorToApply)
+                .oudsForegroundColor(color)
             )
     }
 }

--- a/OUDS/Core/Components/Sources/ViewModifiers/DividerModifier/DividerModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/DividerModifier/DividerModifier.swift
@@ -37,7 +37,7 @@ public struct DividerModifier: ViewModifier {
         if show {
             VStack(spacing: 0) {
                 content
-                Divider().foregroundStyle(theme.colors.colorBorderDefault.color(for: colorScheme))
+                Divider().oudsForegroundStyle(theme.colors.colorBorderDefault)
             }
         } else {
             content

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -10,15 +10,14 @@ The unified design system implemented by OUDS iOS library allows to apply *eleva
 Because the design tool in use is _Figma_ which defines such shadow with a _blur_ and a _spread_ radiuses, and because _SwiftUI_ uses only its own _radius_ definition, an extension of `View` has been implemented to let users apply some effect using an [`ElevationCompositeSemanticToken`](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/elevationcompositesemantictoken) from the [OUDSTokensSemantic](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/) library thanks to the method `shadow(elevation: ElevationCompositeSemanticToken)`.
 
 ```swift
-// For example, apply the elevation effect "elevationDragLight" from your theme:
-myView.shadow(elevation: theme.elevationDragLight)
+// For example, apply the elevation effect "elevationDrag" from your theme:
+myView.oudsShadow(theme.elevations.elevationDrag)
 
-// And in the theme this "elevationDragLight" has been defined for example like:
-@objc open var elevationDragLight: ElevationCompositeSemanticToken { ElevationRawTokens.elevationBottom_3_500 }
-ColorRawTokens.colorOpacityBlack400)
+// And in the theme this "elevationDrag" has been defined for example like:
+@objc open var elevationDrag: ElevationCompositeSemanticToken { ElevationCompositeSemanticToken(ElevationRawTokens.elevationBottom_3_500) }
 
 // And if you look deeper, the raw token "elevationBottom_3_500" can be like:
-public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: 0, y: 4, blur: 4, color: ColorRawTokens.colorOpacityBlack500)
+public static let elevationBottom_3_500 = ElevationCompositeRawToken(x: elevationX0, y: elevationY300, blur: elevationBlur400, color: ColorRawTokens.colorOpacityBlack320)
 
 // Blur will be used to compute the radius value
 ```
@@ -74,6 +73,30 @@ The helper is available through `View`, and tokens through the provider of the t
              radius: theme.borders.borderRadiusNone,
              color: theme.colors.colorBorderDefault)
      }
+```
+
+### Apply specific colors
+
+Colors can be applied on view for background and foreground colors, foreground style or also accent color.
+Some helpers are available in the OUDS API to avoid to use the `color(for:ColorScheme)` method.
+
+```swift
+    // Given a color at theme.colors.colorBgPrimary
+    // This token can have light and dark declinations 
+
+    @Environment(\.theme) private var theme
+
+    // Apply a foreground style
+    someView.oudsForegroundStyle(theme.colors.colorBgPrimary)
+
+    // Apply a foreground color
+    someView.oudsForegroundColor(theme.colors.colorBgPrimary)
+
+    // Apply a background
+    someView.oudsBackground(theme.colors.colorBgPrimary)
+
+    // Apply an accent color
+    someView.oudsAccentColor(theme.colors.colorBgPrimary)
 ```
 
 ## Topics

--- a/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSColoredSurface.swift
+++ b/OUDS/Core/OUDS/Sources/OUDSTheme/OUDSColoredSurface.swift
@@ -11,7 +11,10 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System 
 //
 
+import OUDSTokensSemantic
 import SwiftUI
+
+// MARK: - OUDS Colored Surface
 
 /// Used to define if a content is used on a colored surface.
 ///
@@ -54,6 +57,8 @@ public struct OUDSColoredSurface<Content>: View where Content: View {
     }
 }
 
+// MARK: - Extension of View$
+
 extension View {
 
     /// Helper to set the current view on colored surface based on ``OUDSColoredSurface``.
@@ -63,6 +68,50 @@ extension View {
         self
             .background(color)
             .environment(\.oudsOnColoredSurface, true)
+    }
+
+    /// Helper to set the current view on colored surface based on ``OUDSColoredSurface``.
+    /// Applied colors will depend to current color scheme.
+    ///
+    /// - Parameter token: The tokens of colors applied as background on the current view.
+    public func oudsColoredSurface(colors token: MultipleColorSemanticTokens) -> some View {
+        self
+            .modifier(ColorSchemeBasedBackgroundColor(color: token))
+            .environment(\.oudsOnColoredSurface, true)
+    }
+}
+
+// MARK: - Color Scheme Based Background Color
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **background** on the calling view.
+private struct ColorSchemeBasedBackgroundColor: ViewModifier {
+
+    let color: MultipleColorSemanticTokens
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.background(color.color(for: colorScheme))
+    }
+}
+
+// MARK: - Color Scheme Based Foreground Style
+
+/// Depending to the current color scheme, will load the expected `ColorSemanticToken` from the given
+/// `MultipleColorSemanticTokens` object and applies it as **foreground style** on the calling view.
+private struct ColorSchemeBasedForegroundStyle: ViewModifier {
+
+    let color: MultipleColorSemanticTokens
+
+    private var colorSchemeBasedColor: ColorSemanticToken {
+        colorScheme == .light ? color.light : color.dark
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content.foregroundStyle(colorSchemeBasedColor.color)
     }
 }
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorSemanticTokens.swift
@@ -40,6 +40,26 @@ import SwiftUI
 ///         // It is recommended to use the higher level version as it is less error-prone.
 /// ```
 ///
+///
+/// ```swift
+///      @Environment(\.theme) var theme
+///      @Environment(\.colorScheme) var colorScheme
+///
+///     // Given you want to apply the color token "colorSurfaceBrandPrimary"
+///     var body: some View {
+///         // Apply the token of color for the view without managing yourself the color scheme
+///         SomeView()
+///             .oudsBackground(theme.colors.colorSurfaceBrandPrimary)
+///
+///         // Or also oudsForegroundtyle(), oudsForegroundColor(), oudsAccentColor(), ...
+///     }
+/// ```
+///
+/// ```swift
+///     // Or get the token depending to the color scheme and do whatever you want with
+///     theme.colors.colorSurfaceBrandPrimary.color(for: colorScheme)
+/// ```
+///
 /// - Since: 0.8.0
 public final class MultipleColorSemanticTokens: NSObject, Sendable {
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawTokens.swift
@@ -83,13 +83,6 @@ public final class MultipleElevationCompositeRawTokens: NSObject, Sendable {
         guard let other = object as? MultipleElevationCompositeRawTokens else { return false }
         return self.light == other.light && self.dark == other.dark
     }
-
-    /// Returns the right elevation according to the `colorScheme`.
-    /// - Parameter colorScheme: The color scheme
-    /// - Returns: The `ElevationCompositeRawToken` to use depending to `colorScheme`
-    public func elevation(for colorScheme: ColorScheme) -> ElevationCompositeRawToken {
-        (colorScheme == .light ? light : dark)
-    }
 }
 
 // swiftlint:enable line_length

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawTokens.swift
@@ -30,8 +30,8 @@ import SwiftUI
 ///
 ///         // Then the develoment team declares an "higher" level elevation semantic token
 ///         // inside ElevationCompositeSemanticTokens protocol,
-///         // and defined inside OUDSTheme+ElevationCompositeSemanticTokens extension
-///         // ElevationCompositeSemanticToken is a typealias for MultipleElevationCompositeRawTokens to keep same grammar as dsign kit
+///         // and defined inside OrangeTheme+ElevationCompositeSemanticTokens extension
+///         // ElevationCompositeSemanticToken is a typealias for MultipleElevationCompositeRawTokens to keep same grammar as design kit
 ///         var elevationNone: ElevationCompositeSemanticToken {
 ///             ElevationCompositeSemanticToken(light: elevationBottom_0, dark: elevationBottom_1_100)
 ///         }
@@ -40,9 +40,26 @@ import SwiftUI
 ///         var elevationNone: ElevationCompositeSemanticToken {
 ///             ElevationCompositeSemanticToken(elevationBottom_0)
 ///         }
+/// ```
 ///
+/// ```swift
 ///         // The theme exposes both generated elevation semantic tokens and "crafted" higher level elevation semantic tokens.
 ///         // It is recommended to use the higher level version as it is less error-prone.
+///
+///         @Environment(\.theme) var theme
+///         @Environment(\.colorScheme) var colorScheme
+///
+///         // Given you want to apply the elevation token "elevationRaised"
+///         var body: some View {
+///             // Apply the token of elevation for the shadow effect without managing yourself the color scheme
+///             Rectangle()
+///                 .shadow(elevation: theme.elevations.elevationRaised))
+///         }
+/// ```
+///
+/// ```swift
+///     // Or get the token depending to the color scheme and do whatever you want with
+///     theme.elevations.elevationRaised.elevation(for: colorScheme)
 /// ```
 ///
 /// The case of this `MultipleElevationCompositeRawTokens` is quite particular because in fact it contains `MultipleElevationCompositeRawTokens` (i.e. raw tokens) instead of semantic tokens.
@@ -82,6 +99,13 @@ public final class MultipleElevationCompositeRawTokens: NSObject, Sendable {
     override public func isEqual(_ object: Any?) -> Bool {
         guard let other = object as? MultipleElevationCompositeRawTokens else { return false }
         return self.light == other.light && self.dark == other.dark
+    }
+
+    /// Returns the right elevation according to the `colorScheme`.
+    /// - Parameter colorScheme: The color scheme
+    /// - Returns: The `ElevationCompositeRawToken` to use depending to `colorScheme`
+    public func elevation(for colorScheme: ColorScheme) -> ElevationCompositeRawToken {
+        (colorScheme == .light ? light : dark)
     }
 }
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ElevationCompositeSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ElevationCompositeSemanticTokens.swift
@@ -27,7 +27,7 @@
 /// This `ElevationCompositeRawToken` is not managed by tokenator yet as it is composed by three properties.
 ///
 /// This ``ElevationCompositeSemanticTokens`` protocol contains a set of ``ElevationCompositeSemanticToken``.
-/// They can be applied to views and components using `shadow(elevation:)` and `elevation(for:)`:
+/// They can be applied to views and components using `shadow(elevation:)` or `elevation(for:)`:
 ///
 /// ```swift
 ///      @Environment(\.theme) var theme
@@ -35,10 +35,15 @@
 ///
 ///     // Given you want to apply the elevation token "elevationRaised"
 ///     var body: some View {
+///         // Apply the token of elevation for the shadow effect without managing yourself the color scheme
 ///         Rectangle()
-///             .shadow(elevation: theme.elevations.elevationRaised.elevation(for: colorScheme))
-///         // Or use .light or .dark instead of elevation(for:)
+///             .shadow(elevation: theme.elevations.elevationRaised))
 ///     }
+/// ```
+///
+/// ```swift
+///     // Or get the token depending to the color scheme and do whatever you want with
+///     theme.elevations.elevationRaised.elevation(for: colorScheme)
 /// ```
 ///
 /// - Since: 0.8.0


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#146 (discussion 574)

### Description

<!-- Describe your changes in detail -->
- New methods in public API to apply foreground colors and style, accent and backgound colors, with the user of view modifiers using the color scheme
- Utilities are kept so as to use theme elsewhere

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
- Better developer expeience, les code to write for them

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
