### PR TITLE
[#690] Add versions of components in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/0.15.0...develop)
 
+### Changed
+
+- Improve documentation of components by adding component versions
+
 ## [0.15.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.14.0...0.15.0) - 2025-05-28
 
 ### Added

--- a/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Buttons/OUDSButton.swift
@@ -70,6 +70,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/48a788-button)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.10.0
 public struct OUDSButton: View {
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
@@ -68,6 +68,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.12.0
 public struct OUDSCheckbox: View {
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
@@ -69,6 +69,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.12.0
 public struct OUDSCheckboxIndeterminate: View {
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
@@ -110,8 +110,10 @@ import SwiftUI
 /// According to the [documentation](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox/t/14bf4bd854), the checkbox by default must be used in unselected state.
 ///
 /// ## Design documentation
+///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.12.0
 public struct OUDSCheckboxItem: View {
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -120,6 +120,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.12.0
 public struct OUDSCheckboxItemIndeterminate: View {
 

--- a/OUDS/Core/Components/Sources/Divider/OUDSHorizontalDivider.swift
+++ b/OUDS/Core/Components/Sources/Divider/OUDSHorizontalDivider.swift
@@ -29,6 +29,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/629e1b-divider)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.14.0
 public struct OUDSHorizontalDivider: View { // TODO: #511 - Update documentation hyperlink
 

--- a/OUDS/Core/Components/Sources/Divider/OUDSVerticalDivider.swift
+++ b/OUDS/Core/Components/Sources/Divider/OUDSVerticalDivider.swift
@@ -29,6 +29,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/629e1b-divider)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.14.0
 public struct OUDSVerticalDivider: View { // TODO: #511 - Update documentation hyperlink
 

--- a/OUDS/Core/Components/Sources/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Link/OUDSLink.swift
@@ -48,6 +48,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/31c33b-link)
 ///
+/// - Version: 2.0.0
 /// - Since: 0.11.0
 public struct OUDSLink: View {
 

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
@@ -56,6 +56,7 @@ import SwiftUI
 ///
 /// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/90c467-radio-button)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.12.0
 public struct OUDSRadio: View {
 

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
@@ -72,9 +72,9 @@ import SwiftUI
 ///     // The default layout will be used here.
 ///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", isReadOnly: true)
 ///
-///     // A leading radio with a label, and an helper text.
+///     // A leading radio with a label, and an additional label but without text.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", helper: "The Beatles")
+///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", additionalLabel: "The Beatles")
 ///
 ///     // A leading radio with an additional label.
 ///     // The default layout will be used here.
@@ -116,6 +116,7 @@ import SwiftUI
 ///
 /// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/90c467-radio-button)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.12.0
 public struct OUDSRadioItem: View {
 

--- a/OUDS/Core/Components/Sources/Switch/OUDSSwitch.swift
+++ b/OUDS/Core/Components/Sources/Switch/OUDSSwitch.swift
@@ -40,6 +40,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/18acc0-switch)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.14.0
 public struct OUDSSwitch: View {
 

--- a/OUDS/Core/Components/Sources/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Switch/OUDSSwitchItem.swift
@@ -104,6 +104,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/18acc0-switch)
 ///
+/// - Version: 1.0.0
 /// - Since: 0.14.0
 public struct OUDSSwitchItem: View {
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#690 

### Description

<!-- Describe your changes in detail -->
Add version meta tag in documentation with versions of components

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

Display Figma components versions in the tehnical documentation

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_

### Rendering of documentation with evolution

<img width="1646" alt="Capture d’écran 2025-06-05 à 11 07 53" src="https://github.com/user-attachments/assets/2b3b0080-4e39-4e71-a132-b1822aff9252" />
