### PR TITLE
[#720] Update background color in pressecd and hover states for Radio button and Checkbox components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update background color in pressecd and hover states for Radio button and Checkbox components (Orange-OpenSource/ouds-ios#4720) 
+- Background color in pressed and hover states for Radio button and Checkbox components (Orange-OpenSource/ouds-ios#720)  
 - Change color of indicator and borders in high contrast mode (light scheme) for radio and checkbox components (Orange-OpenSource/ouds-ios#645)
 - Change color of button loader in high contrast light mode (Orange-OpenSource/ouds-ios#437)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update background color in pressecd and hover states for Radio button and Checkbox components (Orange-OpenSource/ouds-ios#4720) 
 - Change color of indicator and borders in high contrast mode (light scheme) for radio and checkbox components (Orange-OpenSource/ouds-ios#645)
 - Change color of button loader in high contrast light mode (Orange-OpenSource/ouds-ios#437)
 

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxBackgroundColorModifier.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxBackgroundColorModifier.swift
@@ -2,13 +2,26 @@
 // Software Name: OUDS iOS
 // SPDX-FileCopyrightText: Copyright (c) Orange SA
 // SPDX-License-Identifier: MIT
-// 
+//
 // This software is distributed under the MIT license,
 // the text of which is available at https://opensource.org/license/MIT/
 // or see the "LICENSE" file for more details.
-// 
+//
 // Authors: See CONTRIBUTORS.txt
-// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
 import OUDSTokensSemantic

--- a/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxBackgroundColorModifier.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/Internal/CheckboxBackgroundColorModifier.swift
@@ -1,0 +1,39 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import OUDSTokensSemantic
+import SwiftUI
+
+// MARK: - Checkbox Background Color
+
+struct CheckboxBackgroundColorModifier: ViewModifier {
+
+    // MARK: Properties
+
+    var interactionState: InteractionState
+
+    @Environment(\.theme) private var theme
+
+    // MARK: Body
+
+    func body(content: Content) -> some View {
+        switch interactionState {
+        case .enabled, .disabled, .readOnly:
+            content
+        case .hover:
+            content.oudsBackground(theme.controlItem.controlItemColorBgHover)
+        case .pressed:
+            content.oudsBackground(theme.controlItem.controlItemColorBgPressed)
+        }
+    }
+}

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckbox.swift
@@ -72,7 +72,7 @@ import SwiftUI
 /// - Since: 0.12.0
 public struct OUDSCheckbox: View {
 
-    // MARK: - Properties
+    // MARK: Properties
 
     private let isError: Bool
     private let a11yLabel: String
@@ -82,7 +82,7 @@ public struct OUDSCheckbox: View {
 
     @Binding var isOn: Bool
 
-    // MARK: - Initializers
+    // MARK: Initializers
 
     /// Creates a checkbox with only an indicator.
     ///
@@ -116,6 +116,7 @@ public struct OUDSCheckbox: View {
                        minHeight: theme.checkbox.checkboxSizeMinHeight,
                        maxHeight: theme.checkbox.checkboxSizeMaxHeight)
                 .contentShape(Rectangle())
+                .modifier(CheckboxBackgroundColorModifier(interactionState: interactionState))
         }
         .accessibilityRemoveTraits([.isButton]) // .isToggle trait for iOS 17+
         .accessibilityLabel(a11yLabel(isDisabled: !isEnabled))
@@ -123,7 +124,7 @@ public struct OUDSCheckbox: View {
         .accessibilityHint(a11yHint())
     }
 
-    // MARK: - Computed value
+    // MARK: Computed value
 
     private var convertedState: OUDSCheckboxIndicatorState {
         isOn ? .selected : .unselected

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxIndeterminate.swift
@@ -115,6 +115,7 @@ public struct OUDSCheckboxIndeterminate: View {
                        maxWidth: theme.checkbox.checkboxSizeMinWidth,
                        minHeight: theme.checkbox.checkboxSizeMinHeight,
                        maxHeight: theme.checkbox.checkboxSizeMaxHeight)
+                .modifier(CheckboxBackgroundColorModifier(interactionState: interactionState))
         }
         .accessibilityRemoveTraits([.isButton]) // .isToggle trait for iOS 17+
         .accessibilityLabel(a11yLabel(isDisabled: !isEnabled))

--- a/OUDS/Core/Components/Sources/Radio/Internal/RadioBackgroundModifier.swift
+++ b/OUDS/Core/Components/Sources/Radio/Internal/RadioBackgroundModifier.swift
@@ -1,0 +1,36 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+// 
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+// 
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+//
+
+import OUDSTokensSemantic
+import SwiftUI
+
+struct RadioBackgroundModifier: ViewModifier {
+
+    // MARK: Properties
+
+    var interactionState: InteractionState
+    @Environment(\.theme) private var theme
+
+    // MARK: Body
+
+    func body(content: Content) -> some View {
+        switch interactionState {
+        case .enabled, .disabled, .readOnly:
+            content
+        case .hover:
+            content.oudsBackground(theme.controlItem.controlItemColorBgHover)
+        case .pressed:
+            content.oudsBackground(theme.controlItem.controlItemColorBgPressed)
+        }
+    }
+}

--- a/OUDS/Core/Components/Sources/Radio/Internal/RadioBackgroundModifier.swift
+++ b/OUDS/Core/Components/Sources/Radio/Internal/RadioBackgroundModifier.swift
@@ -2,13 +2,26 @@
 // Software Name: OUDS iOS
 // SPDX-FileCopyrightText: Copyright (c) Orange SA
 // SPDX-License-Identifier: MIT
-// 
+//
 // This software is distributed under the MIT license,
 // the text of which is available at https://opensource.org/license/MIT/
 // or see the "LICENSE" file for more details.
-// 
+//
 // Authors: See CONTRIBUTORS.txt
-// Software description: A SwiftUI components library with code examples for Orange Unified Design System 
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
 import OUDSTokensSemantic
@@ -19,6 +32,7 @@ struct RadioBackgroundModifier: ViewModifier {
     // MARK: Properties
 
     var interactionState: InteractionState
+
     @Environment(\.theme) private var theme
 
     // MARK: Body

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadio.swift
@@ -101,6 +101,7 @@ public struct OUDSRadio: View {
                 .frame(minWidth: theme.radioButton.radioButtonSizeMinWidth,
                        minHeight: theme.radioButton.radioButtonSizeMinHeight,
                        maxHeight: theme.radioButton.radioButtonSizeMaxHeight)
+                .modifier(RadioBackgroundModifier(interactionState: interactionState))
         }
         .accessibilityRemoveTraits([.isButton]) // .isToggle trait for iOS 17+
         .accessibilityLabel(a11yLabel)


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#720 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- (NA)  My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
