### PR TITLE
[#1003] Add new `moderate` typography and tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `body moderate` and `label moderate` typography and tokens (Orange-OpenSource/ouds-ios#1003)
 - Management of `Helvetica Neue Arabic` font family (Orange-OpenSource/ouds-ios#1006)
 - UIKit experimental backports for `button`, `tag`, `badge`, `horizontal divider`, `vertical divider`, `link`, `suggestion chip`, `filter chip`, `checkbox`, `checkbox indeterminate`, `checkbox item`, `radio`, `radio item`, `switch` and `switch item` components
 - Apply `Helvetica Neue` font family for themes `Orange`, `Orange Inverse` and `Orange Business Tools` (Orange-OpenSource/ouds-ios#965)

--- a/OUDS/Core/Components/Sources/_/Extensions/View+Typography.swift
+++ b/OUDS/Core/Components/Sources/_/Extensions/View+Typography.swift
@@ -98,6 +98,30 @@ extension View {
         modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeBodyDefaultSmall))
     }
 
+    /// Modifies the current `View` to apply a *body moderate large* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeBodyModerateLarge(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeBodyDefaultLarge))
+    }
+
+    /// Modifies the current `View` to apply a *body moderate medium* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeBodyModerateMedium(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeBodyDefaultMedium))
+    }
+
+    /// Modifies the current `View` to apply a *body moderate small* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeBodyModerateSmall(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeBodyDefaultSmall))
+    }
+
     /// Modifies the current `View` to apply a *body strong large* typography.
     /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
     /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
@@ -152,6 +176,38 @@ extension View {
     /// - Returns some View: The current `View` but with new typography applied
     public func typeLabelDefaultSmall(_ theme: OUDSTheme) -> some View {
         modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeBodyDefaultSmall))
+    }
+
+    /// Modifies the current `View` to apply a *label moderate x large* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeLabelModerateXLarge(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeLabelModerateXLarge))
+    }
+
+    /// Modifies the current `View` to apply a *label moderate large* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeLabelModerateLarge(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeLabelModerateLarge))
+    }
+
+    /// Modifies the current `View` to apply a *label moderate medium* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeLabelModerateMedium(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeLabelModerateMedium))
+    }
+
+    /// Modifies the current `View` to apply a *label moderate small* typography.
+    /// The current `OUDSTheme` must be given in parameter because `@Environment` property cannot be accessed through an extension or inside a method.
+    /// - Parameter theme: The current `OUDSTheme` to use to load the current font family and the suitable font semantic token.
+    /// - Returns some View: The current `View` but with new typography applied
+    public func typeLabelModerateSmall(_ theme: OUDSTheme) -> some View {
+        modifier(TypographyModifier(fontFamily: theme.fontFamily, font: theme.fonts.typeLabelModerateSmall))
     }
 
     /// Modifies the current `View` to apply a *label strong x large* typography.

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontCompositeSemanticTokens.swift
@@ -45,6 +45,9 @@ extension OrangeThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {
     @objc open var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
     @objc open var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
     @objc open var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc open var typeBodyModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc open var typeBodyModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc open var typeBodyModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
     @objc open var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc open var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
     @objc open var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
@@ -55,6 +58,10 @@ extension OrangeThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {
     @objc open var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc open var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
     @objc open var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc open var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium300) }
+    @objc open var typeLabelModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc open var typeLabelModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc open var typeLabelModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
     @objc open var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
     @objc open var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc open var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }

--- a/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/MockTheme/MockTheme+AllFontSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/MockTheme/MockTheme+AllFontSemanticTokens.swift
@@ -205,6 +205,9 @@ final class MockThemeFontSemanticTokensProvider: OrangeThemeFontSemanticTokensPr
     override var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeBodyModerateLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeBodyModerateMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeBodyModerateSmall: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeBodyStrongLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeBodyStrongMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeBodyStrongSmall: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
@@ -215,6 +218,10 @@ final class MockThemeFontSemanticTokensProvider: OrangeThemeFontSemanticTokensPr
     override var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeLabelModerateLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeLabelModerateMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
+    override var typeLabelModerateSmall: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeLabelStrongLarge: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }
     override var typeLabelStrongMedium: MultipleFontCompositeRawTokens { Self.mockThemeMultipleFontCompositeRawTokens }

