### PR TITLE
[#969] `hierarchy` button component property renamed to `appearance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `SwiftFormat` Swift Package from v0.57.2 to v0.58.0
 - Update `ruby/setup-ruby` GitHub Actions action from v1.257.0 to v1.263.0
+- Button component `hierarchy` property renamed to `appearance` (Orange-OpenSource/ouds-ios#969)
 - Swift package `SwiftLintPlugins` from v0.60.0 to v0.60.1
 - Update various GitHub Actions workflows dependencies
 - Tuning of themes (like rounded corners) (Orange-OpenSource/ouds-ios#951)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Apply `Helvetica Neue` font family for themes `Orange`, `Orange Inverse` and `Orange Business Tools` (Orange-OpenSource/ouds-ios#965)
+- Button component `hierarchy` property renamed to `appearance` (Orange-OpenSource/ouds-ios#969)
 
 ## [0.19.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.18.0...0.19.0) - 2025-09-24
 
@@ -20,7 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Update `SwiftFormat` Swift Package from v0.57.2 to v0.58.0
 - Update `ruby/setup-ruby` GitHub Actions action from v1.257.0 to v1.263.0
-- Button component `hierarchy` property renamed to `appearance` (Orange-OpenSource/ouds-ios#969)
 - Swift package `SwiftLintPlugins` from v0.60.0 to v0.60.1
 - Update various GitHub Actions workflows dependencies
 - Tuning of themes (like rounded corners) (Orange-OpenSource/ouds-ios#951)

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+BackgroundModifier.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+BackgroundModifier.swift
@@ -16,7 +16,7 @@ import OUDSTokensComponent
 import OUDSTokensSemantic
 import SwiftUI
 
-/// Used to apply the right background color associated to the hierarchy and style
+/// Used to apply the right background color associated to the appearance and style
 struct ButtonBackgroundModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
@@ -24,7 +24,7 @@ struct ButtonBackgroundModifier: ViewModifier {
 
     // MARK: Stored Properties
 
-    let hierarchy: OUDSButton.Hierarchy
+    let appearance: OUDSButton.Appearance
     let state: ButtonInternalState
 
     // MARK: Body
@@ -55,7 +55,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     }
 
     private var enabledColor: MultipleColorSemanticTokens? {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorBgDefaultEnabled : theme.button.buttonColorBgDefaultEnabled
         case .strong:
@@ -70,7 +70,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     }
 
     private var hoverColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorBgDefaultHover : theme.button.buttonColorBgDefaultHover
         case .strong:
@@ -85,7 +85,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     }
 
     private var pressedColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorBgDefaultPressed : theme.button.buttonColorBgDefaultPressed
         case .strong:
@@ -100,7 +100,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     }
 
     private var loadingColor: MultipleColorSemanticTokens? {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorBgDefaultLoading : theme.button.buttonColorBgDefaultLoading
         case .strong:
@@ -115,7 +115,7 @@ struct ButtonBackgroundModifier: ViewModifier {
     }
 
     private var disabledColor: MultipleColorSemanticTokens? {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorBgDefaultDisabled : theme.button.buttonColorBgDefaultDisabled
         case .strong:

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+BorderModifier.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+BorderModifier.swift
@@ -16,7 +16,7 @@ import OUDSTokensComponent
 import OUDSTokensSemantic
 import SwiftUI
 
-/// Used to apply a border with color, width and radius associated to the hierarchy
+/// Used to apply a border with color, width and radius associated to the appearance
 struct ButtonBorderModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
@@ -27,13 +27,13 @@ struct ButtonBorderModifier: ViewModifier {
 
     // MARK: Stored Properties
 
-    let hierarchy: OUDSButton.Hierarchy
+    let appearance: OUDSButton.Appearance
     let state: ButtonInternalState
 
     // MARK: Body
 
     func body(content: Content) -> some View {
-        switch hierarchy {
+        switch appearance {
         case .default:
             content
                 .oudsBorder(
@@ -63,7 +63,7 @@ struct ButtonBorderModifier: ViewModifier {
         theme.tuning.hasRoundedButtons ? theme.button.buttonBorderRadiusRounded : theme.button.buttonBorderRadiusDefault
     }
 
-    // MARK: Default hierarchy
+    // MARK: Default appearance
 
     private var defaultWidth: BorderWidthSemanticToken {
         switch state {
@@ -99,7 +99,7 @@ struct ButtonBorderModifier: ViewModifier {
         }
     }
 
-    // MARK: Strong hierarchy
+    // MARK: Strong appearance
 
     private var strongColor: MultipleColorSemanticTokens {
         switch state {

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+ForegroundModifier.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+ForegroundModifier.swift
@@ -17,7 +17,7 @@ import OUDSTokensComponent
 import OUDSTokensSemantic
 import SwiftUI
 
-/// Used to apply the right forground color associated to the hierarchy and state
+/// Used to apply the right forground color associated to the appearance and state
 struct ButtonForegroundModifier: ViewModifier {
 
     @Environment(\.theme) private var theme
@@ -27,7 +27,7 @@ struct ButtonForegroundModifier: ViewModifier {
 
     // MARK: Stored Properties
 
-    let hierarchy: OUDSButton.Hierarchy
+    let appearance: OUDSButton.Appearance
     let state: ButtonInternalState
 
     // MARK: Body
@@ -59,7 +59,7 @@ struct ButtonForegroundModifier: ViewModifier {
     }
 
     private var enabledColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorContentDefaultEnabled : theme.button.buttonColorContentDefaultEnabled
         case .strong:
@@ -74,7 +74,7 @@ struct ButtonForegroundModifier: ViewModifier {
     }
 
     private var hoverColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorContentDefaultHover : theme.button.buttonColorContentDefaultHover
         case .strong, .brand:
@@ -87,7 +87,7 @@ struct ButtonForegroundModifier: ViewModifier {
     }
 
     private var pressedColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorContentDefaultPressed : theme.button.buttonColorContentDefaultPressed
         case .strong, .brand:
@@ -100,7 +100,7 @@ struct ButtonForegroundModifier: ViewModifier {
     }
 
     private var disabledColor: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             useMonochrome ? theme.button.buttonMonoColorContentDefaultDisabled : theme.button.buttonColorContentDefaultDisabled
         case .strong, .brand:

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
@@ -29,7 +29,7 @@ struct ButtonLoadingContentModifier: ViewModifier {
 
     // MARK: Stored Properties
 
-    let hierarchy: OUDSButton.Hierarchy
+    let appearance: OUDSButton.Appearance
 
     // MARK: Body
 
@@ -44,7 +44,7 @@ struct ButtonLoadingContentModifier: ViewModifier {
     // MARK: Private helper
 
     private var colorToken: MultipleColorSemanticTokens {
-        switch hierarchy {
+        switch appearance {
         case .default:
             if colorSchemeContrast == .increased, colorScheme == .light {
                 theme.colors.colorContentDefault

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+NormalModifier.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+NormalModifier.swift
@@ -24,20 +24,20 @@ enum ButtonInternalState {
 
 /// This modifier has in charge to:
 /// - compute the internal state based on `isEnabled`, `isPressed` and `isHover` flags
-/// - apply foreground, background colors and add a border (width, radius and color) associated to the hierarchy and according to the internal state
+/// - apply foreground, background colors and add a border (width, radius and color) associated to the appearance and according to the internal state
 struct ButtonViewModifier: ViewModifier {
 
     // MARK: Stored Properties
 
-    let hierarchy: OUDSButton.Hierarchy
+    let appearance: OUDSButton.Appearance
     let state: ButtonInternalState
 
     // MARK: Body
 
     func body(content: Content) -> some View {
         content
-            .modifier(ButtonForegroundModifier(hierarchy: hierarchy, state: state))
-            .modifier(ButtonBackgroundModifier(hierarchy: hierarchy, state: state))
-            .modifier(ButtonBorderModifier(hierarchy: hierarchy, state: state))
+            .modifier(ButtonForegroundModifier(appearance: appearance, state: state))
+            .modifier(ButtonBackgroundModifier(appearance: appearance, state: state))
+            .modifier(ButtonBorderModifier(appearance: appearance, state: state))
     }
 }

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle.swift
@@ -14,10 +14,10 @@
 import Foundation
 import SwiftUI
 
-/// Used to apply the right style on an ``OUDSButton`` according to the `hierarchy`
+/// Used to apply the right style on an ``OUDSButton`` according to the `appearance`
 /// and the `style`.
 ///
-/// Four hierarchies are proposed:
+/// Four appearances are proposed:
 /// - **default**: Default buttons are used for actions which are not mandatory or essential for the user.
 ///
 /// - **strong**: The strong "call for action" on the page should be singular and prominent, limited to one per view.
@@ -37,22 +37,22 @@ struct OUDSButtonStyle: ButtonStyle {
     // MARK: Stored Properties
 
     private let isHover: Bool
-    private let hierarchy: OUDSButton.Hierarchy
+    private let appearance: OUDSButton.Appearance
     private let style: OUDSButton.Style
 
     @Environment(\.isEnabled) private var isEnabled
 
     // MARK: Initializer
 
-    /// Initialize the `OUDSButtonStyle` for the `hierarchy`
+    /// Initialize the `OUDSButtonStyle` for the `appearance`
     /// and the `style` of the `OUDSButton`.
     ///
     /// - Parameters:
     ///    - isHover: Flag is button is hovered (e.g. by mouse)
-    ///    - hierarchy: The button hierarchy
+    ///    - appearance: The button appearance
     ///    - style: The button style
-    public init(isHover: Bool, hierarchy: OUDSButton.Hierarchy, style: OUDSButton.Style) {
-        self.hierarchy = hierarchy
+    public init(isHover: Bool, appearance: OUDSButton.Appearance, style: OUDSButton.Style) {
+        self.appearance = appearance
         self.style = style
         self.isHover = isHover
     }
@@ -63,11 +63,11 @@ struct OUDSButtonStyle: ButtonStyle {
         switch style {
         case .default:
             configuration.label
-                .modifier(ButtonViewModifier(hierarchy: hierarchy, state: internalState(isPressed: configuration.isPressed)))
+                .modifier(ButtonViewModifier(appearance: appearance, state: internalState(isPressed: configuration.isPressed)))
         case .loading:
             configuration.label
-                .modifier(ButtonViewModifier(hierarchy: hierarchy, state: .loading))
-                .modifier(ButtonLoadingContentModifier(hierarchy: hierarchy))
+                .modifier(ButtonViewModifier(appearance: appearance, state: .loading))
+                .modifier(ButtonLoadingContentModifier(appearance: appearance))
         }
     }
 

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -18,9 +18,9 @@ import SwiftUI
 
 /// The ``OUDSButton`` proposes layout with text only, icon only or text with icon.
 ///
-/// ## Hierarchies
+/// ## Appearances
 ///
-/// Five hierarchies are proposed for all layouts:
+/// Five appearances are proposed for all layouts:
 ///
 /// - **default (by default)**: Default buttons are used for actions which are not mandatory or essential for the user.
 ///
@@ -29,32 +29,32 @@ import SwiftUI
 ///
 /// - **brand**: A brand primary color alternative to the *strong* button.
 /// To be used sparingly for high-value specific actions or to visually anchor a brand moment. Do not use it as the default primary button in your interfaces.
-/// A button with `OUDSButton.Hierarchy.Brand` hierarchy is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
+/// A button with `OUDSButton.Appearance.Brand` appearance is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
 ///
 /// - **minimal**: Minimal buttons are commonly used for actions that are considered less crucial. They can be used independently or together with a strong button.
 ///
 /// - **negative**: Negative buttons should be used sparingly to warn of a destructive action,
 /// for example, delete or remove, typically resulting in the opening of a confirmation dialog.
-/// A button with `OUDSButton.Hierarchy.Negative` hierarchy is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
+/// A button with `OUDSButton.Appearance.Negative` appearance is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
 ///
 /// ## Code samples
 ///
 /// ```swift
-///     // Icon only with default hierarchy
-///     OUDSButton(icon: Image("ic_heart"), hierarchy: .default) { /* the action to process */ }
+///     // Icon only with default appearance
+///     OUDSButton(icon: Image("ic_heart"), appearance: .default) { /* the action to process */ }
 ///     // Or simpler
 ///     OUDSButton(icon: Image("ic_heart")) { /* the action to process */ }
 ///
-///     // Text only with negative hierarchy
-///     OUDSButton(text: "Delete", hierarchy: .negative,  style: .default) { /* the action to process */ }
+///     // Text only with negative appearance
+///     OUDSButton(text: "Delete", appearance: .negative,  style: .default) { /* the action to process */ }
 ///     // Or simpler
-///     OUDSButton(text: "Delete", hierarchy: .negative) { /* the action to process */ }
+///     OUDSButton(text: "Delete", appearance: .negative) { /* the action to process */ }
 ///
 ///     // A loading button
 ///     OUDSButton(text: "Delete", style: .loading) { /* the action to process */ }
 ///
-///     // Text and icon with strong hierarchy
-///     OUDSButton(icon: Image("ic_heart"), text: "Validate", hierarchy: .strong) { /* the action to process */ }
+///     // Text and icon with strong appearance
+///     OUDSButton(icon: Image("ic_heart"), text: "Validate", appearance: .strong) { /* the action to process */ }
 /// ```
 ///
 /// ## Styles
@@ -118,7 +118,7 @@ public struct OUDSButton: View {
     // MARK: Stored Properties
 
     private let type: `Type`
-    private let hierarchy: Hierarchy
+    private let appearance: Appearance
     private let style: Style
     private let action: () -> Void
 
@@ -131,8 +131,8 @@ public struct OUDSButton: View {
         case textAndIcon(text: String, icon: Image)
     }
 
-    /// Represents the hierarchy of an OUDS button, i.e. a kind of type
-    public enum Hierarchy {
+    /// Represents the appearance of an OUDS button, i.e. a kind of type
+    public enum Appearance {
         /// Default button is used for action
         case `default`
         /// Strong button on the page should be singular and prominent
@@ -161,12 +161,12 @@ public struct OUDSButton: View {
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
     ///    - text: The text to display in the button
-    ///    - hierarchy: The button hierarchy, default set to `.default`
+    ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
-    public init(icon: Image, text: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
+    public init(icon: Image, text: String, appearance: Appearance = .default, style: Style = .default, action: @escaping () -> Void) {
         type = .textAndIcon(text: text, icon: icon)
-        self.hierarchy = hierarchy
+        self.appearance = appearance
         self.style = style
         self.action = action
         isHover = false
@@ -177,12 +177,12 @@ public struct OUDSButton: View {
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
     ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the button action
-    ///    - hierarchy: The button hierarchy, default set to `.default`
+    ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
-    public init(icon: Image, accessibilityLabel: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
+    public init(icon: Image, accessibilityLabel: String, appearance: Appearance = .default, style: Style = .default, action: @escaping () -> Void) {
         type = .icon(icon, accessibilityLabel)
-        self.hierarchy = hierarchy
+        self.appearance = appearance
         self.style = style
         self.action = action
         isHover = false
@@ -192,12 +192,12 @@ public struct OUDSButton: View {
     ///
     /// - Parameters:
     ///    - text: The text of the button to display
-    ///    - hierarchy: The button hierarchy, default set to `.default`
+    ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - action: The action to perform when the user triggers the button
-    public init(text: String, hierarchy: Hierarchy = .default, style: Style = .default, action: @escaping () -> Void) {
+    public init(text: String, appearance: Appearance = .default, style: Style = .default, action: @escaping () -> Void) {
         type = .text(text)
-        self.hierarchy = hierarchy
+        self.appearance = appearance
         self.style = style
         self.action = action
         isHover = false
@@ -207,10 +207,10 @@ public struct OUDSButton: View {
 
     // swiftlint:disable line_length
     public var body: some View {
-        // A button with negative or brand hierarchy is not allowed on a colored surface.
+        // A button with negative or brand appearance is not allowed on a colored surface.
         // Test is done here because onColoredSurface is environment variable which is not accessible in init.
-        if onColoredSurface, hierarchy == .negative || hierarchy == .brand {
-            OL.fatal("An OUDSButton with OUDSButton.Hierarchy.{Negative | Brand} hierarchy has been detected as a direct or indirect child of an OUDSColoredSurface, which is not allowed.")
+        if onColoredSurface, appearance == .negative || appearance == .brand {
+            OL.fatal("An OUDSButton with OUDSButton.Appearance.{Negative | Brand} appearance has been detected as a direct or indirect child of an OUDSColoredSurface, which is not allowed.")
         }
 
         Button(action: action) {
@@ -223,7 +223,7 @@ public struct OUDSButton: View {
                 ButtonTextAndIcon(text: text, icon: icon)
             }
         }
-        .buttonStyle(OUDSButtonStyle(isHover: isHover, hierarchy: hierarchy, style: style))
+        .buttonStyle(OUDSButtonStyle(isHover: isHover, appearance: appearance, style: style))
         .accessibilityLabel(accessibilityLabel)
         .onHover { isHover in
             self.isHover = isHover

--- a/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
+++ b/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///
 /// ```swift
 ///   OUDSColoredSurface(color: theme.colorModes.modeOnBrandPrimary) {
-///      OUDSButton(icon: Image("ic_heart"), hierarchy: .strong) {}
+///      OUDSButton(icon: Image("ic_heart"), appearance: .strong) {}
 ///   }
 /// ```
 ///

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
@@ -33,14 +33,14 @@ The ``OUDSButton`` proposes layout with text only, icon only or text and icon.
 Four hierarchies are proposed for all layouts: *default*, *strong*, *minimal* and *negative*.
 Two style are available: *default* and *loading*. 
 If button is placed on colored surface using `OUDSColoredSurface`, the default colors (content, background and border) are automatically adjusted to switch to monochrom.
-A button with `OUDSButton.Hierarchy.Negative` hierarchy is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
+A button with `OUDSButton.Appearance.Negative` appearance is not allowed as a direct or indirect child of an `OUDSColoredSurface`.
 
 ```swift
-     // Icon only with default hierarchy
-     OUDSButton(icon: Image("ic_heart"), hierarchy: .default) {}
+     // Icon only with default appearance
+     OUDSButton(icon: Image("ic_heart"), appearance: .default) {}
 
-     // Text only with negative hierarchy
-     OUDSButton(text: "Delete", hierarchy: .negative) {}
+     // Text only with negative appearance
+     OUDSButton(text: "Delete", appearance: .negative) {}
 ```
 
 For accessibility reasons, if the user in the system settings toggles the option to reduce the animations, the loading indicator will be frozen to be more comfortable for the user.


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#969 

### Description

<!-- Describe your changes in detail -->
Rename the _hierarchy_ property of the _button_ component to _appearance_.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Anticipate enxt Figma evolutions.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
