### PR TITLE
[#654] Udpate wordings to avoid traduction for components and tokens names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [DesignToolbox] Udpate wordings to avoid traduction for components and tokens names ([#654](https://github.com/Orange-OpenSource/ouds-ios/issues/654))
 - [Tool] Update `SwiftLint` pod from v0.59.0 to v0.59.1 ([#616](https://github.com/Orange-OpenSource/ouds-ios/pull/616))
 - [Tool] Update `json` RubyGem from v2.10.2 to v2.11.3 ([#630](https://github.com/Orange-OpenSource/ouds-ios/pull/630))
 - [DemoApp] Update components configuration section ([#637](https://github.com/Orange-OpenSource/ouds-ios/issues/637))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [DesignToolbox] Udpate wordings to avoid traduction for components and tokens names ([#654](https://github.com/Orange-OpenSource/ouds-ios/issues/654))
 - [DesignToolbox] Use the new Switch component in all screens of the application ([#431](https://github.com/Orange-OpenSource/ouds-ios/issues/431))
 - [Library] Debug warnings for link and button components for WCAG 2.1 3:1 and 4.5:1 ratios on colored surface ([#656](https://github.com/Orange-OpenSource/ouds-ios/issues/656))
 
@@ -34,7 +35,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [DesignToolbox] Udpate wordings to avoid traduction for components and tokens names ([#654](https://github.com/Orange-OpenSource/ouds-ios/issues/654))
 - [Tool] Update `SwiftLint` pod from v0.59.0 to v0.59.1 ([#616](https://github.com/Orange-OpenSource/ouds-ios/pull/616))
 - [Tool] Update `json` RubyGem from v2.10.2 to v2.11.3 ([#630](https://github.com/Orange-OpenSource/ouds-ios/pull/630))
 - [DemoApp] Update components configuration section ([#637](https://github.com/Orange-OpenSource/ouds-ios/issues/637))

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxElement.swift
@@ -20,7 +20,7 @@ struct CheckboxElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_components_checkbox_twoStates_indicatorOnly_label".localized()
+        name = "app_components_checkbox_label".localized()
         image = Image(decorative: "il_component_checkbox").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/Checkbox/CheckboxIndeterminateElement.swift
@@ -25,7 +25,7 @@ struct CheckboxIndeterminateElement: DesignToolboxElement {
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,
-            description: "app_components_checkbox_threeStates_description_text",
+            description: "app_components_checkbox_indeterminateCheckbox_description_text",
             illustration: AnyView(CheckboxIndeterminatePage())))
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/Checkbox/CheckboxItem/CheckboxItemIndeterminateElement.swift
@@ -25,7 +25,7 @@ struct CheckboxItemIndeterminateElement: DesignToolboxElement {
         pageDescription = AnyView(DesignToolboxElementPage(
             name: name,
             image: nil,
-            description: "app_components_checkbox_threeState_controlItem_description_text",
+            description: "app_components_checkbox_indeterminateCheckboxItem_description_text",
             illustration: AnyView(CheckboxItemIndeterminatePage())))
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/CheckboxPicker/CheckboxPickerConfiguration.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/CheckboxPicker/CheckboxPickerConfiguration.swift
@@ -139,13 +139,13 @@ struct CheckboxPickerConfiguration: View {
             OUDSSwitchItem("app_common_enabled_label", isOn: $model.isEnabled)
                 .disabled(model.isError || model.isReadOnly)
 
-            OUDSSwitchItem("app_components_common_onError_label", isOn: $model.isError)
+            OUDSSwitchItem("app_components_common_error_label", isOn: $model.isError)
                 .disabled(!model.isEnabled || model.isReadOnly)
 
-            OUDSSwitchItem("app_components_common_readOnly_label", isOn: $model.isReadOnly)
+            OUDSSwitchItem("app_components_controlItem_readOnly_label", isOn: $model.isReadOnly)
                 .disabled(!model.isEnabled || model.isError)
 
-            OUDSSwitchItem("app_components_common_divider_label", isOn: $model.hasDivider)
+            OUDSSwitchItem("app_components_controlItem_divider_label", isOn: $model.hasDivider)
 
             DesignToolboxChoicePicker(title: "app_components_common_orientation_label",
                                       selection: $model.pickerPlacement,

--- a/DesignToolbox/DesignToolbox/Pages/Components/ColoredSurface/ColoredSurfaceElement.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/ColoredSurface/ColoredSurfaceElement.swift
@@ -19,7 +19,7 @@ struct ColoredSurfaceElement: DesignToolboxElement {
     let pageDescription: AnyView
 
     init() {
-        name = "app_components_coloredSurface_label".localized()
+        name = "app_components_common_onColoredBackground_label".localized()
         image = Image(decorative: "il_components_colored_background").renderingMode(.original)
         pageDescription = AnyView(DesignToolboxElementPage(
                 name: name,

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -390,7 +390,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مُمَكَّن"
+            "value" : "Enabled"
           }
         },
         "en" : {
@@ -402,10 +402,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Actif"
+            "value" : "Enabled"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_common_showCode_text" : {
       "comment" : "Common",
@@ -522,19 +523,19 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les boutons permettent aux utilisateurs de faire des choix ou d'effectuer une action. Ils ont plusieurs styles pour divers besoins."
+            "value" : "Le composant Button permet aux utilisateurs de faire des choix ou d'effectuer une action. Ils ont plusieurs styles pour divers besoins."
           }
         }
       }
     },
     "app_components_button_hierarchy_label" : {
-      "comment" : "Component - Link",
+      "comment" : "Component - Button",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تَسَلسُل"
+            "value" : "Hierarchy"
           }
         },
         "en" : {
@@ -546,10 +547,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hiérarchie"
+            "value" : "Hierarchy"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_button_icon_a11y" : {
       "comment" : "Component - Button (a11y)",
@@ -582,7 +584,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أيقونة فقط"
+            "value" : "Icon only"
           }
         },
         "en" : {
@@ -594,10 +596,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône seul"
+            "value" : "Icon only"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_button_label" : {
       "comment" : "Component - Button",
@@ -606,7 +609,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "زر"
+            "value" : "Button"
           }
         },
         "en" : {
@@ -618,10 +621,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bouton"
+            "value" : "Button"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_button_negative_hierary_notAllowed_text" : {
       "comment" : "Component - Button",
@@ -654,7 +658,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "عنصر مربع الاختيار الخاص بالحالتين"
+            "value" : "Checkbox Item"
           }
         },
         "en" : {
@@ -666,10 +670,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Case à cocher dans une liste"
+            "value" : "Checkbox Item"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_checkbox_controlItem_description_text" : {
       "comment" : "Component - Checkbox",
@@ -690,7 +695,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les cases à cocher permettent aux utilisateurs de sélectionner une ou plusieurs options dans une liste, d'activer ou de désactiver les paramètres ou de confirmer une action."
+            "value" : "Le composant CheckboxItem permet aux utilisateurs de sélectionner une ou plusieurs options dans une liste, d'activer ou de désactiver les paramètres ou de confirmer une action."
           }
         }
       }
@@ -714,7 +719,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les cases à cocher permettent aux utilisateurs de sélectionner une ou plusieurs options dans une liste, d'activer ou de désactiver les paramètres ou de confirmer une action."
+            "value" : "Le composant CheckBox permet aux utilisateurs de sélectionner une ou plusieurs options dans une liste, d'activer ou de désactiver les paramètres ou de confirmer une action."
           }
         }
       }
@@ -743,200 +748,8 @@
         }
       }
     },
-    "app_components_checkbox_indeterminateCheckbox_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "مربع الاختيار الخاص بثلاث حالات فقط"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indeterminate checkbox"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Case à cocher indéterminée"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_indeterminateCheckboxItem_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "عنصر مربع الاختيار ثلاثي الحالات"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indeterminate checkbox item"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Case à cocher indéterminée dans une liste"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_indicatorOnly_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خانة الاختيار"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checkbox"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Case à cocher seule"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خانة الاختيار"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checkbox"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Case à cocher"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_label_text" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملصق"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_layout_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تَخطِيط"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Layout"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Disposition"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_selection_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "اختيار"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selection"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sélection"
-          }
-        }
-      }
-    },
-    "app_components_checkbox_threeState_controlItem_description_text" : {
-      "comment" : "Component - Checkbox - Three States",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تتيح مربعات الاختيار غير المحددة للمستخدمين، على سبيل المثال، داخل بنية المجلد وشجرة الملفات تحديد أو إلغاء تحديد أو تحديد جزئي لعنصر واحد أو عناصر متعددة."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Indeterminate checkboxes allows users for example within a folder and file tree structure to select, unselect or partially select one or multiple items."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La case à cocher indéterminée est utilisée dans des structures de dossier et de fichiers ou l’utilisateur peut sélectionner, désélectionner ou sélectionner partiellement certains éléments."
-          }
-        }
-      }
-    },
-    "app_components_checkbox_threeStates_description_text" : {
-      "comment" : "Component - Checkbox - Three States",
+    "app_components_checkbox_indeterminateCheckbox_description_text" : {
+      "comment" : "Component - Checkbox - Indeterminate",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
@@ -954,19 +767,93 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La case à cocher indéterminée est utilisée dans des structures de dossier et de fichiers ou l’utilisateur peut sélectionner, désélectionner ou sélectionner partiellement certains éléments."
+            "value" : "Le composant CheckboxIndeterminate est utilisé dans des structures de dossier et de fichiers ou l’utilisateur peut sélectionner, désélectionner ou sélectionner partiellement certains éléments."
           }
         }
       }
     },
