### PR TITLE
[#437] Fix color of default loading button in high contrast light mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Change color of indicator and borders in high contrast mode (light scheme) for radio and checkbox components (#645)
+- Change color of button loader in high contrast light mode (#437)
 
 ## [0.15.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.14.0...0.15.0) - 2025-05-28
 

--- a/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+BorderModifier.swift
+++ b/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+BorderModifier.swift
@@ -22,6 +22,8 @@ struct ButtonBorderModifier: ViewModifier {
     @Environment(\.theme) private var theme
     @Environment(\.oudsUseMonochrome) private var useMonochrome
     @Environment(\.oudsOnColoredSurface) private var onColoredSurface
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
 
     // MARK: Stored Properties
 
@@ -88,7 +90,11 @@ struct ButtonBorderModifier: ViewModifier {
         case .pressed:
             useMonochrome ? theme.button.buttonColorBorderDefaultPressedMono : theme.button.buttonColorBorderDefaultPressed
         case .loading:
-            useMonochrome ? theme.button.buttonColorBorderDefaultLoadingMono : theme.button.buttonColorBorderDefaultLoading
+            if colorSchemeContrast == .increased, colorScheme == .light {
+                theme.colors.colorContentDefault
+            } else {
+                useMonochrome ? theme.button.buttonColorBorderDefaultLoadingMono : theme.button.buttonColorBorderDefaultLoading
+            }
         case .disabled:
             useMonochrome ? theme.button.buttonColorBorderDefaultDisabledMono : theme.button.buttonColorBorderDefaultDisabled
         }

--- a/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+LoadingModifiers.swift
+++ b/OUDS/Core/Components/Sources/Buttons/Internal/ButtonStyle+LoadingModifiers.swift
@@ -21,10 +21,12 @@ import SwiftUI
 /// Used to add a progress indicator instead of content (Text, Icon)
 /// As the button must keep the size of the content, the indicator is
 /// added as overlay on top, and the content is hidden applying an opacity.
+/// If the device has the high contrast mode enabled, changes the loader color.
 struct ButtonLoadingContentModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @Environment(\.oudsUseMonochrome) private var useMonochrome
 
     // MARK: Stored Properties
@@ -46,7 +48,11 @@ struct ButtonLoadingContentModifier: ViewModifier {
     private var colorToken: MultipleColorSemanticTokens {
         switch hierarchy {
         case .default:
-            useMonochrome ? theme.button.buttonColorContentDefaultLoadingMono : theme.button.buttonColorContentDefaultLoading
+            if colorSchemeContrast == .increased, colorScheme == .light {
+                theme.colors.colorContentDefault
+            } else {
+                useMonochrome ? theme.button.buttonColorContentDefaultLoadingMono : theme.button.buttonColorContentDefaultLoading
+            }
         case .strong:
             useMonochrome ? theme.button.buttonColorContentStrongLoadingMono : theme.colors.colorContentOnActionLoading
         case .minimal:


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#437 

### Description

<!-- Describe your changes in detail -->

In default loading button change color if high contrast light mode

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