--- a/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfFontCompositeSemanticTokensTests.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfFontCompositeSemanticTokensTests.swift
@@ -89,6 +89,21 @@ struct ThemeOverrideOfFontCompositeSemanticTokensTests {
         #expect(inheritedTheme.fonts.typeBodyDefaultSmall == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeModerateLarge() throws {
+        #expect(inheritedTheme.fonts.typeBodyModerateLarge != abstractTheme.fonts.typeBodyModerateLarge)
+        #expect(inheritedTheme.fonts.typeBodyModerateLarge == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeModerateMedium() throws {
+        #expect(inheritedTheme.fonts.typeBodyModerateMedium != abstractTheme.fonts.typeBodyModerateMedium)
+        #expect(inheritedTheme.fonts.typeBodyModerateMedium == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeModerateSmall() throws {
+        #expect(inheritedTheme.fonts.typeBodyModerateSmall != abstractTheme.fonts.typeBodyModerateSmall)
+        #expect(inheritedTheme.fonts.typeBodyModerateSmall == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenTypeStrongLarge() throws {
         #expect(inheritedTheme.fonts.typeBodyStrongLarge != abstractTheme.fonts.typeBodyStrongLarge)
         #expect(inheritedTheme.fonts.typeBodyStrongLarge == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
@@ -124,6 +139,26 @@ struct ThemeOverrideOfFontCompositeSemanticTokensTests {
     @Test func inheritedThemeCanOverrideSemanticTokenTypeLabelDefaultSmall() throws {
         #expect(inheritedTheme.fonts.typeLabelDefaultSmall != abstractTheme.fonts.typeLabelDefaultSmall)
         #expect(inheritedTheme.fonts.typeLabelDefaultSmall == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeLabeModerateXLarge() throws {
+        #expect(inheritedTheme.fonts.typeLabelModerateXLarge != abstractTheme.fonts.typeLabelModerateXLarge)
+        #expect(inheritedTheme.fonts.typeLabelModerateXLarge == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeLabelModerateLarge() throws {
+        #expect(inheritedTheme.fonts.typeLabelModerateLarge != abstractTheme.fonts.typeLabelModerateLarge)
+        #expect(inheritedTheme.fonts.typeLabelModerateLarge == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeLabelModerateMedium() throws {
+        #expect(inheritedTheme.fonts.typeLabelModerateMedium != abstractTheme.fonts.typeLabelModerateMedium)
+        #expect(inheritedTheme.fonts.typeLabelModerateMedium == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenTypeLabelModerateSmall() throws {
+        #expect(inheritedTheme.fonts.typeLabelModerateSmall != abstractTheme.fonts.typeLabelModerateSmall)
+        #expect(inheritedTheme.fonts.typeLabelModerateSmall == MockThemeFontSemanticTokensProvider.mockThemeMultipleFontCompositeRawTokens)
     }
 
     @Test func inheritedThemeCanOverrideSemanticTokenTypeLabelStrongXLarge() throws {

--- a/OUDS/Core/Themes/OrangeBusinessTools/Sources/Values/SemanticTokens/OrangeBusinessToolsTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeBusinessTools/Sources/Values/SemanticTokens/OrangeBusinessToolsTheme+FontCompositeSemanticTokens.swift
@@ -44,6 +44,9 @@ extension OrangeBusinessToolsThemeFontSemanticTokensProvider: FontCompositeSeman
     @objc public final var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
     @objc public final var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
     @objc public final var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeBodyModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeBodyModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeBodyModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
     @objc public final var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc public final var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
     @objc public final var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
@@ -54,6 +57,10 @@ extension OrangeBusinessToolsThemeFontSemanticTokensProvider: FontCompositeSeman
     @objc public final var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc public final var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
     @objc public final var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium300) }
+    @objc public final var typeLabelModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeLabelModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeLabelModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
     @objc public final var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
     @objc public final var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
     @objc public final var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }

--- a/OUDS/Core/Themes/OrangeInverse/Sources/Values/SemanticTokens/OrangeInverseTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeInverse/Sources/Values/SemanticTokens/OrangeInverseTheme+FontCompositeSemanticTokens.swift
@@ -29,41 +29,48 @@ extension OrangeInverseThemeFontSemanticTokensProvider: FontCompositeSemanticTok
 
     // MARK: - Semantic tokens - Typography - Composites - Display
 
-    @objc public var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
-    @objc public var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
-    @objc public var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
+    @objc public final var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
+    @objc public final var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
+    @objc public final var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
 
     // MARK: - Semantic tokens - Typography - Composites - Heading
 
-    @objc public var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
-    @objc public var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
-    @objc public var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
-    @objc public var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
+    @objc public final var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
+    @objc public final var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
+    @objc public final var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
+    @objc public final var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
 
     // MARK: - Semantic tokens - Typography - Composites - Body
 