-    "app_components_checkbox_twoStates_indicatorOnly_label" : {
+    "app_components_checkbox_indeterminateCheckbox_label" : {
       "comment" : "Component - Checkbox",
       "extractionState" : "manual",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مربع الاختيار الخاص بالحالتين فقط"
+            "value" : "Indeterminate checkbox"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkbox"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkbox"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "app_components_checkbox_indeterminateCheckboxItem_description_text" : {
+      "comment" : "Component - Checkbox - Indeterminate",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تسمح مربعات الاختيار غير المحددة للمستخدمين على سبيل المثال داخل بنية شجرة المجلدات والملفات بتحديد عنصر واحد أو عدة عناصر أو إلغاء تحديدها أو تحديدها جزئيًا."
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkboxes allows users for example within a folder and file tree structure to select, unselect or partially select one or multiple items."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "needs_review",
+            "value" : "Le composant CheckboxIndeterminate Item est utilisé dans des structures de dossier et de fichiers ou l’utilisateur peut sélectionner, désélectionner ou sélectionner partiellement certains éléments."
+          }
+        }
+      }
+    },
+    "app_components_checkbox_indeterminateCheckboxItem_label" : {
+      "comment" : "Component - Checkbox",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkbox item"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkbox item"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Indeterminate checkbox item"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "app_components_checkbox_label" : {
+      "comment" : "Component - Checkbox",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Checkbox"
           }
         },
         "en" : {
@@ -978,10 +865,36 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Case à cocher"
+            "value" : "Checkbox"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
+    },
+    "app_components_checkbox_selection_label" : {
+      "comment" : "Component - Checkbox",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selection"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selection"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selection"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "app_components_checkboxPicker_description_text" : {
       "comment" : "Component - Checkbox Picker",
@@ -1002,7 +915,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Un sélecteur de cases à cocher permet à l'utilisateur de sélectionner entre 0 et tous les éléments fournis dans une liste"
+            "value" : "Le composant Checkbox piocker permet à l'utilisateur de sélectionner entre 0 et tous les éléments fournis dans une liste"
           }
         }
       }
