### PR TITLE
[#556] Make control-item-based components able to flip images or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.13.0...develop)
 
+### Added
+
+- [Library] Let control-item-based component flip the icons programatically or not ([#556](https://github.com/Orange-OpenSource/ouds-ios/issues/556))
+
 ### Changed
 
 - [DesignToolbox] Rename checkbox and radio button entries ([#584](https://github.com/Orange-OpenSource/ouds-ios/issues/584))

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemConfiguration.swift
@@ -38,6 +38,10 @@ final class CheckboxItemConfigurationModel: ComponentConfiguration {
         didSet { updateCode() }
     }
 
+    @Published var flipIcon: Bool {
+        didSet { updateCode() }
+    }
+
     @Published var isError: Bool {
         didSet { updateCode() }
     }
@@ -71,6 +75,7 @@ final class CheckboxItemConfigurationModel: ComponentConfiguration {
         enabled = true
         helperText = true
         icon = true
+        flipIcon = false
         layoutOrientation = .default
         divider = false
         labelTextContent = String(localized: "app_components_checkbox_label_text")
@@ -81,24 +86,30 @@ final class CheckboxItemConfigurationModel: ComponentConfiguration {
 
     // MARK: - Component Configuration
 
+    // swiftlint:disable line_length
     override func updateCode() {
         code =
           """
-        OUDSCheckboxItem(isOn: $isOn, labelText: \"\(labelTextContent)\"\(helperTextPatern)\(iconPatern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPatern))
+        OUDSCheckboxItem(isOn: $isOn, labelText: \"\(labelTextContent)\"\(helperTextPattern)\(iconPattern)\(flipIconPattern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPattern))
         \(disableCode)
         """
     }
+    // swiftlint:enable line_length
 
     private var disableCode: String {
         ".disable(\(enabled ? "false" : "true"))"
     }
 
-    private var helperTextPatern: String {
+    private var helperTextPattern: String {
         helperText ? ", helperText: \"\(helperTextContent)\")" : ""
     }
 
-    private var iconPatern: String {
-        icon ? ", icon: Image(decorative: \"ic_heart\")" : ""
+    private var iconPattern: String {
+        icon ? ", icon: Image(systemName: \"figure.handball\")" : ""
+    }
+
+    private var flipIconPattern: String {
+        flipIcon ? ", flipIcon: true" : ""
     }
 
     private var isInversedPattern: String {
@@ -113,7 +124,7 @@ final class CheckboxItemConfigurationModel: ComponentConfiguration {
         isReadOnly ? ", isReadOnly: true" : ""
     }
 
-    private var dividerPatern: String {
+    private var dividerPattern: String {
         divider ? ", divider: true" : ""
     }
 }
@@ -157,6 +168,10 @@ struct CheckboxItemConfiguration: View {
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
+                .typeHeadingMedium(theme)
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
+
+            Toggle("app_components_common_flipIcon_label", isOn: $model.flipIcon)
                 .typeHeadingMedium(theme)
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
@@ -92,7 +92,7 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
     override func updateCode() {
         code =
           """
-        OUDSCheckboxItemIndeterminate(selection: $selection, labelText: \"\(labelTextContent)\"\(helperTextPattern)\(iconPattern)\(flipIcon)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPattern))
+        OUDSCheckboxItemIndeterminate(selection: $selection, labelText: \"\(labelTextContent)\"\(helperTextPattern)\(iconPattern)\(flipIconPattern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPattern))
         \(disableCode)
         """
     }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateConfiguration.swift
@@ -40,6 +40,10 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
         didSet { updateCode() }
     }
 
+    @Published var flipIcon: Bool {
+        didSet { updateCode() }
+    }
+
     @Published var isError: Bool {
         didSet { updateCode() }
     }
@@ -73,6 +77,7 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
         enabled = true
         helperText = true
         icon = true
+        flipIcon = false
         layoutOrientation = .default
         divider = false
         labelTextContent = String(localized: "app_components_checkbox_label_text")
@@ -87,7 +92,7 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
     override func updateCode() {
         code =
           """
-        OUDSCheckboxItemIndeterminate(selection: $selection, labelText: \"\(labelTextContent)\"\(helperTextPatern)\(iconPatern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPatern))
+        OUDSCheckboxItemIndeterminate(selection: $selection, labelText: \"\(labelTextContent)\"\(helperTextPattern)\(iconPattern)\(flipIcon)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPattern))
         \(disableCode)
         """
     }
@@ -97,12 +102,16 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
         ".disable(\(enabled ? "false" : "true"))"
     }
 
-    private var helperTextPatern: String {
+    private var helperTextPattern: String {
         helperText ? ", helperText: \"\(helperTextContent)\")" : ""
     }
 
-    private var iconPatern: String {
-        icon ? ", icon: Image(decorative: \"ic_heart\")" : ""
+    private var iconPattern: String {
+        icon ? ", icon: Image(systemName: \"figure.handball\")" : ""
+    }
+
+    private var flipIconPattern: String {
+        flipIcon ? ", flipIcon: true" : ""
     }
 
     private var isInversedPattern: String {
@@ -117,7 +126,7 @@ final class CheckboxItemIndeterminateConfigurationModel: ComponentConfiguration 
         isReadOnly ? ", isReadOnly: true" : ""
     }
 
-    private var dividerPatern: String {
+    private var dividerPattern: String {
         divider ? ", divider: true" : ""
     }
 }
@@ -163,6 +172,10 @@ struct CheckboxItemIndeterminateConfiguration: View {
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
+                .typeHeadingMedium(theme)
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
+
+            Toggle("app_components_common_flipIcon_label", isOn: $model.flipIcon)
                 .typeHeadingMedium(theme)
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminatePage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminatePage.swift
@@ -77,6 +77,7 @@ private struct CheckboxItemIndeterminateDemo: View {
                                       labelText: model.labelTextContent,
                                       helperText: helperTextContent,
                                       icon: icon,
+                                      flipIcon: model.flipIcon,
                                       isInversed: model.layoutOrientation == .inverse,
                                       isError: model.isError,
                                       isReadOnly: model.isReadOnly,
@@ -90,7 +91,10 @@ private struct CheckboxItemIndeterminateDemo: View {
         model.helperText ? model.helperTextContent : nil
     }
 
+    // Need here that system name, a11y managed in component
+    // swiftlint:disable accessibility_label_for_image
     private var icon: Image? {
-        model.icon ? Image(decorative: "ic_heart") : nil
+        model.icon ? Image(systemName: "figure.handball") : nil
     }
+    // swiftlint:enable accessibility_label_for_image
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemPage.swift
@@ -77,6 +77,7 @@ private struct CheckboxItemDemo: View {
                          labelText: model.labelTextContent,
                          helperText: helperTextContent,
                          icon: icon,
+                         flipIcon: model.flipIcon,
                          isInversed: model.layoutOrientation == .inverse,
                          isError: model.isError,
                          isReadOnly: model.isReadOnly,
@@ -90,7 +91,10 @@ private struct CheckboxItemDemo: View {
         model.helperText ? model.helperTextContent : nil
     }
 
+    // Need here that system name, a11y managed in component
+    // swiftlint:disable accessibility_label_for_image
     private var icon: Image? {
-        model.icon ? Image(decorative: "ic_heart") : nil
+        model.icon ? Image(systemName: "figure.handball") : nil
     }
+    // swiftlint:enable accessibility_label_for_image
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadioItemPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadioItemPage.swift
@@ -78,6 +78,7 @@ private struct RadioItemDemo: View {
                       additionalLabelText: additionalLabelTextContent,
                       helperText: helperTextContent,
                       icon: icon,
+                      flipIcon: model.flipIcon,
                       isOutlined: model.outlined,
                       isInversed: model.layoutOrientation == .inverse,
                       isError: model.isError,
@@ -96,7 +97,10 @@ private struct RadioItemDemo: View {
         model.additionalLabelText ? model.additionalLabelTextContent : nil
     }
 
+    // Need here that system name, a11y managed in component
+    // swiftlint:disable accessibility_label_for_image
     private var icon: Image? {
-        model.icon ? Image(decorative: "ic_heart") : nil
+        model.icon ? Image(systemName: "figure.handball") : nil
     }
+    // swiftlint:enable accessibility_label_for_image
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Radio/RadioItem/RadiolItemConfiguration.swift
@@ -41,6 +41,10 @@ final class RadioItemConfigurationModel: ComponentConfiguration {
         didSet { updateCode() }
     }
 
+    @Published var flipIcon: Bool {
+        didSet { updateCode() }
+    }
+
     @Published var isError: Bool {
         didSet { updateCode() }
     }
@@ -84,6 +88,7 @@ final class RadioItemConfigurationModel: ComponentConfiguration {
         additionalLabelText = true
         helperText = true
         icon = true
+        flipIcon = false
         layoutOrientation = .default
         divider = true
         labelTextContent = String(localized: "app_components_radio_label_text")
@@ -94,11 +99,12 @@ final class RadioItemConfigurationModel: ComponentConfiguration {
     deinit { }
 
     // MARK: - Component Configuration
+
     // swiftlint:disable line_length
     override func updateCode() {
         code =
           """
-        OUDSRadioItem(isOn: $isOn, labelText: "\(labelTextContent)"\(additionalLabelTextPatern)\(helperTextPatern)\(iconPatern)\(outlinedPatern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPatern))
+        OUDSRadioItem(isOn: $isOn, labelText: "\(labelTextContent)"\(additionalLabelTextPattern)\(helperTextPattern)\(iconPattern)\(flipIconPattern)\(outlinedPattern)\(isInversedPattern)\(isErrorPattern)\(isReadOnlyPattern)\(dividerPattern))
         \(disableCode)
         """
     }
@@ -108,19 +114,23 @@ final class RadioItemConfigurationModel: ComponentConfiguration {
         ".disable(\(enabled ? "false" : "true"))"
     }
 
-    private var additionalLabelTextPatern: String {
+    private var additionalLabelTextPattern: String {
         helperText ? ", additionalLabelText: \"\(additionalLabelTextContent)\"" : ""
     }
 
-    private var helperTextPatern: String {
+    private var helperTextPattern: String {
         helperText ? ", helperText: \"\(helperTextContent)\"" : ""
     }
 
-    private var iconPatern: String {
-        icon ? ", icon: Image(decorative: \"ic_heart\")" : ""
+    private var iconPattern: String {
+        icon ? ", icon: Image(systemName: \"figure.handball\")" : ""
     }
 
-    private var outlinedPatern: String {
+    private var flipIconPattern: String {
+        flipIcon ? ", flipIcon: true" : ""
+    }
+
+    private var outlinedPattern: String {
         outlined ? ", isOutlined: true" : ""
     }
 
@@ -136,7 +146,7 @@ final class RadioItemConfigurationModel: ComponentConfiguration {
         isReadOnly ? ", isReadOnly: true" : ""
     }
 
-    private var dividerPatern: String {
+    private var dividerPattern: String {
         divider ? ", divider: true" : ""
     }
 }
@@ -189,6 +199,10 @@ struct RadioItemConfiguration: View {
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 
             Toggle("app_components_common_divider_label", isOn: $model.divider)
+                .typeHeadingMedium(theme)
+                .oudsForegroundStyle(theme.colors.colorContentDefault)
+
+            Toggle("app_components_common_flipIcon_label", isOn: $model.flipIcon)
                 .typeHeadingMedium(theme)
                 .oudsForegroundStyle(theme.colors.colorContentDefault)
 

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -1157,6 +1157,30 @@
         }
       }
     },
+    "app_components_common_flipIcon_label" : {
+      "comment" : "Control item - Common",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أيقونة الوجه"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Flip icon"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inverser l’icône"
+          }
+        }
+      }
+    },
     "app_components_common_helperText_label" : {
       "comment" : "Component - Checkbox",
       "extractionState" : "manual",

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
@@ -41,6 +41,12 @@ import SwiftUI
 /// In addition, the ``OUDSCheckboxItem`` can be in read only mode, i.e. the user cannot interact with the component yet but this component must not be considered
 /// as disabled.
 ///
+/// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
+/// to have for example the indicator in trailing position for LTR mode and vice versa.
+/// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
+/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
+/// It prevents the user do implement its own rules to flip or not image.
+///
 /// ## Accessibility considerations
 ///
 /// *Voice Over* will use several elements to describe the component: if component disabled / read only, if error context, the label and helper texts and a custom checkbox trait.
@@ -77,16 +83,6 @@ import SwiftUI
 ///                      isInversed: true,
 ///                      icon: Image(decorative: "ic_heart"))
 ///
-///     // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error.
-///     // The inverse layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn,
-///                      labelText: "Rescue from this world!",
-///                      helperText: "Put your hand in mine",
-///                      icon: Image(decorative: "ic_heart"),
-///                      isInversed: true,
-///                      isError: true,
-///                      divider: true)
-///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
 ///     OUDSCheckboxItem(isOn: $isOn, labelText: "Hello world")
@@ -96,6 +92,17 @@ import SwiftUI
 ///     // This is forbidden by design!
 ///     OUDSCheckboxItem(isOn: $isOn, labelText: "Hello world", isError: true).disabled(true) // fatal error
 ///     OUDSCheckboxItem(isOn: $isOn, labelText: "Hello world", isReadyOnly: true).disabled(true) // fatal error
+/// ```
+///
+/// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
+/// ```swift
+///     @Environment(\.layoutDirection) var layoutDirection
+///
+///     OUDSCheckboxItem(isOn: $selection,
+///                      labelText: "Cocorico !",
+///                      icon: Image(systemName: "figure.handball"),
+///                      flipIcon: layoutDirection == .rightToLeft,
+///                      isInversed: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Design documentation
@@ -123,6 +130,7 @@ public struct OUDSCheckboxItem: View {
     ///   - labelText: The main label text of the checkbox.
     ///   - helperText: An additonal helper text, should not be empty
     ///   - icon: An optional icon
+    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isInversed: `true` of the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
@@ -131,6 +139,7 @@ public struct OUDSCheckboxItem: View {
                 labelText: String,
                 helperText: String? = nil,
                 icon: Image? = nil,
+                flipIcon: Bool = false,
                 isInversed: Bool = false,
                 isError: Bool = false,
                 isReadOnly: Bool = false,
@@ -149,6 +158,7 @@ public struct OUDSCheckboxItem: View {
             additionalLabelText: nil,
             helperText: helperText,
             icon: icon,
+            flipIcon: flipIcon,
             isOutlined: false,
             isError: isError,
             isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -39,8 +39,14 @@ import SwiftUI
 ///
 /// An ``OUDSCheckboxItemIndeterminate`` can be related to an error situation, for example troubles for a formular.
 /// A dedicated look and feel is implemented for that if the `isError` flag is risen.
-/// In addition, the ``OUDSCheckboxItemIndeterminate`` can be in read only mode, i.e. the user cannot interact with the component yet but this component must not be considered
-/// as disabled.
+/// In addition, the ``OUDSCheckboxItemIndeterminate`` can be in read only mode, i.e. the user cannot interact with the component yet
+/// but this component must not be considered as disabled.
+///
+/// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
+/// to have for example the indicator in trailing position for LTR mode and vice versa.
+/// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
+/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
+/// It prevents the user do implement its own rules to flip or not image.
 ///
 /// ## Accessibility considerations
 ///
@@ -78,25 +84,32 @@ import SwiftUI
 ///                                   isInversed: true,
 ///                                   icon: Image(decorative: "ic_heart"))
 ///
-///     // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error.
-///     // The inverse layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection,
-///                                   labelText: "Rescue from this world!",
-///                                   helperText: "Put your hand in mine",
-///                                   icon: Image(decorative: "ic_heart"),
-///                                   isInversed: true,
-///                                   isError: true,
-///                                  divider: true)
-///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
 ///     OUDSCheckboxItemIndeterminate(selection: $selection, labelText: "Hello world")
 ///         .disabled(true)
 ///
+///     // A leading checkbox with a label and and icon but with the icon flipped vertically
+///     OUDSCheckboxItemIndeterminate(isOn: $selection,
+///                                   labelText: "Cocorico !",
+///                                   icon: Image(systemName: "figure.handball"),
+///                                   flipIcon: true)
+///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
 ///     OUDSCheckboxItemIndeterminate(selection: $selection, labelText: "Hello world", isError: true).disabled(true) // fatal error
 ///     OUDSCheckboxItemIndeterminate(selection: $selection, labelText: "Hello world", isReadyOnly: true).disabled(true) // fatal error
+/// ```
+///
+/// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
+/// ```swift
+///     @Environment(\.layoutDirection) var layoutDirection
+///
+///     OUDSCheckboxItemIndeterminate(isOn: $selection,
+///                                   labelText: "Cocorico !",
+///                                   icon: Image(systemName: "figure.handball"),
+///                                   flipIcon: layoutDirection == .rightToLeft,
+///                                   isInversed: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Design documentation
@@ -124,6 +137,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - labelText: The main label text of the checkbox.
     ///   - helperText: An additonal helper text, should not be empty
     ///   - icon: An optional icon
+    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isInversed: `true` of the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
@@ -132,6 +146,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
                 labelText: String,
                 helperText: String? = nil,
                 icon: Image? = nil,
+                flipIcon: Bool = false,
                 isInversed: Bool = false,
                 isError: Bool = false,
                 isReadOnly: Bool = false,
@@ -150,6 +165,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
             additionalLabelText: nil,
             helperText: helperText,
             icon: icon,
+            flipIcon: flipIcon,
             isOutlined: false,
             isError: isError,
             isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItem.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItem.swift
@@ -66,6 +66,7 @@ struct ControlItem: View {
     ///   - additionalLabelText: An additional label text of the item.
     ///   - helperText: An additonal helper text, should not be empty
     ///   - icon: An optional icon
+    ///   - flipIcon: Set to `true` to flip the icon, false otherwise
     ///   - isOutlined: If the component has lines around it like kind of borders (`true`)
     ///   - isOnError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - isReadOnly: `true` if component is in read only mode, i.e. not really disabled but user cannot interact with it yet, default set to `false`
@@ -78,6 +79,7 @@ struct ControlItem: View {
          helperText: String? = nil,
          additionalLabelText: String? = nil,
          icon: Image? = nil,
+         flipIcon: Bool = false,
          isOutlined: Bool = false,
          isOnError: Bool = false,
          isReadOnly: Bool = false,
@@ -88,6 +90,7 @@ struct ControlItem: View {
                                     additionalLabelText: additionalLabelText,
                                     helperText: helperText,
                                     icon: icon,
+                                    flipIcon: flipIcon,
                                     isOutlined: isOutlined,
                                     isError: isOnError,
                                     isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
@@ -70,7 +70,7 @@ struct ControlItemContent: View {
     }
 
     private func iconContainer() -> some View {
-        ControlItemIconContainer(interactionState: interactionState, icon: layoutData.icon)
+        ControlItemIconContainer(interactionState: interactionState, icon: layoutData.icon, flip: layoutData.flipIcon)
     }
 
     // MARK: Computed properties

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemIconContainer.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemIconContainer.swift
@@ -25,6 +25,7 @@ struct ControlItemIconContainer: View {
 
     let interactionState: InteractionState
     let icon: Image?
+    let flip: Bool
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
@@ -38,7 +39,9 @@ struct ControlItemIconContainer: View {
                     .resizable()
                     .renderingMode(.template)
                     .oudsForegroundStyle(iconColor)
+                    .accessibilityHidden(true)
                     .frame(width: theme.controlItem.controlItemSizeIcon, height: theme.controlItem.controlItemSizeIcon)
+                    .toFlip(flip: flip)
             }
             .frame(maxHeight: theme.controlItem.controlItemSizeMaxHeightAssetsContainer, alignment: .center)
         }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemLabel.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemLabel.swift
@@ -36,6 +36,7 @@ struct ControlItemLabel: View {
         let additionalLabelText: String?
         let helperText: String?
         let icon: Image?
+        let flipIcon: Bool
         let isOutlined: Bool
         let isError: Bool
         let isReadOnly: Bool

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
@@ -54,10 +54,10 @@ import SwiftUI
 ///
 /// ## Design documentation
 ///
-/// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/73c701-components)
+/// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/90c467-radio-button)
 ///
 /// - Since: 0.12.0
-public struct OUDSRadio: View { // TODO: #266 - Update documentation hyperlink above
+public struct OUDSRadio: View {
 
     // MARK: - Properties
 

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
@@ -40,6 +40,12 @@ import SwiftUI
 /// as disabled.
 /// The radio can be also outlined in some cases.
 ///
+/// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
+/// to have for example the indicator in trailing position for LTR mode and vice versa.
+/// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
+/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
+/// It prevents the user do implement its own rules to flip or not image.
+///
 /// ## Accessibility considerations
 ///
 /// *Voice Over* will use several elements to describe the component: if component disabled / read only, if error context, the label and helper texts and a custom radio trait.
@@ -68,22 +74,9 @@ import SwiftUI
 ///     // The default layout will be used here.
 ///     OUDSRadioItem(isOn: $selection, labelText: "Lucy in the Sky with Diamonds", helperText: "The Beatles")
 ///
-///     // A leading oulined radio with an additional label, an helper text.
-///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, labelText: "Lucy in the Sky with Diamonds", additionalLabelText: "The Beatles", helperText: "1967", outlined: true)
-///
 ///     // A leading radio with an additional label.
 ///     // The default layout will be used here.
 ///     OUDSRadioItem(isOn: $selection, labelText: "Lucy in the Sky with Diamonds", additionalLabelText: "The Beatles", helperText: "1967")
-///
-///     // A trailing radio with a label, an additonal label, an helper text and an icon.
-///     // The inverse layout will be used here.
-///     OUDSRadioItem(isOn: $selection,
-///                   labelText: "Lucy in the Sky with Diamonds",
-///                   additionalLabelText: "The Beatles",
-///                   helperText: "1967",
-///                   isInversed: true,
-///                   icon: Image(decorative: "ic_heart"))
 ///
 ///     // A trailing radio with a label, an helper text, an icon, a divider and is about an error.
 ///     // The inverse layout will be used here.
@@ -106,12 +99,23 @@ import SwiftUI
 ///     OUDSRadioItem(isOn: $selection, labelText: "Kaboom!", isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
+/// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
+/// ```swift
+///     @Environment(\.layoutDirection) var layoutDirection
+///
+///     OUDSRadioItem(isOn: $selection,
+///                   labelText: "Cocorico !",
+///                   icon: Image(systemName: "figure.handball"),
+///                   flipIcon: layoutDirection == .rightToLeft,
+///                   isInversed: layoutDirection == .rightToLeft)
+/// ```
+///
 /// ## Design documentation
 ///
-/// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/73c701-components)
+/// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/90c467-radio-button)
 ///
 /// - Since: 0.12.0
-public struct OUDSRadioItem: View { // TODO: #266 - Update documentation hyperlink above
+public struct OUDSRadioItem: View {
 
     // MARK: - Properties
 
@@ -129,10 +133,11 @@ public struct OUDSRadioItem: View { // TODO: #266 - Update documentation hyperli
     /// - Parameters:
     ///   - isOn: A binding to a property that determines whether the toggle is on or off.
     ///   - labelText: The main label text of the radio.
-    ///   - additionalLabelText: An additional label text of the radio.
-    ///   - helperText: An additonal helper text, should not be empty
-    ///   - icon: An optional icon
-    ///   - isOutlined: Flag to get an outlined radio
+    ///   - additionalLabelText: An additional label text of the radio, default set to `nil`
+    ///   - helperText: An additonal helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - isOutlined: Flag to get an outlined radio, default set to `true`
     ///   - isInversed: `True` of the radio indicator must be in trailing position,` false` otherwise. Default to `false`
     ///   - isError: `True` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
@@ -144,6 +149,7 @@ public struct OUDSRadioItem: View { // TODO: #266 - Update documentation hyperli
                 additionalLabelText: String? = nil,
                 helperText: String? = nil,
                 icon: Image? = nil,
+                flipIcon: Bool = false,
                 isOutlined: Bool = true,
                 isInversed: Bool = false,
                 isError: Bool = false,
@@ -168,6 +174,7 @@ public struct OUDSRadioItem: View { // TODO: #266 - Update documentation hyperli
             additionalLabelText: additionalLabelText,
             helperText: helperText,
             icon: icon,
+            flipIcon: flipIcon,
             isOutlined: isOutlined,
             isError: isError,
             isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/ViewModifiers/LayoutModifiers/FlipperModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/LayoutModifiers/FlipperModifier.swift
@@ -1,0 +1,32 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// A `ViewModifier` which will apply a specific flip effect on a `View`
+struct FlipperModifier: ViewModifier { // 🐬
+
+    // MARK: - Stored properties
+
+    let flip: Bool
+
+    // MARK: - Body
+
+    public func body(content: Content) -> some View {
+        if flip {
+            content.scaleEffect(x: -1, y: 1)
+        } else {
+            content
+        }
+    }
+}

--- a/OUDS/Core/Components/Sources/ViewModifiers/LayoutModifiers/View+Flipper.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/LayoutModifiers/View+Flipper.swift
@@ -1,0 +1,25 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+extension View {
+
+    /// Modifies the current `View` to apply or not a flip effect
+    ///
+    /// - Parameter flip: if `true` mirrors the view, `false` does nothing
+    /// - Returns some View: The current `View` with or not a flip effect
+    func toFlip(flip: Bool) -> some View {
+        self.modifier(FlipperModifier(flip: flip))
+    }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#556 

### Description

<!-- Describe your changes in detail -->
Make control-item-based component able to flip their icon content

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
If a radio item, a checkbox item our a switch item is used in RTL mode or with indicator in LTR trailing position, the image may be flipped. Indeed for some layouts the image direction brings meanings ; and if the image is not in the same place, the meaning can be lost. It could be interesting to let users define a boolean (default set to false) if the image must be flipped ; it is more suer friendly compared to let users flip the image themselves.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
