### PR TITLE
[#585] Sort tokens and component in design toolbox by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [DesignToolbox] Order of components and tokens in design toolbox component page ([#585](https://github.com/Orange-OpenSource/ouds-ios/issues/585))
 - [Library] Default hierarchy and style for button component ([#609](https://github.com/Orange-OpenSource/ouds-ios/issues/609))
 - [DesignToolbox] Rename checkbox and radio button entries ([#584](https://github.com/Orange-OpenSource/ouds-ios/issues/584))
 - [DesignToolbox] Rename the radio buton component ([#583](https://github.com/Orange-OpenSource/ouds-ios/issues/583))
-- [DesignToolbox] Order of components and tokens in design toolbox component page ([#585](https://github.com/Orange-OpenSource/ouds-ios/issues/585))
 - [Tool] Update `fastlane` gem from v2.227.0 to v2.227.1
 - [Tool] Update `SwiftLint` pod from v0.58.2 to v0.59.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [Library] Default hierarchy and style for button component ([#609](https://github.com/Orange-OpenSource/ouds-ios/issues/609))
 - [DesignToolbox] Rename checkbox and radio button entries ([#584](https://github.com/Orange-OpenSource/ouds-ios/issues/584))
 - [DesignToolbox] Rename the radio buton component ([#583](https://github.com/Orange-OpenSource/ouds-ios/issues/583))
+- [DesignToolbox] Order of components and tokens in design toolbox component page ([#585](https://github.com/Orange-OpenSource/ouds-ios/issues/585))
 - [Tool] Update `fastlane` gem from v2.227.0 to v2.227.1
 - [Tool] Update `SwiftLint` pod from v0.58.2 to v0.59.0
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Button/ButtonElement.swift
@@ -19,7 +19,7 @@ struct ButtonElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_components_button_label"
+        name = "app_components_button_label".localized()
         image = Image(decorative: "il_component_button").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
                 name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxElements.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxElements.swift
@@ -29,7 +29,7 @@ struct CheckboxElements: DesignToolboxElement {
             CheckboxItemIndeterminateElement(),
         ]
 
-        name = "app_components_checkbox_label"
+        name = "app_components_checkbox_label".localized()
         image = Image(decorative: "il_component_checkbox").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Components/ColoredSurface/ColoredSurfaceElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/ColoredSurface/ColoredSurfaceElement.swift
@@ -19,7 +19,7 @@ struct ColoredSurfaceElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_components_coloredSurface_label"
+        name = "app_components_coloredSurface_label".localized()
         image = Image(decorative: "il_components_colored_background").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
                 name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Components/ComponentsPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/ComponentsPage.swift
@@ -26,7 +26,7 @@ struct ComponentsPage: View {
     ]
 
     var body: some View {
-        DesignToolboxElementsPage(elements: componentElements)
+        DesignToolboxElementsPage(elements: componentElements.sorted(by: { $0.name < $1.name }))
             .oudsNavigationTitle("app_bottomBar_components_label")
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkElement.swift
@@ -20,7 +20,7 @@ struct LinkElement: DesignToolboxElement {
 
     init() {
         name = "app_components_link_label".localized()
-        image = Image(decorative: "il_components_link").renderingMode(.original)
+        image = Image(decorative: "il_component_link").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
                 name: name,
                 image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Link/LinkElement.swift
@@ -19,8 +19,8 @@ struct LinkElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_components_link_label"
-        image = Image(decorative: "il_component_link").renderingMode(.original)
+        name = "app_components_link_label".localized()
+        image = Image(decorative: "il_components_link").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
                 name: name,
                 image: nil,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioElements.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioElements.swift
@@ -27,7 +27,7 @@ struct RadioElements: DesignToolboxElement {
             RadioItemElement(),
         ]
 
-        name = "app_components_radio_label"
+        name = "app_components_radio_label".localized()
         image = Image(decorative: "il_component_radio").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Border/BorderTokenElement.swift
@@ -19,7 +19,7 @@ struct BorderTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_border_label"
+        name = "app_tokens_border_label".localized()
         image = Image(decorative: "ic_border").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Color/ColorTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Color/ColorTokenElement.swift
@@ -19,7 +19,7 @@ struct ColorTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_color_label"
+        name = "app_tokens_color_label".localized()
         image = Image(decorative: "ic_palette").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/DimensionTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/DimensionTokenElement.swift
@@ -25,12 +25,12 @@ struct DimensionTokenElement: DesignToolboxElement {
             SpaceTokenElement(),
         ]
 
-        name = "app_tokens_dimension_label"
+        name = "app_tokens_dimension_label".localized()
         image = Image(decorative: "ic_dimension").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: Image(decorative: "ic_dimension").renderingMode(.template),
             description: "app_tokens_dimension_description_text",
-            illustration: AnyView(DesignToolboxVariantElement(elements: variants))))
+            illustration: AnyView(DesignToolboxVariantElement(elements: variants.sorted(by: { $0.name < $1.name })))))
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Size/SizeTokenElement.swift
@@ -19,7 +19,7 @@ struct SizeTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_dimension_size_label"
+        name = "app_tokens_dimension_size_label".localized()
         image = Image(decorative: "ic_dimension").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Dimension/Space/SpaceTokenElement.swift
@@ -19,7 +19,7 @@ struct SpaceTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_dimension_space_label"
+        name = "app_tokens_dimension_space_label".localized()
         image = Image(decorative: "ic_dimension").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Elevation/ElevationTokenElement.swift
@@ -19,7 +19,7 @@ struct ElevationTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_elevation_label"
+        name = "app_tokens_elevation_label".localized()
         image = Image(decorative: "ic_layers").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Font/FontTokenElement.swift
@@ -19,7 +19,7 @@ struct FontTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_typography_label"
+        name = "app_tokens_typography_label".localized()
         image = Image(decorative: "ic_typography").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GridTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Grid/GridTokenElement.swift
@@ -19,7 +19,7 @@ struct GridTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_grid_label"
+        name = "app_tokens_grid_label".localized()
         image = Image(decorative: "ic_grid").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/Opacity/OpacityTokenElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/Opacity/OpacityTokenElement.swift
@@ -19,7 +19,7 @@ struct OpacityTokenElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_tokens_opacity_label"
+        name = "app_tokens_opacity_label".localized()
         image = Image(decorative: "ic_filter_effects").renderingMode(.template)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/TokensPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/TokensPage.swift
@@ -26,7 +26,7 @@ struct TokensPage: View {
     ]
 
     var body: some View {
-        DesignToolboxElementsPage(elements: tokenElements)
+        DesignToolboxElementsPage(elements: tokenElements.sorted(by: { $0.name < $1.name }))
             .oudsNavigationTitle("app_bottomBar_tokens_label")
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementPage.swift
@@ -65,7 +65,7 @@ struct DesignToolboxElementPage: View {
         .padding(.top, theme.spaces.spaceFixedNone)
         .padding(.horizontal, theme.spaces.spaceFixedNone)
         .oudsBackground(theme.colors.colorBgPrimary)
-        .navigationTitle(LocalizedStringKey(name))
+        .navigationTitle(name)
         .navigationbarMenuForThemeSelection()
         .oudsRequestAccessibleFocus(_requestFocus)
     }

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -1104,7 +1104,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Colored background"
+            "value" : "Surface colorée"
           }
         }
       }
@@ -2594,7 +2594,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Élévation"
+            "value" : "Elévation"
           }
         }
       }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#585

### Description

<!-- Describe your changes in detail -->
Tokens and components should be sorted by name in the design system toolbox app.
Thus the name of each designl toolbox element is localized during the init so as to be sure the convertion will be done and use the name for sorting purposes

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let users find easily the components by names

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