@@ -1014,7 +927,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "منتقي خانات الاختيار"
+            "value" : "Checkbox picker"
           }
         },
         "en" : {
@@ -1026,10 +939,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sélecteur de cases à cocher"
+            "value" : "Checkbox picker"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_checkboxPicker_root" : {
       "comment" : "Component - Checkbox Picker",
@@ -1074,7 +988,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les arrière-plans colorés utilisent des couleurs de surface pour maximiser le contraste avec le contenu. Plusieurs composants, tels que les boutons ou les liens, adaptent leur affichage en conséquence lorsqu'ils sont affichés sur des arrière-plans colorés."
+            "value" : "Le composant ColoredSurface utilisent des couleurs de surface pour maximiser le contraste avec le contenu. Plusieurs composants, tels que les boutons ou les liens, adaptent leur affichage en conséquence lorsqu'ils sont affichés sur des arrière-plans colorés."
           }
         }
       }
@@ -1086,7 +1000,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "خلفيات ملونة"
+            "value" : "Colored background"
           }
         },
         "en" : {
@@ -1098,10 +1012,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Surface colorée"
+            "value" : "Colored background"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_color_label" : {
       "comment" : "Component - Common",
@@ -1109,7 +1024,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لون"
+            "value" : "Color"
           }
         },
         "en" : {
@@ -1121,34 +1036,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Couleur"
+            "value" : "Color"
           }
         }
-      }
-    },
-    "app_components_common_divider_label" : {
-      "comment" : "Component screen - Common",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "فاصل"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Divider"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Séparateur"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_editContent_label" : {
       "comment" : "Component - Common",
@@ -1205,7 +1097,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "خطأ"
+            "value" : "Error"
           }
         },
         "en" : {
@@ -1217,34 +1109,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erreur"
+            "value" : "Error"
           }
         }
-      }
-    },
-    "app_components_common_helperText_label" : {
-      "comment" : "Component - Checkbox",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "المساعد"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Helper"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texte d’aide"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_iconAndTextLayout_label" : {
       "comment" : "Component screen - Common",
@@ -1253,7 +1122,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أيقونة + نص"
+            "value" : "Icon + text"
           }
         },
         "en" : {
@@ -1265,10 +1134,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône + texte"
+            "value" : "Icon + text"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_label_label" : {
       "comment" : "Component - Checkbox",
@@ -1277,7 +1147,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ملصق"
+            "value" : "Label"
           }
         },
         "en" : {
@@ -1292,7 +1162,8 @@
             "value" : "Label"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_layout_label" : {
       "comment" : "Component screen - Common",
@@ -1301,7 +1172,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تَخطِيط"
+            "value" : "Layout"
           }
         },
         "en" : {
@@ -1313,10 +1184,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Variants"
+            "value" : "Layout"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_onColoredSurface_label" : {
       "comment" : "Component screen - Common",
@@ -1325,7 +1197,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "على خلفية ملونة"
+            "value" : "On colored surface"
           }
         },
         "en" : {
@@ -1337,34 +1209,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sur fond de couleur"
+            "value" : "On colored surface"
           }
         }
-      }
-    },
-    "app_components_common_onError_label" : {
-      "comment" : "Component - Common",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خطأ"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_orientation_label" : {
       "comment" : "Component screen - Common",
@@ -1373,13 +1222,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تَخطِيط"
+            "value" : "Orientation"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Layout"
+            "value" : "Orientation"
           }
         },
         "fr" : {
@@ -1388,31 +1237,8 @@
             "value" : "Orientation"
           }
         }
