### PR TITLE
[#680] Bug: Set boder as inner stroke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Set border as inner stroke (Orange-OpenSource/ouds-ios#680)
 - Bad wording key for accessibility label of switch item (Orange-OpenSource/ouds-ios#642)
 - Missing accessibility hint for switch (Orange-OpenSource/ouds-ios#642)
 - Missing token `colorBorderMuted` (Orange-OpenSource/ouds-ios#643)

--- a/OUDS/Core/Components/Sources/ViewModifiers/BorderModifiers/BorderModifier.swift
+++ b/OUDS/Core/Components/Sources/ViewModifiers/BorderModifiers/BorderModifier.swift
@@ -73,15 +73,17 @@ struct BorderModifier: ViewModifier {
     private func solid(_ content: Content) -> some View {
         content
             .clipShape(RoundedRectangle(cornerRadius: radius))
-            .overlay(RoundedRectangle(cornerRadius: radius).stroke(color.color(for: colorScheme), lineWidth: width))
-            .oudsForegroundColor(color)
+            .overlay(RoundedRectangle(cornerRadius: radius)
+                    .strokeBorder(color.color(for: colorScheme), lineWidth: width)
+                    .oudsForegroundColor(color)
+            )
     }
 
     private func dashed(_ content: Content) -> some View {
         content
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(RoundedRectangle(cornerRadius: radius)
-                .stroke(style: StrokeStyle(lineWidth: width, dash: [2, 2]))
+                .strokeBorder(style: StrokeStyle(lineWidth: width, dash: [2, 2]))
                 .oudsForegroundColor(color)
             )
     }
@@ -90,7 +92,7 @@ struct BorderModifier: ViewModifier {
         content
             .clipShape(RoundedRectangle(cornerRadius: radius))
             .overlay(RoundedRectangle(cornerRadius: radius)
-                .stroke(style: StrokeStyle(lineWidth: width, dash: [1, 5]))
+                .strokeBorder(style: StrokeStyle(lineWidth: width, dash: [1, 5]))
                 .oudsForegroundColor(color)
             )
     }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#680

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
