### PR TITLE
[#622] Add title in Compoent and Token screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [DesignToolbox] Add title in Component and Token screens ([#662](https://github.com/Orange-OpenSource/ouds-ios/issues/662))
 - [DesignToolbox] Udpate wordings to avoid traduction for components and tokens names ([#654](https://github.com/Orange-OpenSource/ouds-ios/issues/654))
 - [DesignToolbox] Use the new Switch component in all screens of the application ([#431](https://github.com/Orange-OpenSource/ouds-ios/issues/431))
 - [Library] Debug warnings for link and button components for WCAG 2.1 3:1 and 4.5:1 ratios on colored surface ([#656](https://github.com/Orange-OpenSource/ouds-ios/issues/656))

--- a/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/About/AboutPage.swift
@@ -81,7 +81,9 @@ struct AboutPage: View {
                     UIApplication.shared.open(appSettingsUrl)
                 }.accessibilityHint("app_about_appSettings_hint_a11y")
             }
-            .navigationTitle("app_bottomBar_about_label")
+            .oudsNavigationTitle("app_bottomBar_about_label")
+            .navigationBarTitleDisplayMode(.inline)
         }
+        .navigationViewStyle(.stack)
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Components/ComponentsPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Components/ComponentsPage.swift
@@ -28,7 +28,6 @@ struct ComponentsPage: View {
     ]
 
     var body: some View {
-        DesignToolboxElementsPage(elements: componentElements.sorted(by: { $0.name < $1.name }))
-            .oudsNavigationTitle("app_bottomBar_components_label")
+        DesignToolboxElementsPage(title: "app_bottomBar_components_label", elements: componentElements.sorted(by: { $0.name < $1.name }))
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Tokens/TokensPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Tokens/TokensPage.swift
@@ -26,7 +26,6 @@ struct TokensPage: View {
     ]
 
     var body: some View {
-        DesignToolboxElementsPage(elements: tokenElements.sorted(by: { $0.name < $1.name }))
-            .oudsNavigationTitle("app_bottomBar_tokens_label")
+        DesignToolboxElementsPage(title: "app_bottomBar_tokens_label", elements: tokenElements.sorted(by: { $0.name < $1.name }))
     }
 }

--- a/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementsPage.swift
+++ b/DesignToolbox/DesignToolbox/Pages/Utils/Elements/DesignToolboxElementsPage.swift
@@ -24,6 +24,7 @@ struct DesignToolboxElementsPage: View {
 
     // MARK: Stored properties
 
+    let title: String
     let elements: [DesignToolboxElement]
 
     // MARK: Body
@@ -48,6 +49,8 @@ struct DesignToolboxElementsPage: View {
                 .navigationbarMenuForThemeSelection()
             }
             .oudsBackground(theme.colors.colorBgPrimary)
+            .oudsNavigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
         }
         .navigationViewStyle(.stack)
     }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#662

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- (NA) My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