-      }
-    },
-    "app_components_common_readOnly_label" : {
-      "comment" : "Component screen - Common",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "للقراءة فقط"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Read only"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lecture seule"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_style_label" : {
       "comment" : "Component screen - Common",
@@ -1421,7 +1247,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أسلوب"
+            "value" : "Style"
           }
         },
         "en" : {
@@ -1436,7 +1262,8 @@
             "value" : "Style"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_textOnlyLayout_label" : {
       "comment" : "Component screen - Common",
@@ -1445,7 +1272,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نص فقط"
+            "value" : "Text only"
           }
         },
         "en" : {
@@ -1457,34 +1284,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Texte seul"
+            "value" : "Texte only"
           }
         }
-      }
-    },
-    "app_components_common_userText_label" : {
-      "comment" : "Component screen - Common",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "نص"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Text"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Texte"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_common_viewCodeExample_label" : {
       "comment" : "Component screen - Common",
@@ -1517,7 +1321,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فاصل"
+            "value" : "Divider"
           }
         },
         "en" : {
@@ -1529,10 +1333,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Séparateur"
+            "value" : "Divider"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_controlItem_flipIcon_label" : {
       "comment" : "Component - ControlItem",
@@ -1541,7 +1346,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أيقونة الوجه"
+            "value" : "Flip icon"
           }
         },
         "en" : {
@@ -1553,10 +1358,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inverser l’icône"
+            "value" : "Flip icon"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_controlItem_helperText_label" : {
       "comment" : "Component - ControlItem",
@@ -1565,7 +1371,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نص مساعد"
+            "value" : "Helper text"
           }
         },
         "en" : {
@@ -1577,10 +1383,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Texte d’aide"
+            "value" : "Helper text"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_controlItem_icon_label" : {
       "comment" : "Component - ControlItem",
@@ -1589,7 +1396,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "رمز"
+            "value" : "Icon"
           }
         },
         "en" : {
@@ -1601,10 +1408,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône"
+            "value" : "Icon"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_controlItem_readOnly_label" : {
       "comment" : "Component - ControlItem",
@@ -1613,7 +1421,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "للقراءة فقط"
+            "value" : "Read Only"
           }
         },
         "en" : {
@@ -1625,10 +1433,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lecture seule"
+            "value" : "Read only"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_controlItem_reversed_label" : {
       "comment" : "Component - ControlItem",
@@ -1637,7 +1446,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "معكوس"
+            "value" : "Reversed"
           }
         },
         "en" : {
@@ -1649,7 +1458,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inversé"
+            "value" : "Reversed"
           }
         }
       }
@@ -1673,7 +1482,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Un séparateur structure visuellement une interface en séparant clairement les sections de contenu. Il améliore la lisibilité et l'organisation du contenu sans introduire une hiérarchie trop marquée comme le feraient un titre ou un conteneur."
+            "value" : "Le composant Divider structure visuellement une interface en séparant clairement les sections de contenu. Il améliore la lisibilité et l'organisation du contenu sans introduire une hiérarchie trop marquée comme le feraient un titre ou un conteneur."
           }
         }
       }
@@ -1697,7 +1506,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le séparateur horizontal est utilisé pour séparer des contenus positionnés côte à côte"
+            "value" : "Le variant horizontal du composant Divider est utilisé pour séparer des contenus positionnés côte à côte"
           }
         }
       }
@@ -1709,7 +1518,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فاصل أفقي"
+            "value" : "Horizontal divider"
           }
         },
         "en" : {
@@ -1721,10 +1530,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Séparateur horizontal"
+            "value" : "Horizontal divider"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_divider_label" : {
       "comment" : "Component - Divider",
@@ -1733,7 +1543,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فاصل"
+            "value" : "Divider"
           }
         },
         "en" : {
@@ -1745,10 +1555,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Séparateur"
+            "value" : "Divider"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_divider_verticalDivider_description_text" : {
       "comment" : "Component - Divider",
@@ -1769,7 +1580,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le séparateur vertical est utilisé pour séparer des contenus positionnés l’un en dessous de l’autre"
+            "value" : "Le variant vertical du composant est utilisé pour séparer des contenus positionnés l’un en dessous de l’autre"
           }
         }
       }
@@ -1781,7 +1592,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فاصل عمودي"
+            "value" : "Vertical divider"
           }
         },
         "en" : {
@@ -1793,10 +1604,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Séparateur vertical"
+            "value" : "Vertical divider"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_link_backLayout_label" : {
       "comment" : "Component - Link",
@@ -1805,7 +1617,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "خلف"
+            "value" : "Back"
           }
         },
         "en" : {
@@ -1817,10 +1629,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Retour"
+            "value" : "Back"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_link_description_text" : {
       "comment" : "Component - Link",
@@ -1841,7 +1654,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les liens dirigent les utilisateurs vers d'autres ressources ou sections, qu'elles soient internes (dans la même application) ou externes (vers un site web ou un document)."
+            "value" : "Le composant Link dirige les utilisateurs vers d'autres ressources ou sections, qu'elles soient internes (dans la même application) ou externes (vers un site web ou un document)."
           }
         }
       }
