### PR TITLE
[#609] Refactor init of `OUDSButton` with default hierarchy and style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [Library] Default hierarchy and style for button component ([#609](https://github.com/Orange-OpenSource/ouds-ios/issues/609))
 - [DesignToolbox] Rename checkbox and radio button entries ([#584](https://github.com/Orange-OpenSource/ouds-ios/issues/584))
 - [DesignToolbox] Rename the radio buton component ([#583](https://github.com/Orange-OpenSource/ouds-ios/issues/583))
-- [Library] Default hierarchy and style for button component ([#609](https://github.com/Orange-OpenSource/ouds-ios/issues/609))
 - [Tool] Update `fastlane` gem from v2.227.0 to v2.227.1
 - [Tool] Update `SwiftLint` pod from v0.58.2 to v0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [DesignToolbox] Rename checkbox and radio button entries ([#584](https://github.com/Orange-OpenSource/ouds-ios/issues/584))
 - [DesignToolbox] Rename the radio buton component ([#583](https://github.com/Orange-OpenSource/ouds-ios/issues/583))
+- [Library] Default hierarchy and style for button component ([#609](https://github.com/Orange-OpenSource/ouds-ios/issues/609))
 - [Tool] Update `fastlane` gem from v2.227.0 to v2.227.1
 - [Tool] Update `SwiftLint` pod from v0.58.2 to v0.59.0
 

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -22,7 +22,7 @@ import SwiftUI
 ///
 /// Four hierarchies are proposed for all layouts:
 ///
-/// - **defaul (by default)t**: Default buttons are used for actions which are not mandatory or essential for the user.
+/// - **default (by default)**: Default buttons are used for actions which are not mandatory or essential for the user.
 ///
 /// - **strong**: The Strong "call for action" on the page should be singular and prominent, limited to one per view.
 /// It should be reserved for the most critical action, such as "Next," "Save," "Submit," etc.
@@ -115,9 +115,9 @@ public struct OUDSButton: View {
     ///
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
-    ///    - text: The text to display in the button, default set to `.default`
+    ///    - text: The text to display in the button
     ///    - hierarchy: The button hierarchy, default set to `.default`
-    ///    - style: The button style
+    ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
     public init(icon: Image, text: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
         self.type = .textAndIcon(text: text, icon: icon)

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -22,7 +22,7 @@ import SwiftUI
 ///
 /// Four hierarchies are proposed for all layouts:
 ///
-/// - **default**: Default buttons are used for actions which are not mandatory or essential for the user.
+/// - **defaul (by default)t**: Default buttons are used for actions which are not mandatory or essential for the user.
 ///
 /// - **strong**: The Strong "call for action" on the page should be singular and prominent, limited to one per view.
 /// It should be reserved for the most critical action, such as "Next," "Save," "Submit," etc.
@@ -37,20 +37,27 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only with default hierarchy
-///     OUDSButton(hierarchy: .default, icon: Image("ic_heart")) { /* the action to process */ }
+///     OUDSButton(icon: Image("ic_heart"), hierarchy: .default) { /* the action to process */ }
+///     // Or simpler
+///     OUDSButton(icon: Image("ic_heart")) { /* the action to process */ }
 ///
 ///     // Text only with negative hierarchy
-///     OUDSButton(hierarchy: .negative, text: "Delete") { /* the action to process */ }
+///     OUDSButton(text: "Delete", hierarchy: .negative,  style: .default) { /* the action to process */ }
+///     // Or simpler
+///     OUDSButton(text: "Delete", hierarchy: .negative) { /* the action to process */ }
+///
+///     // A loading button
+///     OUDSButton(text: "Delete", style: .loading) { /* the action to process */ }
 ///
 ///     // Text and icon with strong hierarchy
-///     OUDSButton(hierarchy: .strong, icon: Image("ic_heart"), text: "Validate") { /* the action to process */ }
+///     OUDSButton(icon: Image("ic_heart"), text: "Validate", hierarchy: .strong) { /* the action to process */ }
 /// ```
 ///
 /// ## Styles
 ///
 /// Two style are available:
 ///
-/// - **default**: used in the normal usage of button. The aspect of the button changes for following states disabled, pressed, hovered or normal (i.e. enabled)
+/// - **default (by default)**: used in the normal usage of button. The aspect of the button changes for following states disabled, pressed, hovered or normal (i.e. enabled)
 /// - **loading**: used after button was clicked and probably data are requested before navigate to a next screen or get updated data.
 ///
 /// ## Colored Surface
@@ -108,11 +115,11 @@ public struct OUDSButton: View {
     ///
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
-    ///    - text: The text to display in the button
-    ///    - hierarchy: The button hierarchy
+    ///    - text: The text to display in the button, default set to `.default`
+    ///    - hierarchy: The button hierarchy, default set to `.default`
     ///    - style: The button style
     ///    - action: The action to perform when the user triggers the button
-    public init(icon: Image, text: String, hierarchy: Hierarchy, style: Style, action: @escaping () -> Void) {
+    public init(icon: Image, text: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
         self.type = .textAndIcon(text: text, icon: icon)
         self.hierarchy = hierarchy
         self.style = style
@@ -124,10 +131,10 @@ public struct OUDSButton: View {
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
     ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the button action
-    ///    - hierarchy: The button hierarchy
-    ///    - style: The button style
+    ///    - hierarchy: The button hierarchy, default set to `.default`
+    ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
-    public init(icon: Image, accessibilityLabel: String, hierarchy: Hierarchy, style: Style, action: @escaping () -> Void) {
+    public init(icon: Image, accessibilityLabel: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
         self.type = .icon(icon, accessibilityLabel)
         self.hierarchy = hierarchy
         self.style = style
@@ -138,10 +145,10 @@ public struct OUDSButton: View {
     ///
     /// - Parameters:
     ///    - text: The text of the button to display
-    ///    - hierarchy: The button hierarchy
-    ///    - style: The button style
+    ///    - hierarchy: The button hierarchy, default set to `.default`
+    ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
-    public init(text: String, hierarchy: Hierarchy, style: Style, action: @escaping () -> Void) {
+    public init(text: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
         self.type = .text(text)
         self.hierarchy = hierarchy
         self.style = style

--- a/OUDS/Core/Components/Sources/ColoredSurface/OUDSColoredSurface.swift
+++ b/OUDS/Core/Components/Sources/ColoredSurface/OUDSColoredSurface.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///
 /// ```swift
 ///   OUDSColoredSurface(color: theme.colorModes.modeOnBrandPrimary) {
-///      OUDSButton(icon: Image("ic_heart"), hierarchy: .strong, state: .default) {}
+///      OUDSButton(icon: Image("ic_heart"), hierarchy: .strong) {}
 ///   }
 /// ```
 ///

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
@@ -14,8 +14,8 @@ A button with `OUDSButton.Hierarchy.Negative` hierarchy is not allowed as a dire
 
 ```swift
      // Icon only with default hierarchy
-     OUDSButton(hierarchy: .default, icon: Image("ic_heart")) {}
+     OUDSButton(icon: Image("ic_heart"), hierarchy: .default) {}
 
      // Text only with negative hierarchy
-     OUDSButton(hierarchy: .negative, text: "Delete") {}
+     OUDSButton(text: "Delete", hierarchy: .negative) {}
 ```


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#609 

### Description

<!-- Describe your changes in detail -->
Init of `OUDSButton` has been simplified wirh default hiarchy and style

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Keep API simple

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
