### PR TITLE
[#855] Update API to use a specific size for count and icon badge types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Color semantic tokens (Orange-OpenSource/ouds-ios#915)
 - Update API to use a specific size for count and icon badge types (Orange-OpenSource/ouds-ios#855)
+- Use specific size types for count and icon badges (Orange-OpenSource/ouds-ios#855)
 - Structure of components and files in repository (Orange-OpenSource/ouds-ios#908)
 - Update typography of the title in the chip picker component (Orange-OpenSource/ouds-ios#841)
 - Chip version 1.3.0 (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#906)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Color semantic tokens (Orange-OpenSource/ouds-ios#915)
+- Update API to use a specific size for count and icon badge types (Orange-OpenSource/ouds-ios#855)
 - Structure of components and files in repository (Orange-OpenSource/ouds-ios#908)
 - Update typography of the title in the chip picker component (Orange-OpenSource/ouds-ios#841)
 - Chip version 1.3.0 (tokens library v1.5.0) (Orange-OpenSource/ouds-ios#906)

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeCount.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeCount.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 struct BadgeCount: View {
 
-    // MARK: Stored Properties
+    // MARK: Stored properties
 
     let count: UInt?
     let size: OUDSBadge.StandardSize

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeCount.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeCount.swift
@@ -20,7 +20,7 @@ struct BadgeCount: View {
     // MARK: Stored Properties
 
     let count: UInt?
-    let size: OUDSBadge.Size
+    let size: OUDSBadge.StandardSize
 
     @Environment(\.theme) private var theme
 

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
@@ -16,7 +16,7 @@ import SwiftUI
 
 struct BadgeIcon: View {
 
-    // MARK: Stored Properties
+    // MARK: Stored properties
 
     let icon: Image?
     let size: OUDSBadge.StandardSize

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
@@ -19,7 +19,7 @@ struct BadgeIcon: View {
     // MARK: Stored Properties
 
     let icon: Image?
-    let size: OUDSBadge.Size
+    let size: OUDSBadge.StandardSize
 
     @Environment(\.theme) private var theme
 

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -14,15 +14,13 @@
 import OUDSTokensSemantic
 import SwiftUI
 
-// MARK: - OUDS Badge
-
 /// The ``OUDSBadge`` is a small UI element used to highlight status, notifications, or categorization
 /// within an interface. It is often displayed as a label or indicator with a distinct background color and text.
 ///
 /// ## Code samples
 ///
 /// ```swift
-///     // Default badge is netral with medium size
+///     // Default badge is neutral with medium size
 ///     OUDSBadge()
 ///
 ///     // Accent badge in small size without information
@@ -45,7 +43,7 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
 
     static let maxCount = 99
 
-    // MARK: Stored Properties
+    // MARK: Stored properties
 
     private let status: Status
     private let size: StandardSize
@@ -55,10 +53,11 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
     @Environment(\.theme) private var theme
     @Environment(\.sizeCategory) private var sizeCategory: ContentSizeCategory
 
-    // MARK: - Configuration
+    // MARK: - Configurations
 
     /// The status depends on the context of the information it represents.
     public enum Status {
+
         /// Used for general labels without specific emphasis
         case neutral
 
@@ -83,8 +82,9 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         case disabled
     }
 
-    /// All available sizes of a badge as **stadard** type
+    /// All available sizes of a badge as *standard* type
     public enum StandardSize {
+
         /// A compact badge for minimal space usage, ideal for small UI elements like icons or tooltips.
         case extraSmall
 
@@ -98,8 +98,9 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         case large
     }
 
-    /// All available sizes of a badge with **count** or **icon**
+    /// All available sizes of a badge with *count* or *icon*
     public enum IllustrationSize {
+
         /// The default size, providing a balance between visibility and space efficiency, suitable for most use cases.
         case medium
 
@@ -107,7 +108,7 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         case large
 
         /// Internal usage: convert to standard size
-        var standardSize: StandardSize {
+        public var standardSize: StandardSize {
             switch self {
             case .medium:
                 .medium
@@ -119,7 +120,7 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
 
     // MARK: Initializers
 
-    /// Creates a basic standard badge.
+    /// Creates a basic standard neutral badge.
     ///
     /// - Parameters:
     ///    - status: The status of this badge. The background color of the badge is based on this status, *neutral* by default
@@ -133,8 +134,8 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
 
     /// Creates a badge which displays numerical value (e.g., unread messages, notifications).
     /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99, "+99" is displayed.
-    /// Negative values are not allowed.
-    /// The background color of the badge and the number color are based on thie given `status`.
+    /// Negative values are not allowed by design.
+    /// The background color of the badge and the number color are based on the given `status`.
     ///
     /// - Parameters:
     ///    - count:The number displayed in the badge.
@@ -147,7 +148,7 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         icon = nil
     }
 
-    /// Create a badge which displays an icon to visually reinforce meaning.
+    /// Creates a badge which displays an icon to visually reinforce meaning.
     /// It is used for status indicators (e.g., "New", "Pending", "Success").
     /// The size remains unchanged despite the increase in the interface size.
     /// The background color of the badge and the icon color are based on the given `status`.

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -48,7 +48,7 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
     // MARK: Stored Properties
 
     private let status: Status
-    private let size: Size
+    private let size: StandardSize
     private let count: UInt?
     private let icon: Image?
 
@@ -83,8 +83,8 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         case disabled
     }
 
-    /// All available sizes of a badge
-    public enum Size {
+    /// All available sizes of a badge as **stadard** type
+    public enum StandardSize {
         /// A compact badge for minimal space usage, ideal for small UI elements like icons or tooltips.
         case extraSmall
 
@@ -98,14 +98,33 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
         case large
     }
 
+    /// All available sizes of a badge with **count** or **icon**
+    public enum IllustrationSize {
+        /// The default size, providing a balance between visibility and space efficiency, suitable for most use cases.
+        case medium
+
+        /// A prominent badge for drawing more attention, often used in dashboards or highlighted sections.
+        case large
+
+        /// Internal usage: convert to standard size
+        var standardSize: StandardSize {
+            switch self {
+            case .medium:
+                .medium
+            case .large:
+                .large
+            }
+        }
+    }
+
     // MARK: Initializers
 
-    /// Creates a basic badge.
+    /// Creates a basic standard badge.
     ///
     /// - Parameters:
     ///    - status: The status of this badge. The background color of the badge is based on this status, *neutral* by default
     ///    - size: The size of this badge, *medium* by default
-    public init(status: Status = .neutral, size: Size = .medium) {
+    public init(status: Status = .neutral, size: StandardSize = .medium) {
         self.status = status
         self.size = size
         icon = nil
@@ -115,16 +134,15 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
     /// Creates a badge which displays numerical value (e.g., unread messages, notifications).
     /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99, "+99" is displayed.
     /// Negative values are not allowed.
-    /// The number is not displayed when size is `OUDSBadge.Size.extraSmall` or `OUDSBadge.Size.small`.
     /// The background color of the badge and the number color are based on thie given `status`.
     ///
     /// - Parameters:
     ///    - count:The number displayed in the badge.
     ///    - status: The status of this badge, default set to *neutral*
     ///    - size: The size of this badge, default set to *medium*
-    public init(count: UInt, status: Status = .neutral, size: Size = .medium) {
+    public init(count: UInt, status: Status = .neutral, size: IllustrationSize = .medium) {
         self.status = status
-        self.size = size
+        self.size = size.standardSize
         self.count = count
         icon = nil
     }
@@ -133,15 +151,14 @@ public struct OUDSBadge: View { // TODO: #514 - Add hyperlink for badge document
     /// It is used for status indicators (e.g., "New", "Pending", "Success").
     /// The size remains unchanged despite the increase in the interface size.
     /// The background color of the badge and the icon color are based on the given `status`.
-    /// The icon is not displayed when size is `OUDSBadge.Size.extraSmall` or `OUDSBadge.Size.small`.
     ///
     /// - Parameters:
     ///    - icon: The icon displayed in the badge
     ///    - status: The status of this badge, default set to *neutral*
     ///    - size: The size of this badge, default set to *medium*
-    public init(icon: Image, status: Status = .neutral, size: Size = .medium) {
+    public init(icon: Image, status: Status = .neutral, size: IllustrationSize = .medium) {
         self.status = status
-        self.size = size
+        self.size = size.standardSize
         count = nil
         self.icon = icon
     }

--- a/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxStateTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxStateTests.swift
@@ -14,7 +14,7 @@
 import OUDSComponents
 import Testing
 
-/// Tests some helper functions defined in extensions of `OUDSComponents` module.
+/// Tests some API for `OUDSCheckbox`
 struct OUDSCheckboxStateTests {
 
     /// A selected checkbox must be toggled to an unselected checkbox.

--- a/OUDS/Core/Components/Tests/Indicators/Badge/OUDSBadgeIllustrationSizeTests.swift
+++ b/OUDS/Core/Components/Tests/Indicators/Badge/OUDSBadgeIllustrationSizeTests.swift
@@ -1,0 +1,29 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSComponents
+import Testing
+
+/// Tests some API for `OUDSBadge`
+struct OUDSBadgeIllustrationSizeTests {
+
+    @Test("A medium illustration size for badge must be a medium standard size")
+    func mediumIllustrationSizeIsMediumStandardSize() {
+        #expect(OUDSBadge.IllustrationSize.medium.standardSize == .medium)
+    }
+
+    @Test("A large illustration size for badge must be a large standard size")
+    func largeIllustrationSizeIsLargetandardSize() {
+        #expect(OUDSBadge.IllustrationSize.large.standardSize == .large)
+    }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#855

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- [ ] Accessibility review has been done
- [ ] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
