### PR TITLE
fix: disable OUDSButton during loading state (#988)

### DIFF
--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -225,6 +225,7 @@ public struct OUDSButton: View {
             }
         }
         .buttonStyle(OUDSButtonStyle(isHover: isHover, appearance: appearance, style: style))
+                .disabled(style == .loading)
         .accessibilityLabel(accessibilityLabel)
         .onHover { isHover in
             self.isHover = isHover


### PR DESCRIPTION
### Related issues
Fixes #988

### Description
For the button component, the loading state should automatically disable the button to avoid unwanted interactions and update the accessibility voiceover to "loading, dimmed, button." This PR adds `.disabled(style == .loading)` in the `OUDSButton` view builder so that when the style is `.loading`, the button is disabled and VoiceOver says "loading, dimmed, button."

### Motivation & Context
Issue #988 describes an accessibility bug where a button remains tappable while in the loading state. Disabling the button while loading ensures there are no accidental taps and provides the correct VoiceOver feedback.

### How Has This Been Tested
Manually tested in the Example app: pressing a button into loading state disables interactions and VoiceOver reads "loading, dimmed, button".