-    @objc public var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
-    @objc public var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
+    @objc public final var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeBodyModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeBodyModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeBodyModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Label
 
-    @objc public var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
-    @objc public var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
-    @objc public var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
+    @objc public final var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium300) }
+    @objc public final var typeLabelModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeLabelModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeLabelModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
+    @objc public final var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Code
 
-    @objc public var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
 }
 
 // swiftlint:enable line_length

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontCompositeSemanticTokens.swift
@@ -29,41 +29,48 @@ extension SoshThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {
 
     // MARK: - Semantic tokens - Typography - Composites - Display
 
-    @objc public var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
-    @objc public var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
-    @objc public var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
+    @objc public final var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
+    @objc public final var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
+    @objc public final var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
 
     // MARK: - Semantic tokens - Typography - Composites - Heading
 
-    @objc public var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
-    @objc public var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
-    @objc public var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
-    @objc public var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
+    @objc public final var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
+    @objc public final var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
+    @objc public final var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
+    @objc public final var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
 
     // MARK: - Semantic tokens - Typography - Composites - Body
 
-    @objc public var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
-    @objc public var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
+    @objc public final var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeBodyModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeBodyModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeBodyModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Label
 
-    @objc public var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
-    @objc public var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
-    @objc public var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
+    @objc public final var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium300) }
+    @objc public final var typeLabelModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeLabelModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeLabelModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
+    @objc public final var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Code
 
-    @objc public var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
 }
 
 // swiftlint:enable line_length

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontCompositeSemanticTokens.swift
@@ -29,41 +29,48 @@ extension WireframeThemeFontSemanticTokensProvider: FontCompositeSemanticTokens 
 
     // MARK: - Semantic tokens - Typography - Composites - Display
 
-    @objc public var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
-    @objc public var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
-    @objc public var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
+    @objc public final var typeDisplayLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold850, regular: FontRawTokens.typeBold1450) }
+    @objc public final var typeDisplayMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold750, regular: FontRawTokens.typeBold1050) }
+    @objc public final var typeDisplaySmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold650, regular: FontRawTokens.typeBold850) }
 
     // MARK: - Semantic tokens - Typography - Composites - Heading
 
-    @objc public var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
-    @objc public var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
-    @objc public var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
-    @objc public var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
+    @objc public final var typeHeadingXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold550, regular: FontRawTokens.typeBold750) }
+    @objc public final var typeHeadingLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold450, regular: FontRawTokens.typeBold550) }
+    @objc public final var typeHeadingMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold350, regular: FontRawTokens.typeBold450) }
+    @objc public final var typeHeadingSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(compact: FontRawTokens.typeBold300, regular: FontRawTokens.typeBold350) }
 
     // MARK: - Semantic tokens - Typography - Composites - Body
 
-    @objc public var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
-    @objc public var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular250) }
+    @objc public final var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeBodyModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeBodyModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeBodyModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeBodyStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeBodyStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeBodyStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Label
 
-    @objc public var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
-    @objc public var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
-    @objc public var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
-    @objc public var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
-    @objc public var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
-    @objc public var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
+    @objc public final var typeLabelDefaultXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular300) }
+    @objc public final var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium300) }
+    @objc public final var typeLabelModerateLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium250) }
+    @objc public final var typeLabelModerateMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium200) }
+    @objc public final var typeLabelModerateSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeMedium150) }
+    @objc public final var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold300) }
+    @objc public final var typeLabelStrongLarge: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold250) }
+    @objc public final var typeLabelStrongMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold200) }
+    @objc public final var typeLabelStrongSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeBold150) }
 
     // MARK: - Semantic tokens - Typography - Composites - Code
 
-    @objc public var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
-    @objc public var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
+    @objc public final var typeCodeMedium: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular200) }
+    @objc public final var typeCodeSmall: MultipleFontCompositeRawTokens { MultipleFontCompositeRawTokens(FontRawTokens.typeRegular150) }
 }
 
 // swiftlint:enable line_length

--- a/OUDS/Core/Tokens/RawTokens/Sources/Values/FontRawTokens+Composites.swift
+++ b/OUDS/Core/Tokens/RawTokens/Sources/Values/FontRawTokens+Composites.swift
@@ -33,6 +33,16 @@ extension FontRawTokens {
 
     public static let typeRegular300 = FontCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeight400, letterSpacing: fontLetterSpacing300)
 
