### PR TITLE
[#1060]  Add an accessibility label for badge "standard" and "count" types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `radio` components to v1.4.0 (Orange-OpenSource/ouds-ios#1139)
 - Update `checkbox` components to v2.4.0 (Orange-OpenSource/ouds-ios#1137)
 - Read only variant for `checkbox` and  `checkbox indeterminate` components (Orange-OpenSource/ouds-ios#1137)
+
 ### Fixed
 
 - Add an accessibility label for badge "standard" and "count" types (Orange-OpenSource/ouds-ios#1060)

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -27,7 +27,7 @@ import SwiftUI
 ///     OUDSBadge(accessibilityLabel: "New feature available", status: .accent, size: .small)
 ///
 ///     // Negative badge in large size with count information
-///     OUDSBadge(count: 9, "9 new messages", status: .negative, size: .large)
+///     OUDSBadge(count: 9, accessibilityLabel: "9 new messages", status: .negative, size: .large)
 ///
 ///     // Info badge in medium size (default size) with default icon information
 ///     OUDSBadge(status: .info, accessibilityLabel: "Like", size: .medium)
@@ -50,7 +50,7 @@ import SwiftUI
 ///
 /// ### Vocalizations
 ///
-/// A badge need an accessibility label to decribe the meaning that will be vocalized.
+/// A badge needs an accessibility label to decribe the meaning that will be vocalized.
 ///
 /// ## Design documentation
 ///


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1060

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

Ajout d'un accessibilityLable dans l'API d'init pout forcer le developper à en fournir un.
Pour le badge :
- de type count, cet paramètre lui permet de mettre un text plus riche que juste la valeur du compteur (exemple 3 messages reçus).
- de type standard permet de mettre un message du type (nouvelle fonctionnalité disponible)

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- [ ] Accessibility review has been done
- [ ] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