@@ -1853,7 +1666,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "وصلة"
+            "value" : "Link"
           }
         },
         "en" : {
@@ -1865,10 +1678,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lien"
+            "value" : "Link"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_link_nextLayout_label" : {
       "comment" : "Component - Link",
@@ -1877,7 +1691,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التالي"
+            "value" : "Next"
           }
         },
         "en" : {
@@ -1889,10 +1703,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suivant"
+            "value" : "Next"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_link_size_label" : {
       "comment" : "Component - Link",
@@ -1901,7 +1716,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مقاس"
+            "value" : "Size"
           }
         },
         "en" : {
@@ -1913,34 +1728,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taille"
+            "value" : "Size"
           }
         }
-      }
-    },
-    "app_components_radio_label_text" : {
-      "comment" : "Component - Radio",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملصق"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_description_text" : {
       "comment" : "Component - Radio",
@@ -1961,7 +1753,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les boutons radio permettent aux utilisateurs de sélectionner une option dans une liste."
+            "value" : "Le composant Radio Button permettent aux utilisateurs de sélectionner une option dans une liste."
           }
         }
       }
@@ -1997,7 +1789,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "راديو بوتون"
+            "value" : "Radio button"
           }
         },
         "en" : {
@@ -2009,10 +1801,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bouton radio"
+            "value" : "Radio button"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_radioButton_label" : {
       "comment" : "Component - Radio",
@@ -2021,7 +1814,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مؤشر فقط"
+            "value" : "Radio button"
           }
         },
         "en" : {
@@ -2033,10 +1826,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bouton radio"
+            "value" : "Radio button"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_radioButtonItem_additionalLabel_label" : {
       "comment" : "Component - Radio",
@@ -2045,7 +1839,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نص الملصق الإضافي"
+            "value" : "Additional label"
           }
         },
         "en" : {
@@ -2057,10 +1851,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Label supplémentaire"
+            "value" : "Additional label"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_radioButtonItem_description_text" : {
       "comment" : "Component - Radio",
@@ -2081,7 +1876,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les boutons radio permettent aux utilisateurs de sélectionner une options dans une liste."
+            "value" : "Le composant Radio Button Item permet aux utilisateurs de sélectionner une options dans une liste."
           }
         }
       }
@@ -2093,7 +1888,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "عنصر زر الاختيار"
+            "value" : "Radio button item"
           }
         },
         "en" : {
@@ -2105,10 +1900,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bouton radio dans une liste"
+            "value" : "Radio button item"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_radioButtonItem_outlined_label" : {
       "comment" : "Component - Radio",
@@ -2117,7 +1913,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مخطط تفصيلي"
+            "value" : "Outlined"
           }
         },
         "en" : {
@@ -2129,10 +1925,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Encadré"
+            "value" : "Outlined"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioButton_selection_label" : {
       "comment" : "Component - Radio",
@@ -2141,7 +1938,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "اختيار"
+            "value" : "Selection"
           }
         },
         "en" : {
@@ -2153,10 +1950,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sélection"
+            "value" : "Selection"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_radioPicker_description_text" : {
       "comment" : "Component - Radio Picker",
@@ -2177,7 +1975,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le sélecteur de radio permet aux utilisateurs de choisir un élément au sein d'un groupe de plusieurs boutons radio"
+            "value" : "Le composant Radio Picker permet aux utilisateurs de choisir un élément au sein d'un groupe"
           }
         }
       }
@@ -2189,7 +1987,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "منتقي الراديو"
+            "value" : "Radio picker"
           }
         },
         "en" : {
@@ -2201,10 +1999,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sélecteur de boutons radio"
+            "value" : "Radio picker"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_switch_description_text" : {
       "comment" : "Component - Switch",
@@ -2225,7 +2024,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Un switch permet aux utilisateurs d’activer ou désactiver une fonctionnalité, une option ou un paramètre. "
+            "value" : "Le composant Switch permet aux utilisateurs d’activer ou désactiver une fonctionnalité, une option ou un paramètre. "
           }
         }
       }
@@ -2261,7 +2060,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التبديل"
+            "value" : "Switch"
           }
         },
         "en" : {
@@ -2276,7 +2075,8 @@
             "value" : "Switch"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_switch_label_text" : {
       "comment" : "Component - Switch",
@@ -2309,7 +2109,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "اختيار"
+            "value" : "Selection"
           }
         },
         "en" : {
@@ -2321,10 +2121,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sélection"
+            "value" : "Selection"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_switch_switch_label" : {
       "comment" : "Component - Switch",
@@ -2333,7 +2134,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يُحوّل"
+            "value" : "Switch"
           }
         },
         "en" : {
@@ -2348,7 +2149,8 @@
             "value" : "Switch"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_components_switch_switchItem_description_text" : {
       "comment" : "Component - Switch",
@@ -2369,7 +2171,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Un switch permet aux utilisateurs d’activer ou désactiver une fonctionnalité, une option ou un paramètre."
+            "value" : "Le composant Switch Item permet aux utilisateurs d’activer ou désactiver une fonctionnalité, une option ou un paramètre."
           }
         }
       }