+    public static let typeMedium150 = FontCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight500, letterSpacing: fontLetterSpacing150)
+
+    public static let typeMedium175 = FontCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight500, letterSpacing: fontLetterSpacing175)
+
+    public static let typeMedium200 = FontCompositeRawToken(size: fontSize200, lineHeight: fontLineHeight450, weight: fontWeight500, letterSpacing: fontLetterSpacing200)
+
+    public static let typeMedium250 = FontCompositeRawToken(size: fontSize250, lineHeight: fontLineHeight450, weight: fontWeight500, letterSpacing: fontLetterSpacing250)
+
+    public static let typeMedium300 = FontCompositeRawToken(size: fontSize300, lineHeight: fontLineHeight450, weight: fontWeight500, letterSpacing: fontLetterSpacing300)
+
     public static let typeBold150 = FontCompositeRawToken(size: fontSize150, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing150)
 
     public static let typeBold175 = FontCompositeRawToken(size: fontSize175, lineHeight: fontLineHeight250, weight: fontWeight700, letterSpacing: fontLetterSpacing175)

--- a/OUDS/Core/Tokens/RawTokens/Tests/FontRawTokensTests.swift
+++ b/OUDS/Core/Tokens/RawTokens/Tests/FontRawTokensTests.swift
@@ -1154,6 +1154,22 @@ struct FontRawTokensTests {
         #expect(FontRawTokens.typeRegular250 <| FontRawTokens.typeRegular300)
     }
 
+    @Test func fontRawTokensTypeMedium150LessThanTypeMedium175() throws {
+        #expect(FontRawTokens.typeMedium150 <| FontRawTokens.typeMedium175)
+    }
+
+    @Test func fontRawTokensTypeMedium175LessThanTypeMedium200() throws {
+        #expect(FontRawTokens.typeMedium175 <| FontRawTokens.typeMedium200)
+    }
+
+    @Test func fontRawTokensTypeMedium200LessThanTypeMedium250() throws {
+        #expect(FontRawTokens.typeMedium200 <| FontRawTokens.typeMedium250)
+    }
+
+    @Test func fontRawTokensTypeMedium250LessThanTypeMedium300() throws {
+        #expect(FontRawTokens.typeMedium250 <| FontRawTokens.typeMedium300)
+    }
+
     @Test func fontRawTokensTypeBold150LessThanTypeBold175() throws {
         #expect(FontRawTokens.typeBold150 <| FontRawTokens.typeBold175)
     }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/FontCompositeSemanticTokens.swift
@@ -65,6 +65,9 @@ public protocol FontCompositeSemanticTokens {
     var typeBodyDefaultLarge: MultipleFontCompositeRawTokens { get }
     var typeBodyDefaultMedium: MultipleFontCompositeRawTokens { get }
     var typeBodyDefaultSmall: MultipleFontCompositeRawTokens { get }
+    var typeBodyModerateLarge: MultipleFontCompositeRawTokens { get }
+    var typeBodyModerateSmall: MultipleFontCompositeRawTokens { get }
+    var typeBodyModerateMedium: MultipleFontCompositeRawTokens { get }
     var typeBodyStrongLarge: MultipleFontCompositeRawTokens { get }
     var typeBodyStrongMedium: MultipleFontCompositeRawTokens { get }
     var typeBodyStrongSmall: MultipleFontCompositeRawTokens { get }
@@ -75,6 +78,10 @@ public protocol FontCompositeSemanticTokens {
     var typeLabelDefaultLarge: MultipleFontCompositeRawTokens { get }
     var typeLabelDefaultMedium: MultipleFontCompositeRawTokens { get }
     var typeLabelDefaultSmall: MultipleFontCompositeRawTokens { get }
+    var typeLabelModerateXLarge: MultipleFontCompositeRawTokens { get }
+    var typeLabelModerateLarge: MultipleFontCompositeRawTokens { get }
+    var typeLabelModerateMedium: MultipleFontCompositeRawTokens { get }
+    var typeLabelModerateSmall: MultipleFontCompositeRawTokens { get }
     var typeLabelStrongXLarge: MultipleFontCompositeRawTokens { get }
     var typeLabelStrongLarge: MultipleFontCompositeRawTokens { get }
     var typeLabelStrongMedium: MultipleFontCompositeRawTokens { get }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1003

### Description

<!-- Describe your changes in detail -->
Add composite tokens (raw ans semantic) for fonts and view modifiers to apply the new _moderate_ typography for _body_ and _label_ cases

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Provide more typographies

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
