### PR TITLE
[#777] Update `controlItem` component to use `controlItemBorderRadius*` tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Update `controlItem` component to use `controlItemBorderRadius*` tokens (Orange-OpenSource/ouds-ios#777)
 - Update `switch` component to use `switchBorderRadius*` tokens (Orange-OpenSource/ouds-ios#780)
 
 ## [0.16.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.15.0...0.16.0) - 2025-07-07

--- a/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Checkbox/OUDSCheckboxItem.swift
@@ -114,7 +114,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/09d860-checkbox)
 ///
-/// - Version: 2.0.0
+/// - Version: 2.1.0
 /// - Since: 0.12.0
 public struct OUDSCheckboxItem: View {
 

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemBordersModifier.swift
@@ -39,7 +39,7 @@ struct ControlItemBordersModifier: ViewModifier {
             content
                 .oudsBorder(style: theme.borders.borderStyleDefault,
                             width: theme.borders.borderWidthDefault,
-                            radius: theme.borders.borderRadiusNone,
+                            radius: borderRadius,
                             color: borderColor)
         } else {
             if layoutData.hasDivider {
@@ -95,5 +95,11 @@ struct ControlItemBordersModifier: ViewModifier {
                 + " Only non-error situation are allowed to have a disabled state.")
         }
         return isOn ? theme.colors.colorActionDisabled : nil
+    }
+
+    private var borderRadius: BorderRadiusSemanticToken {
+        interactionState == .readOnly ?
+        theme.controlItem.controlItemBorderRadiusItemOnly :
+        theme.controlItem.controlItemBorderRadius
     }
 }

--- a/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
+++ b/OUDS/Core/Components/Sources/Internal/ControlItem/ControlItemContent.swift
@@ -52,6 +52,7 @@ struct ControlItemContent: View {
         .padding(.all, theme.controlItem.controlItemSpaceInset)
         .oudsBackground(backgroundColor)
         .modifier(ControlItemBordersModifier(interactionState: interactionState, layoutData: layoutData, isOn: isOn))
+        .clipShape(RoundedRectangle(cornerRadius: theme.controlItem.controlItemBorderRadius))
     }
 
     // MARK: Containers

--- a/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Radio/OUDSRadioItem.swift
@@ -117,7 +117,7 @@ import SwiftUI
 ///
 /// See [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/90c467-radio-button)
 ///
-/// - Version: 1.0.0
+/// - Version: 1.1.0
 /// - Since: 0.12.0
 public struct OUDSRadioItem: View {
 

--- a/OUDS/Core/Components/Sources/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Switch/OUDSSwitchItem.swift
@@ -104,7 +104,7 @@ import SwiftUI
 ///
 /// [unified-design-system.orange.com](https://unified-design-system.orange.com/472794e18/p/18acc0-switch)
 ///
-/// - Version: 1.0.0
+/// - Version: 1.1.0
 /// - Since: 0.14.0
 public struct OUDSSwitchItem: View {
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#777

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