@@ -2381,7 +2183,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تبديل العنصر"
+            "value" : "Switch Item"
           }
         },
         "en" : {
@@ -2393,7 +2195,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Switch enrichi"
+            "value" : "Switch Item"
           }
         }
       }
@@ -2417,7 +2219,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Border sont utilisées pour les couleurs de contour sur les composants et pour les couleurs des lignes de séparation pour des composants comme les tableaux."
+            "value" : "Les tokens Border sont utilisés pour les couleurs de contour sur les composants et pour les couleurs des lignes de séparation pour des composants comme les tableaux."
           }
         }
       }
@@ -2541,7 +2343,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Color renforce notre identité de marque et assure la cohérence à travers toutes les expériences produit. Les tokens sémantiques décrits sont ceux que vous devez utiliser lors de la création d'une application mobile."
+            "value" : "Les tokens Color renforcent notre identité de marque et assurent la cohérence à travers toutes les expériences produit. Les tokens sémantiques décrits sont ceux que vous devez utiliser lors de la création d'une application mobile."
           }
         }
       }
@@ -2675,7 +2477,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أيقونة زخرفية"
+            "value" : "Icon decorative"
           }
         },
         "en" : {
@@ -2687,7 +2489,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône décorative"
+            "value" : "Icon decorative"
           }
         }
       }
@@ -2786,7 +2588,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Column Gap comprondent à l'espacement vertical entre les objets."
+            "value" : "Les tokens Column Gap correspondent à l'espacement vertical entre les objets."
           }
         }
       }
@@ -2982,7 +2784,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Padding Inset corespondent au remplissage équivalant autour d’un objet (gauche, droit, supérieur et inférieur)."
+            "value" : "Les tokens Padding Inset correspondent au remplissage équivalant autour d’un objet (gauche, droit, supérieur et inférieur)."
           }
         }
       }
@@ -3031,7 +2833,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Padding Stack comprondent au rembourrage supérieur et inférieur."
+            "value" : "Les tokens Padding Stack correspondent au remplissage supérieur et inférieur."
           }
         }
       }
@@ -3080,7 +2882,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Raw Gap corespondent à l'espacement horizontal entre les objets."
+            "value" : "Les tokens Raw Gap correspondent à l'espacement horizontal entre les objets."
           }
         }
       }
@@ -3129,7 +2931,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les ‘tokens Scaled font référence à un espacement qui s'ajuste de manière dynamique en fonction de facteurs tels que la taille du conteneur, la résolution de l'écran ou les éléments de mise en page."
+            "value" : "Les tokens Scaled font référence à un espacement qui s'ajuste de manière dynamique en fonction de facteurs tels que la taille du conteneur, la résolution de l'écran ou les éléments de mise en page."
           }
         }
       }
@@ -3153,7 +2955,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Elevation sont utilisées pour donner l'impression de distance ou d'élévation entre les surfaces, ce qui ajoute de la profondeur à nos designs."
+            "value" : "Les tokens Elevation sont utilisés pour donner l'impression de distance ou d'élévation entre les surfaces, ce qui ajoute de la profondeur à nos designs."
           }
         }
       }
@@ -3202,7 +3004,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les tokens Grid sont utilisées pour positionner le contenu et créer des mises en page de page cohérentes."
+            "value" : "Les tokens Grid sont utilisés pour positionner le contenu et créer des mises en page de page cohérentes."
           }
         }
       }

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -815,7 +815,7 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "needs_review",
+            "state" : "translated",
             "value" : "Le composant CheckboxIndeterminate Item est utilisé dans des structures de dossier et de fichiers ou l’utilisateur peut sélectionner, désélectionner ou sélectionner partiellement certains éléments."
           }
         }
@@ -993,31 +993,6 @@
         }
       }
     },
-    "app_components_coloredSurface_label" : {
-      "comment" : "Component - Colored Surface",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Colored background"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Colored background"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Colored background"
-          }
-        }
-      },
-      "shouldTranslate" : false
-    },
     "app_components_common_color_label" : {
       "comment" : "Component - Common",
       "localizations" : {
@@ -1185,6 +1160,31 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Layout"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "app_components_common_onColoredBackground_label" : {
+      "comment" : "Component - Colored Surface",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colored background"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colored background"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Colored background"
           }
         }
       },
@@ -2077,30 +2077,6 @@
         }
       },
       "shouldTranslate" : false
