### PR TITLE
[#841] Update typography in title of the ChipPicker component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update typography of the title in the ChipPicker component (Orange-OpenSource/ouds-ios#841)
 - Chip version 1.3.0 (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#906)
 - Text input component tokens (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#898)
 - Link component tokens (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#898)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update typography of the title in the ChipPicker component (Orange-OpenSource/ouds-ios#841)
+- Update typography of the title in the chip picker component (Orange-OpenSource/ouds-ios#841)
 - Chip version 1.3.0 (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#906)
 - Text input component tokens (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#898)
 - Link component tokens (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#898)

--- a/OUDS/Core/Components/Sources/Chips/Pickers/OUDSChipPicker.swift
+++ b/OUDS/Core/Components/Sources/Chips/Pickers/OUDSChipPicker.swift
@@ -157,7 +157,7 @@ public struct OUDSChipPicker<Tag>: View where Tag: Hashable {
         VStack(alignment: .leading, spacing: theme.spaces.spaceFixedSm) {
             if let title, !title.isEmpty {
                 Text(title)
-                    .typeHeadingLarge(theme)
+                    .typeBodyStrongLarge(theme)
                     .padding(.leading, theme.spaces.spaceFixedMd)
                     .accessibilityAddTraits(.isHeader)
             }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

#841 

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

Update the title of the ChipPicker to confor figma.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- (NA) Documentation has been updated if relevant
- (NA) Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
