### PR TITLE
[#645] Fix colors for radio and checkbox components in high contrast light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve documentation of components by adding component versions
+
 ### Fixed
 
 - Change color of indicator and borders in high contrast mode (light scheme) for radio and checkbox components (#645)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Improve documentation of components by adding component versions
+### Fixed
+
+- Change color of indicator and borders in high contrast mode (light scheme) for radio and checkbox components (#645)
 
 ## [0.15.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.14.0...0.15.0) - 2025-05-28
 

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicator.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicator.swift
@@ -18,6 +18,7 @@ import SwiftUI
 
 /// The indicator of the checkbox.
 /// Its content depends to the ``InteractionState`` and the ``OUDSCheckboxIndicatorState`` also.
+/// This `View` manages also the high contrast mode in light color scheme so as to use a dedicated color for indicator.
 struct CheckboxIndicator: View {
 
     // MARK: - Properties
@@ -27,6 +28,8 @@ struct CheckboxIndicator: View {
     let isError: Bool
 
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Body
 
@@ -59,6 +62,7 @@ struct CheckboxIndicator: View {
     }
 
     private var appliedColor: MultipleColorSemanticTokens {
+        // Error case
         if isError {
             switch interactionState {
             case .enabled:
@@ -71,10 +75,16 @@ struct CheckboxIndicator: View {
                 OL.fatal("An OUDS Checkbox with a disabled state / read only mode and an error situation has been detected, which is not allowed"
                     + " Only non-error situation are allowed to have a disabled state / read only mode.")
             }
+
+            // Not error case
         } else {
             switch interactionState {
             case .enabled:
-                theme.colors.colorActionSelected
+                if colorSchemeContrast == .increased, colorScheme == .light {
+                    theme.colors.colorContentDefault
+                } else {
+                    theme.colors.colorActionSelected
+                }
             case .hover:
                 theme.colors.colorActionHover
             case .pressed:

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicatorModifiers.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxIndicatorModifiers.swift
@@ -21,6 +21,7 @@ import SwiftUI
 /// A `ViewModier` to apply to the ``CheckboxIndicator`` component.
 /// It will define the look and feel of the indicator depending to the ``InteractionState``,
 /// the ``OUDSCheckboxIndicatorState`` and if there is an error context or not.
+/// This `View` manages also the high contrast mode in light color scheme so as to use a dedicated color for indicator.
 struct CheckboxIndicatorModifier: ViewModifier {
 
     // MARK: - Properties
@@ -170,6 +171,8 @@ private struct CheckboxIndicatorBorderModifier: ViewModifier {
     let isError: Bool
 
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Body
 
@@ -202,7 +205,11 @@ private struct CheckboxIndicatorBorderModifier: ViewModifier {
         } else {
             switch indicatorState {
             case .selected, .indeterminate:
-                theme.colors.colorActionSelected
+                if colorSchemeContrast == .increased, colorScheme == .light {
+                    theme.colors.colorContentDefault
+                } else {
+                    theme.colors.colorActionSelected
+                }
             case .unselected:
                 theme.colors.colorActionEnabled
             }

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
@@ -77,9 +77,10 @@ public struct OUDSCheckbox: View {
     private let isError: Bool
     private let a11yLabel: String
 
-    @Binding var isOn: Bool
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.theme) private var theme
+
+    @Binding var isOn: Bool
 
     // MARK: - Initializers
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
@@ -81,8 +81,6 @@ public struct OUDSCheckboxIndeterminate: View {
     @Binding var selection: OUDSCheckboxIndicatorState
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.theme) private var theme
-    @Environment(\.colorScheme) private var colorScheme
-    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Initializers
 

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
@@ -81,6 +81,8 @@ public struct OUDSCheckboxIndeterminate: View {
     @Binding var selection: OUDSCheckboxIndicatorState
     @Environment(\.isEnabled) private var isEnabled
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Initializers
 

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
@@ -73,7 +73,7 @@ struct ControlItemBordersModifier: ViewModifier {
             isOn ? theme.colors.colorActionNegativeEnabled : nil
         } else {
             if colorSchemeContrast == .increased, colorScheme == .light {
-                theme.colors.colorContentDefault
+                isOn ? theme.colors.colorContentDefault : nil
             } else {
                 isOn ? theme.colors.colorActionSelected : nil
             }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
@@ -19,6 +19,7 @@ import SwiftUI
 /// A `ViewModifier` to apply to `ControlItem` views so as to define an outline effect, i.e. draw kind of borders around the object, or a divider.
 /// As they are not supposed to be displayed at the same time, even if it is requested the divider is not displayed if the outline effect is active.
 /// If this view modifier is used to draw an outline in an error context for a disabled component, a *fatal error* will happen because this behaviour is forbidden by design.
+/// This `ViewModifier` manages also the high contrast mode in light color scheme so as to use a dedicated color for borders.
 struct ControlItemBordersModifier: ViewModifier {
 
     // MARK: Stored properties
@@ -28,6 +29,8 @@ struct ControlItemBordersModifier: ViewModifier {
     let isOn: Bool
 
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: Body
 
@@ -69,7 +72,11 @@ struct ControlItemBordersModifier: ViewModifier {
         if layoutData.isError {
             isOn ? theme.colors.colorActionNegativeEnabled : nil
         } else {
-            isOn ? theme.colors.colorActionSelected : nil
+            if colorSchemeContrast == .increased, colorScheme == .light {
+                theme.colors.colorContentDefault
+            } else {
+                isOn ? theme.colors.colorActionSelected : nil
+            }
         }
     }
 

--- a/OUDS/Core/Components/Sources/Internal/InteractionState/InteractionButton.swift
+++ b/OUDS/Core/Components/Sources/Internal/InteractionState/InteractionButton.swift
@@ -14,7 +14,7 @@
 import SwiftUI
 
 /// The button will compute the `InteractionState` to send it to the provided content builder.
-/// This state is computed by the `InteractinButtonStyle`.
+/// This state is computed by the `InteractionButtonStyle`.
 ///
 /// Remark: If the isReadOnly flag is true the action on the button is dropped.
 struct InteractionButton<Content>: View where Content: View {
@@ -28,7 +28,10 @@ struct InteractionButton<Content>: View where Content: View {
 
     // MARK: Initializer
 
-    init(isReadOnly: Bool = false, action: @escaping () -> Void, @ViewBuilder content: @escaping (InteractionState) -> Content) {
+    init(isReadOnly: Bool = false,
+         action: @escaping () -> Void,
+         @ViewBuilder content: @escaping (InteractionState) -> Content)
+    {
         self.isReadOnly = isReadOnly
         self.action = action
         self.content = content
@@ -42,7 +45,7 @@ struct InteractionButton<Content>: View where Content: View {
                 action()
             }
         }
-        .buttonStyle(InteractinButtonStyle(isReadOnly: isReadOnly, content: content))
+        .buttonStyle(InteractionButtonStyle(isReadOnly: isReadOnly, content: content))
     }
 }
 
@@ -53,7 +56,7 @@ struct InteractionButton<Content>: View where Content: View {
 /// - the isPressed flag get from `ButtonStyle.Configuration`
 /// - the isEnabled flag get from the `@Environement`
 /// - the isReadOnly flag provided by the init function.
-struct InteractinButtonStyle<Content>: ButtonStyle where Content: View {
+private struct InteractionButtonStyle<Content>: ButtonStyle where Content: View {
 
     // MARK: Stored properties
 

--- a/OUDS/Core/Components/Sources/Radio/Internal/RadioIndicatorModifiers.swift
+++ b/OUDS/Core/Components/Sources/Radio/Internal/RadioIndicatorModifiers.swift
@@ -20,6 +20,7 @@ import SwiftUI
 
 /// A `ViewModier` to apply to the ``RadioIndicator`` component.
 /// It will define the look and feel of the indicator depending to the ``InteractionState`` and some flags
+/// This `View` manages also the high contrast mode in light color scheme so as to use a dedicated color for indicator.
 struct RadioIndicatorModifier: ViewModifier {
 
     // MARK: - Properties
@@ -50,6 +51,8 @@ private struct RadioIndicatorForegroundModifier: ViewModifier {
     let isError: Bool
 
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Body
 
@@ -77,7 +80,11 @@ private struct RadioIndicatorForegroundModifier: ViewModifier {
         if isError {
             theme.colors.colorActionNegativeEnabled
         } else {
-            isOn ? theme.colors.colorActionSelected : theme.colors.colorActionEnabled
+            if colorSchemeContrast == .increased, colorScheme == .light {
+                theme.colors.colorContentDefault
+            } else {
+                isOn ? theme.colors.colorActionSelected : theme.colors.colorActionEnabled
+            }
         }
     }
 
@@ -161,6 +168,8 @@ private struct RadioIndicatorBorderModifier: ViewModifier {
     let isError: Bool
 
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: - Body
 
@@ -191,7 +200,11 @@ private struct RadioIndicatorBorderModifier: ViewModifier {
         if isError {
             theme.colors.colorActionNegativeEnabled
         } else {
-            isOn ? theme.colors.colorActionSelected : theme.colors.colorActionEnabled
+            if colorSchemeContrast == .increased, colorScheme == .light {
+                theme.colors.colorContentDefault
+            } else {
+                isOn ? theme.colors.colorActionSelected : theme.colors.colorActionEnabled
+            }
         }
     }
 


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
Closes #645 

### Description

<!-- Describe your changes in detail -->

For radio button and checkbox components, if high contrast mode is enabled and device in light mode, change some colors for better contrast ratio without impacting hover, pressed, or error states.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

But compliant with a11y rules

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA)  Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