-    },
-    "app_components_switch_label_text" : {
-      "comment" : "Component - Switch",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ملصق"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Label"
-          }
-        }
-      }
     },
     "app_components_switch_selection_label" : {
       "comment" : "Component - Switch",

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -2429,7 +2429,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "حدود"
+            "value" : "Border"
           }
         },
         "en" : {
@@ -2441,10 +2441,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bordure"
+            "value" : "Border"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_border_radius_label" : {
       "comment" : "Tokens - Border",
@@ -2453,7 +2454,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نصف القطر"
+            "value" : "Radius"
           }
         },
         "en" : {
@@ -2465,10 +2466,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rayon"
+            "value" : "Radius"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_border_style_label" : {
       "comment" : "Tokens - Border",
@@ -2477,7 +2479,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أسلوب"
+            "value" : "Style"
           }
         },
         "en" : {
@@ -2492,7 +2494,8 @@
             "value" : "Style"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_border_width_label" : {
       "comment" : "Tokens - Border",
@@ -2501,7 +2504,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "عرض"
+            "value" : "Width"
           }
         },
         "en" : {
@@ -2513,10 +2516,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Largeur"
+            "value" : "Width"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_color_description_text" : {
       "comment" : "Tokens - Color",
@@ -2549,7 +2553,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لون"
+            "value" : "Color"
           }
         },
         "en" : {
@@ -2561,10 +2565,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Couleur"
+            "value" : "Color"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_common_viewCodeExample_label" : {
       "comment" : "Token - Common",
@@ -2621,7 +2626,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "البعد"
+            "value" : "Dimension"
           }
         },
         "en" : {
@@ -2636,7 +2641,8 @@
             "value" : "Dimension"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_size_description_text" : {
       "comment" : "Token - Dimension - Size",
@@ -2693,7 +2699,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "أيقونة مع"
+            "value" : "Icon with"
           }
         },
         "en" : {
@@ -2705,10 +2711,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Icône avec"
+            "value" : "Icon with"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_size_label" : {
       "comment" : "Token - Dimension - Size",
@@ -2717,7 +2724,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مقاس"
+            "value" : "Size"
           }
         },
         "en" : {
@@ -2729,10 +2736,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Taille"
+            "value" : "Size"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_columnGap_label" : {
       "comment" : "Token - Dimension - Space",
@@ -2741,7 +2749,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فجوة مضمنة"
+            "value" : "Column gap"
           }
         },
         "en" : {
@@ -2753,10 +2761,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espacement extérieur entre éléments côte à côte"
+            "value" : "Column gap"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_columnGapHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -2813,7 +2822,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مُثَبَّت"
+            "value" : "Fixed"
           }
         },
         "en" : {
@@ -2825,10 +2834,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fixe"
+            "value" : "Fixed"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_fixedHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -2861,7 +2871,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "فضاء"
+            "value" : "Space"
           }
         },
         "en" : {
@@ -2873,10 +2883,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espace"
+            "value" : "Space"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_paddingInline_label" : {
       "comment" : "Token - Dimension - Space",
@@ -2885,7 +2896,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الحشو المضمن"
+            "value" : "Padding inline"
           }
         },
         "en" : {
@@ -2897,10 +2908,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espacement intérieur gauche droite"
+            "value" : "Padding inline"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_paddingInlineHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -2933,7 +2945,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "حشوة داخلية"
+            "value" : "Padding inset"
           }
         },
         "en" : {
@@ -2945,10 +2957,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espacement intérieur"
+            "value" : "Padding inset"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_paddingInsetHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -2981,7 +2994,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "كومة الحشو"
+            "value" : "Padding stack"
           }
         },
         "en" : {
@@ -2993,10 +3006,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espacement intérieur haut bas"
+            "value" : "Padding stack"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_paddingStackHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -3029,7 +3043,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "كومة الفجوة"
+            "value" : "Row gap"
           }
         },
         "en" : {
@@ -3041,10 +3055,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Espacement extérieur entre éléments empilés"
+            "value" : "Row gap"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_rowGapHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -3077,7 +3092,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "مقياس"
+            "value" : "Scaled"
           }
         },
         "en" : {
@@ -3089,10 +3104,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Échelonné"
+            "value" : "Scaled"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_dimension_space_scaledHeader_text" : {
       "comment" : "Token - Dimension - Space",
@@ -3149,7 +3165,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ارتفاع"
+            "value" : "Elevation"
           }
         },
         "en" : {
@@ -3161,10 +3177,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Elévation"
+            "value" : "Elevation"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_grid_description_text" : {
       "comment" : "Token - Grid",
@@ -3197,7 +3214,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "شبكة"
+            "value" : "Grid"
           }
         },
         "en" : {
@@ -3209,10 +3226,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Grille"
+            "value" : "Grid"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_opacity_description_text" : {
       "comment" : "Token - Opacity",
@@ -3245,7 +3263,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "العتامة"
+            "value" : "Opacity"
           }
         },
         "en" : {
@@ -3257,10 +3275,11 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Opacité"
+            "value" : "Opacity"
           }
         }
-      }
+      },
+      "shouldTranslate" : false
     },
     "app_tokens_typography_description_text" : {
       "comment" : "Token - Typography",
@@ -3317,7 +3336,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يصنع"
+            "value" : "Font"
           }
         },
         "en" : {
@@ -3329,7 +3348,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Police de caractère"
+            "value" : "Font"
           }
         }
       }

--- a/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
+++ b/DesignToolbox/DesignToolbox/Resources/Localizable.xcstrings
@@ -2417,7 +2417,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les bordures sont utilisées pour les couleurs de contour sur les composants et pour les couleurs des lignes de séparation pour des composants comme les tableaux."
+            "value" : "Les tokens Border sont utilisées pour les couleurs de contour sur les composants et pour les couleurs des lignes de séparation pour des composants comme les tableaux."
           }
         }
       }
@@ -2541,7 +2541,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La couleur renforce notre identité de marque et assure la cohérence à travers toutes les expériences produit. Les tokens sémantiques décrits sont ceux que vous devez utiliser lors de la création d'une application mobile."
+            "value" : "Les tokens Color renforce notre identité de marque et assure la cohérence à travers toutes les expériences produit. Les tokens sémantiques décrits sont ceux que vous devez utiliser lors de la création d'une application mobile."
           }
         }
       }
@@ -2614,7 +2614,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La dimension fournit des tailles et des espacements standard pour assurer la cohérence visuelle à travers l'interface utilisateur."
+            "value" : "Les tokens Dimension fournissent des tailles et des espacements standard pour assurer la cohérence visuelle à travers l'interface utilisateur."
           }
         }
       }
@@ -2663,7 +2663,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La taille fait référence aux mesures spécifiques utilisées pour définir les dimensions des éléments de l'interface utilisateur dans le système de design."
+            "value" : "Les tokens Size font référence aux mesures spécifiques utilisées pour définir les dimensions des éléments de l'interface utilisateur dans le système de design."
           }
         }
       }
@@ -2786,7 +2786,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'espacement des colonnes comprend l'espacement vertical entre les objets."
+            "value" : "Les tokens Column Gap comprondent à l'espacement vertical entre les objets."
           }
         }
       }
@@ -2810,7 +2810,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'espace fait référence aux mesures utilisées pour définir l'espacement entre les éléments de l'interface utilisateur."
+            "value" : "Les tokens Space font référence aux mesures utilisées pour définir l'espacement entre les éléments de l'interface utilisateur."
           }
         }
       }
@@ -2859,7 +2859,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'espacement fixe fait référence à une distance constante entre les éléments qui reste la même quels que soient des facteurs tels que la taille du conteneur, la résolution de l'écran ou les changements de mise en page."
+            "value" : "Les tokens Fixed font référence à une distance constante entre les éléments qui reste la même quels que soient des facteurs tels que la taille du conteneur, la résolution de l'écran ou les changements de mise en page."
           }
         }
       }
@@ -2933,7 +2933,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le remplissage en ligne inclut le remplissage gauche et droit d'un objet ou d'un groupe d'objets."
+            "value" : "Les tokens de Padding inline définissent le remplissage gauche et droit d'un objet ou d'un groupe d'objets."
           }
         }
       }
@@ -2982,7 +2982,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Le remplissage inséré comprend le remplissage gauche, droit, supérieur et inférieur, tous les paramètres étant égaux."
+            "value" : "Les tokens Padding Inset corespondent au remplissage équivalant autour d’un objet (gauche, droit, supérieur et inférieur)."
           }
         }
       }
@@ -3031,7 +3031,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La pile de rembourrage comprend le rembourrage supérieur et inférieur."
+            "value" : "Les tokens Padding Stack comprondent au rembourrage supérieur et inférieur."
           }
         }
       }
@@ -3080,7 +3080,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'espacement des rangées comprend l'espacement horizontal entre les objets."
+            "value" : "Les tokens Raw Gap corespondent à l'espacement horizontal entre les objets."
           }
         }
       }
@@ -3129,7 +3129,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'espacement mis à l'échelle fait référence à un espacement qui s'ajuste de manière dynamique en fonction de facteurs tels que la taille du conteneur, la résolution de l'écran ou les éléments de mise en page."
+            "value" : "Les ‘tokens Scaled font référence à un espacement qui s'ajuste de manière dynamique en fonction de facteurs tels que la taille du conteneur, la résolution de l'écran ou les éléments de mise en page."
           }
         }
       }
@@ -3153,7 +3153,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les ombres sont utilisées pour donner l'impression de distance ou d'élévation entre les surfaces, ce qui ajoute de la profondeur à nos designs."
+            "value" : "Les tokens Elevation sont utilisées pour donner l'impression de distance ou d'élévation entre les surfaces, ce qui ajoute de la profondeur à nos designs."
           }
         }
       }
@@ -3202,7 +3202,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Les grilles sont utilisées pour positionner le contenu et créer des mises en page de page cohérentes."
+            "value" : "Les tokens Grid sont utilisées pour positionner le contenu et créer des mises en page de page cohérentes."
           }
         }
       }
@@ -3251,7 +3251,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'opacité peut aider à distinguer les éléments de premier plan des éléments d'arrière-plan, rendant le contenu plus facile à lire et les actions importantes plus visibles."
+            "value" : "Les tokens Opacity peuvent aider à distinguer les éléments de premier plan des éléments d'arrière-plan, rendant le contenu plus facile à lire et les actions importantes plus visibles."
           }
         }
       }
@@ -3300,7 +3300,7 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La typographie est notre système de polices de caractère et de styles de texte. Ils améliorent la communication et renforcent le style de la marque."
+            "value" : "Les tokens Font (i.e. typographie) définissent notre système de polices de caractères et de styles de texte. Ils améliorent la communication et renforcent le style de la marque."
           }
         }
       }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#654

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- (NA) My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
