### PR TITLE
[#1206] Update declaration of color semantic tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Color semantic tokens (Orange-OpenSource/ouds-ios#1206)
 - Update wording keys and translations (Orange-OpenSource/ouds-ios#1200)
 - Define timeout of 2 hours for all GitHub Actions workflows
 - Update icons to v1.4.0 (Orange-OpenSource/ouds-ios#1193)

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorMultipleSemanticTokens.swift
@@ -121,6 +121,16 @@ extension OrangeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
 
     @objc open var borderMinimal: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderMinimalLight, dark: borderMinimalDark) }
 
+    @objc open var borderStatusPositive: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusPositiveLight, dark: borderStatusPositiveDark) }
+
+    @objc open var borderStatusInfo: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusInfoLight, dark: borderStatusInfoDark) }
+
+    @objc open var borderStatusWarning: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusWarningLight, dark: borderStatusWarningDark) }
+
+    @objc open var borderStatusNegative: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusNegativeLight, dark: borderStatusNegativeDark) }
+
+    @objc open var borderStatusAccent: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusAccentLight, dark: borderStatusAccentDark) }
+
     // MARK: - Color - Content
 
     @objc open var contentBrandPrimary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: contentBrandPrimaryLight, dark: contentBrandPrimaryDark) }
@@ -192,6 +202,8 @@ extension OrangeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
     // MARK: - Color - Overlay
 
     @objc open var overlayDropdown: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDropdownLight, dark: overlayDropdownDark) }
+
+    @objc open var overlayTooltip: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayTooltipLight, dark: overlayTooltipDark) }
 
     @objc open var overlayDrag: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDragLight, dark: overlayDragDark) }
 

--- a/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/MockTheme/MockTheme+AllColorSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/MockTheme/MockTheme+AllColorSemanticTokens.swift
@@ -103,6 +103,17 @@ open class MockThemeColorSemanticTokensProvider: OrangeThemeColorSemanticTokensP
     override public var borderOnBrandSecondaryLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var borderOnBrandTertiaryLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
 
+    override public var borderStatusPositiveLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusPositiveDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusInfoLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusInfoDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusWarningLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusWarningDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusNegativeLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusNegativeDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusAccentLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var borderStatusAccentDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+
     override public var borderOnBrandPrimaryDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var borderOnBrandSecondaryDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var borderOnBrandTertiaryDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
@@ -173,14 +184,18 @@ open class MockThemeColorSemanticTokensProvider: OrangeThemeColorSemanticTokensP
     override public var contentStatusWarningLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var contentStatusInfoDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var contentStatusNegativeDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var contentStatusAccentLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var contentStatusAccentDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
 
     override public var contentStatusPositiveDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var contentStatusWarningDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
 
     override public var overlayDropdownLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var overlayTooltipLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var overlayDragLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var overlayModalLight: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var overlayDropdownDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
+    override public var overlayTooltipDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var overlayDragDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
     override public var overlayModalDark: ColorSemanticToken { Self.mockThemeSemanticColorToken }
 
@@ -280,6 +295,12 @@ open class MockThemeColorSemanticTokensProvider: OrangeThemeColorSemanticTokensP
     override public var borderOnBrandSecondary: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
     override public var borderOnBrandTertiary: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
 
+    override public var borderStatusPositive: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+    override public var borderStatusInfo: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+    override public var borderStatusWarning: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+    override public var borderStatusNegative: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+    override public var borderStatusAccent: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+
     // MARK: - Color - Content
 
     override public var contentBrandPrimary: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
@@ -308,6 +329,7 @@ open class MockThemeColorSemanticTokensProvider: OrangeThemeColorSemanticTokensP
     // MARK: - Color - Overlay
 
     override public var overlayDropdown: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
+    override public var overlayTooltip: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
     override public var overlayDrag: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
     override public var overlayModal: MultipleColorSemanticTokens { Self.mockThemeMultipleColorSemanticTokens }
 

--- a/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfColorMultipleSemanticTokensTests.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfColorMultipleSemanticTokensTests.swift
@@ -236,6 +236,31 @@ struct ThemeOverrideOfColorMultipleSemanticTokensTests {
         #expect(inheritedTheme.colors.borderOnBrandTertiary == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusPositive() throws {
+        #expect(inheritedTheme.colors.borderStatusPositive != abstractTheme.colors.borderStatusPositive)
+        #expect(inheritedTheme.colors.borderStatusPositive == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusInfo() throws {
+        #expect(inheritedTheme.colors.borderStatusInfo != abstractTheme.colors.borderStatusInfo)
+        #expect(inheritedTheme.colors.borderStatusInfo == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusWarning() throws {
+        #expect(inheritedTheme.colors.borderStatusWarning != abstractTheme.colors.borderStatusWarning)
+        #expect(inheritedTheme.colors.borderStatusWarning == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusNegative() throws {
+        #expect(inheritedTheme.colors.borderStatusNegative != abstractTheme.colors.borderStatusNegative)
+        #expect(inheritedTheme.colors.borderStatusNegative == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusAccent() throws {
+        #expect(inheritedTheme.colors.borderStatusAccent != abstractTheme.colors.borderStatusAccent)
+        #expect(inheritedTheme.colors.borderStatusAccent == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
     // MARK: - Color - Content
 
     @Test func inheritedThemeCanOverrideSemanticTokenColorContentBrandPrimary() throws {
@@ -403,6 +428,11 @@ struct ThemeOverrideOfColorMultipleSemanticTokensTests {
     @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayDropDown() throws {
         #expect(inheritedTheme.colors.overlayDropdown != abstractTheme.colors.overlayDropdown)
         #expect(inheritedTheme.colors.overlayDropdown == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayTooltip() throws {
+        #expect(inheritedTheme.colors.overlayTooltip != abstractTheme.colors.overlayTooltip)
+        #expect(inheritedTheme.colors.overlayTooltip == MockThemeColorSemanticTokensProvider.mockThemeMultipleColorSemanticTokens)
     }
 
     @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayDrag() throws {

--- a/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfColorSemanticTokensTests.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/SemanticTokens/ThemeOverrideOfColorSemanticTokensTests.swift
@@ -324,6 +324,16 @@ struct ThemeOverrideOfColorSemanticTokensTests {
         #expect(inheritedTheme.colors.borderBrandPrimaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderBrandSecondaryLight() throws {
+        #expect(inheritedTheme.colors.borderBrandSecondaryLight != abstractTheme.colors.borderBrandSecondaryLight)
+        #expect(inheritedTheme.colors.borderBrandSecondaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderBrandTertiaryLight() throws {
+        #expect(inheritedTheme.colors.borderBrandTertiaryLight != abstractTheme.colors.borderBrandTertiaryLight)
+        #expect(inheritedTheme.colors.borderBrandTertiaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorBorderDefaultLight() throws {
         #expect(inheritedTheme.colors.borderDefaultLight != abstractTheme.colors.borderDefaultLight)
         #expect(inheritedTheme.colors.borderDefaultLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
@@ -349,14 +359,94 @@ struct ThemeOverrideOfColorSemanticTokensTests {
         #expect(inheritedTheme.colors.borderOnBrandPrimaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderOnBrandSecondaryLight() throws {
+        #expect(inheritedTheme.colors.borderOnBrandSecondaryLight != abstractTheme.colors.borderOnBrandSecondaryLight)
+        #expect(inheritedTheme.colors.borderOnBrandSecondaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderOnBrandTertiaryLight() throws {
+        #expect(inheritedTheme.colors.borderOnBrandTertiaryLight != abstractTheme.colors.borderOnBrandTertiaryLight)
+        #expect(inheritedTheme.colors.borderOnBrandTertiaryLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorBorderOnBrandPrimaryDark() throws {
         #expect(inheritedTheme.colors.borderOnBrandPrimaryDark != abstractTheme.colors.borderOnBrandPrimaryDark)
         #expect(inheritedTheme.colors.borderOnBrandPrimaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderOnBrandSecondaryDark() throws {
+        #expect(inheritedTheme.colors.borderOnBrandSecondaryDark != abstractTheme.colors.borderOnBrandSecondaryDark)
+        #expect(inheritedTheme.colors.borderOnBrandSecondaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderOnBrandTertiaryDark() throws {
+        #expect(inheritedTheme.colors.borderOnBrandTertiaryDark != abstractTheme.colors.borderOnBrandTertiaryDark)
+        #expect(inheritedTheme.colors.borderOnBrandTertiaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorBorderBrandPrimaryDark() throws {
         #expect(inheritedTheme.colors.borderBrandPrimaryDark != abstractTheme.colors.borderBrandPrimaryDark)
         #expect(inheritedTheme.colors.borderBrandPrimaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderBrandSecondaryDark() throws {
+        #expect(inheritedTheme.colors.borderBrandSecondaryDark != abstractTheme.colors.borderBrandSecondaryDark)
+        #expect(inheritedTheme.colors.borderBrandSecondaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderBrandTertiaryDark() throws {
+        #expect(inheritedTheme.colors.borderBrandTertiaryDark != abstractTheme.colors.borderBrandTertiaryDark)
+        #expect(inheritedTheme.colors.borderBrandTertiaryDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusPositiveLight() throws {
+        #expect(inheritedTheme.colors.borderStatusPositiveLight != abstractTheme.colors.borderStatusPositiveLight)
+        #expect(inheritedTheme.colors.borderStatusPositiveLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusPositiveDark() throws {
+        #expect(inheritedTheme.colors.borderStatusPositiveDark != abstractTheme.colors.borderStatusPositiveDark)
+        #expect(inheritedTheme.colors.borderStatusPositiveDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusInfoLight() throws {
+        #expect(inheritedTheme.colors.borderStatusInfoLight != abstractTheme.colors.borderStatusInfoLight)
+        #expect(inheritedTheme.colors.borderStatusInfoLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusInfoDark() throws {
+        #expect(inheritedTheme.colors.borderStatusInfoDark != abstractTheme.colors.borderStatusInfoDark)
+        #expect(inheritedTheme.colors.borderStatusInfoDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusWarningLight() throws {
+        #expect(inheritedTheme.colors.borderStatusWarningLight != abstractTheme.colors.borderStatusWarningLight)
+        #expect(inheritedTheme.colors.borderStatusWarningLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusWarningDark() throws {
+        #expect(inheritedTheme.colors.borderStatusWarningDark != abstractTheme.colors.borderStatusWarningDark)
+        #expect(inheritedTheme.colors.borderStatusWarningDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusNegativeLight() throws {
+        #expect(inheritedTheme.colors.borderStatusNegativeLight != abstractTheme.colors.borderStatusNegativeLight)
+        #expect(inheritedTheme.colors.borderStatusNegativeLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusNegativeDark() throws {
+        #expect(inheritedTheme.colors.borderStatusNegativeDark != abstractTheme.colors.borderStatusNegativeDark)
+        #expect(inheritedTheme.colors.borderStatusNegativeDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusAccentLight() throws {
+        #expect(inheritedTheme.colors.borderStatusAccentLight != abstractTheme.colors.borderStatusAccentLight)
+        #expect(inheritedTheme.colors.borderStatusAccentLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorBorderStatusAccentDark() throws {
+        #expect(inheritedTheme.colors.borderStatusAccentDark != abstractTheme.colors.borderStatusAccentDark)
+        #expect(inheritedTheme.colors.borderStatusAccentDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
     @Test func inheritedThemeCanOverrideSemanticTokenColorBorderDefaultDark() throws {
@@ -589,6 +679,11 @@ struct ThemeOverrideOfColorSemanticTokensTests {
         #expect(inheritedTheme.colors.contentStatusNegativeLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorContentStatusAccentLight() throws {
+        #expect(inheritedTheme.colors.contentStatusAccentLight != abstractTheme.colors.contentStatusAccentLight)
+        #expect(inheritedTheme.colors.contentStatusAccentLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorContentStatusPositiveLight() throws {
         #expect(inheritedTheme.colors.contentStatusPositiveLight != abstractTheme.colors.contentStatusPositiveLight)
         #expect(inheritedTheme.colors.contentStatusPositiveLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
@@ -609,6 +704,11 @@ struct ThemeOverrideOfColorSemanticTokensTests {
         #expect(inheritedTheme.colors.contentStatusNegativeDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorContentStatusAccentDark() throws {
+        #expect(inheritedTheme.colors.contentStatusAccentDark != abstractTheme.colors.contentStatusAccentDark)
+        #expect(inheritedTheme.colors.contentStatusAccentDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorContentStatusPositiveDark() throws {
         #expect(inheritedTheme.colors.contentStatusPositiveDark != abstractTheme.colors.contentStatusPositiveDark)
         #expect(inheritedTheme.colors.contentStatusPositiveDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
@@ -624,6 +724,11 @@ struct ThemeOverrideOfColorSemanticTokensTests {
         #expect(inheritedTheme.colors.overlayDropdownLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
+    @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayTooltipLight() throws {
+        #expect(inheritedTheme.colors.overlayTooltipLight != abstractTheme.colors.overlayTooltipLight)
+        #expect(inheritedTheme.colors.overlayTooltipLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
     @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayDragLight() throws {
         #expect(inheritedTheme.colors.overlayDragLight != abstractTheme.colors.overlayDragLight)
         #expect(inheritedTheme.colors.overlayDragLight == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
@@ -637,6 +742,11 @@ struct ThemeOverrideOfColorSemanticTokensTests {
     @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayDropdownDark() throws {
         #expect(inheritedTheme.colors.overlayDropdownDark != abstractTheme.colors.overlayDropdownDark)
         #expect(inheritedTheme.colors.overlayDropdownDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
+    }
+
+    @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayTooltipDark() throws {
+        #expect(inheritedTheme.colors.overlayTooltipDark != abstractTheme.colors.overlayTooltipDark)
+        #expect(inheritedTheme.colors.overlayTooltipDark == MockThemeColorSemanticTokensProvider.mockThemeSemanticColorToken)
     }
 
     @Test func inheritedThemeCanOverrideSemanticTokenColorOverlayDragDark() throws {

--- a/OUDS/Core/Themes/OrangeBusinessTools/Sources/Values/SemanticTokens/OrangeBusinessToolsTheme+ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeBusinessTools/Sources/Values/SemanticTokens/OrangeBusinessToolsTheme+ColorMultipleSemanticTokens.swift
@@ -118,6 +118,16 @@ extension OrangeBusinessToolsThemeColorSemanticTokensProvider: ColorMultipleSema
 
     @objc public final var borderMinimal: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderMinimalLight, dark: borderMinimalDark) }
 
+    @objc public final var borderStatusPositive: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusPositiveLight, dark: borderStatusPositiveDark) }
+
+    @objc public final var borderStatusInfo: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusInfoLight, dark: borderStatusInfoDark) }
+
+    @objc public final var borderStatusWarning: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusWarningLight, dark: borderStatusWarningDark) }
+
+    @objc public final var borderStatusNegative: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusNegativeLight, dark: borderStatusNegativeDark) }
+
+    @objc public final var borderStatusAccent: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusAccentLight, dark: borderStatusAccentDark) }
+
     // MARK: - Color - Content
 
     @objc public final var contentBrandPrimary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: contentBrandPrimaryLight, dark: contentBrandPrimaryDark) }
@@ -189,6 +199,8 @@ extension OrangeBusinessToolsThemeColorSemanticTokensProvider: ColorMultipleSema
     // MARK: - Color - Overlay
 
     @objc public final var overlayDropdown: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDropdownLight, dark: overlayDropdownDark) }
+
+    @objc public final var overlayTooltip: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayTooltipLight, dark: overlayTooltipDark) }
 
     @objc public final var overlayDrag: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDragLight, dark: overlayDragDark) }
 

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ColorMultipleSemanticTokens.swift
@@ -88,9 +88,9 @@ extension SoshThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
 
     @objc public final var bgTertiary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgTertiaryLight, dark: bgTertiaryDark) }
 
-    @objc public final var bgInverseHigh: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseHighLight, dark: bgInverseHighDark) }
-
     @objc public final var bgInverseLow: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseLowLight, dark: bgInverseLowDark) }
+
+    @objc public final var bgInverseHigh: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseHighLight, dark: bgInverseHighDark) }
 
     // MARK: - Color - Border
 
@@ -117,6 +117,16 @@ extension SoshThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
     @objc public final var borderOnBrandTertiary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderOnBrandTertiaryLight, dark: borderOnBrandTertiaryDark) }
 
     @objc public final var borderMinimal: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderMinimalLight, dark: borderMinimalDark) }
+
+    @objc public final var borderStatusPositive: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusPositiveLight, dark: borderStatusPositiveDark) }
+
+    @objc public final var borderStatusInfo: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusInfoLight, dark: borderStatusInfoDark) }
+
+    @objc public final var borderStatusWarning: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusWarningLight, dark: borderStatusWarningDark) }
+
+    @objc public final var borderStatusNegative: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusNegativeLight, dark: borderStatusNegativeDark) }
+
+    @objc public final var borderStatusAccent: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusAccentLight, dark: borderStatusAccentDark) }
 
     // MARK: - Color - Content
 
@@ -189,6 +199,8 @@ extension SoshThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
     // MARK: - Color - Overlay
 
     @objc public final var overlayDropdown: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDropdownLight, dark: overlayDropdownDark) }
+
+    @objc public final var overlayTooltip: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayTooltipLight, dark: overlayTooltipDark) }
 
     @objc public final var overlayDrag: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDragLight, dark: overlayDragDark) }
 

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ColorMultipleSemanticTokens.swift
@@ -88,9 +88,9 @@ extension WireframeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens
 
     @objc public final var bgTertiary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgTertiaryLight, dark: bgTertiaryDark) }
 
-    @objc public final var bgInverseHigh: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseHighLight, dark: bgInverseHighDark) }
-
     @objc public final var bgInverseLow: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseLowLight, dark: bgInverseLowDark) }
+
+    @objc public final var bgInverseHigh: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: bgInverseHighLight, dark: bgInverseHighDark) }
 
     // MARK: - Color - Border
 
@@ -117,6 +117,16 @@ extension WireframeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens
     @objc public final var borderOnBrandTertiary: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderOnBrandTertiaryLight, dark: borderOnBrandTertiaryDark) }
 
     @objc public final var borderMinimal: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderMinimalLight, dark: borderMinimalDark) }
+
+    @objc public final var borderStatusPositive: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusPositiveLight, dark: borderStatusPositiveDark) }
+
+    @objc public final var borderStatusInfo: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusInfoLight, dark: borderStatusInfoDark) }
+
+    @objc public final var borderStatusWarning: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusWarningLight, dark: borderStatusWarningDark) }
+
+    @objc public final var borderStatusNegative: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusNegativeLight, dark: borderStatusNegativeDark) }
+
+    @objc public final var borderStatusAccent: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: borderStatusAccentLight, dark: borderStatusAccentDark) }
 
     // MARK: - Color - Content
 
@@ -189,6 +199,8 @@ extension WireframeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens
     // MARK: - Color - Overlay
 
     @objc public final var overlayDropdown: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDropdownLight, dark: overlayDropdownDark) }
+
+    @objc public final var overlayTooltip: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayTooltipLight, dark: overlayTooltipDark) }
 
     @objc public final var overlayDrag: MultipleColorSemanticTokens { MultipleColorSemanticTokens(light: overlayDragLight, dark: overlayDragDark) }
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorMultipleSemanticTokens.swift
@@ -144,6 +144,16 @@ public protocol ColorMultipleSemanticTokens {
 
     var borderMinimal: MultipleColorSemanticTokens { get }
 
+    var borderStatusPositive: MultipleColorSemanticTokens { get }
+
+    var borderStatusInfo: MultipleColorSemanticTokens { get }
+
+    var borderStatusWarning: MultipleColorSemanticTokens { get }
+
+    var borderStatusNegative: MultipleColorSemanticTokens { get }
+
+    var borderStatusAccent: MultipleColorSemanticTokens { get }
+
     // MARK: - Color - Content
 
     var contentBrandPrimary: MultipleColorSemanticTokens { get }
@@ -215,6 +225,8 @@ public protocol ColorMultipleSemanticTokens {
     // MARK: - Color - Overlay
 
     var overlayDropdown: MultipleColorSemanticTokens { get }
+
+    var overlayTooltip: MultipleColorSemanticTokens { get }
 
     var overlayDrag: MultipleColorSemanticTokens { get }
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/ColorSemanticTokens.swift
@@ -139,6 +139,12 @@ public protocol ColorSemanticTokens {
     var borderBrandPrimaryLight: ColorSemanticToken { get }
     var borderBrandPrimaryDark: ColorSemanticToken { get }
 
+    var borderBrandSecondaryLight: ColorSemanticToken { get }
+    var borderBrandSecondaryDark: ColorSemanticToken { get }
+
+    var borderBrandTertiaryLight: ColorSemanticToken { get }
+    var borderBrandTertiaryDark: ColorSemanticToken { get }
+
     var borderDefaultLight: ColorSemanticToken { get }
     var borderDefaultDark: ColorSemanticToken { get }
 
@@ -157,13 +163,40 @@ public protocol ColorSemanticTokens {
     var borderOnBrandPrimaryLight: ColorSemanticToken { get }
     var borderOnBrandPrimaryDark: ColorSemanticToken { get }
 
+    var borderOnBrandSecondaryLight: ColorSemanticToken { get }
+    var borderOnBrandSecondaryDark: ColorSemanticToken { get }
+
+    var borderOnBrandTertiaryLight: ColorSemanticToken { get }
+    var borderOnBrandTertiaryDark: ColorSemanticToken { get }
+
     var borderMinimalLight: ColorSemanticToken { get }
     var borderMinimalDark: ColorSemanticToken { get }
+
+    var borderStatusPositiveLight: ColorSemanticToken { get }
+    var borderStatusPositiveDark: ColorSemanticToken { get }
+
+    var borderStatusInfoLight: ColorSemanticToken { get }
+    var borderStatusInfoDark: ColorSemanticToken { get }
+
+    var borderStatusWarningLight: ColorSemanticToken { get }
+    var borderStatusWarningDark: ColorSemanticToken { get }
+
+    var borderStatusNegativeLight: ColorSemanticToken { get }
+    var borderStatusNegativeDark: ColorSemanticToken { get }
+
+    var borderStatusAccentLight: ColorSemanticToken { get }
+    var borderStatusAccentDark: ColorSemanticToken { get }
 
     // MARK: - Color - Content
 
     var contentBrandPrimaryLight: ColorSemanticToken { get }
     var contentBrandPrimaryDark: ColorSemanticToken { get }
+
+    var contentBrandSecondaryLight: ColorSemanticToken { get }
+    var contentBrandSecondaryDark: ColorSemanticToken { get }
+
+    var contentBrandTertiaryLight: ColorSemanticToken { get }
+    var contentBrandTertiaryDark: ColorSemanticToken { get }
 
     var contentDefaultLight: ColorSemanticToken { get }
     var contentDefaultDark: ColorSemanticToken { get }
@@ -201,14 +234,17 @@ public protocol ColorSemanticTokens {
     var contentOnBrandPrimaryLight: ColorSemanticToken { get }
     var contentOnBrandPrimaryDark: ColorSemanticToken { get }
 
+    var contentOnBrandSecondaryLight: ColorSemanticToken { get }
+    var contentOnBrandSecondaryDark: ColorSemanticToken { get }
+
+    var contentOnBrandTertiaryLight: ColorSemanticToken { get }
+    var contentOnBrandTertiaryDark: ColorSemanticToken { get }
+
     var contentOnStatusPositiveMutedLight: ColorSemanticToken { get }
     var contentOnStatusPositiveMutedDark: ColorSemanticToken { get }
 
     var contentOnStatusPositiveEmphasizedLight: ColorSemanticToken { get }
     var contentOnStatusPositiveEmphasizedDark: ColorSemanticToken { get }
-
-    var contentInverseLight: ColorSemanticToken { get }
-    var contentInverseDark: ColorSemanticToken { get }
 
     var contentOnStatusNegativeMutedLight: ColorSemanticToken { get }
     var contentOnStatusNegativeMutedDark: ColorSemanticToken { get }
@@ -228,6 +264,12 @@ public protocol ColorSemanticTokens {
     var contentOnStatusAccentEmphasizedLight: ColorSemanticToken { get }
     var contentOnStatusAccentEmphasizedDark: ColorSemanticToken { get }
 
+    var contentOnStatusInfoMutedLight: ColorSemanticToken { get }
+    var contentOnStatusInfoMutedDark: ColorSemanticToken { get }
+
+    var contentOnStatusInfoEmphasizedLight: ColorSemanticToken { get }
+    var contentOnStatusInfoEmphasizedDark: ColorSemanticToken { get }
+
     var contentStatusInfoLight: ColorSemanticToken { get }
     var contentStatusInfoDark: ColorSemanticToken { get }
 
@@ -240,10 +282,19 @@ public protocol ColorSemanticTokens {
     var contentStatusWarningLight: ColorSemanticToken { get }
     var contentStatusWarningDark: ColorSemanticToken { get }
 
+    var contentStatusAccentLight: ColorSemanticToken { get }
+    var contentStatusAccentDark: ColorSemanticToken { get }
+
+    var contentInverseLight: ColorSemanticToken { get }
+    var contentInverseDark: ColorSemanticToken { get }
+
     // MARK: - Color - Overlay
 
     var overlayDropdownLight: ColorSemanticToken { get }
     var overlayDropdownDark: ColorSemanticToken { get }
+
+    var overlayTooltipLight: ColorSemanticToken { get }
+    var overlayTooltipDark: ColorSemanticToken { get }
 
     var overlayDragLight: ColorSemanticToken { get }
     var overlayDragDark: ColorSemanticToken { get }
@@ -333,13 +384,28 @@ public protocol ColorSemanticTokens {
     var repositoryNegativeLower: ColorSemanticToken { get }
     var repositoryNegativeLowest: ColorSemanticToken { get }
 
+    var repositoryWarningMedium: ColorSemanticToken { get }
+    var repositoryWarningHigh: ColorSemanticToken { get }
+    var repositoryWarningHigher: ColorSemanticToken { get }
+    var repositoryWarningHighest: ColorSemanticToken { get }
+    var repositoryWarningLow: ColorSemanticToken { get }
+    var repositoryWarningLower: ColorSemanticToken { get }
+    var repositoryWarningLowest: ColorSemanticToken { get }
+
     var repositoryNeutralEmphasizedBlack: ColorSemanticToken { get }
     var repositoryNeutralEmphasizedHigh: ColorSemanticToken { get }
     var repositoryNeutralEmphasizedHigher: ColorSemanticToken { get }
     var repositoryNeutralEmphasizedHighest: ColorSemanticToken { get }
     var repositoryNeutralEmphasizedMedium: ColorSemanticToken { get }
     var repositoryNeutralEmphasizedLow: ColorSemanticToken { get }
+    var repositoryNeutralEmphasizedLower: ColorSemanticToken { get }
+    var repositoryNeutralEmphasizedLowest: ColorSemanticToken { get }
 
+    var repositoryNeutralMutedHigh: ColorSemanticToken { get }
+    var repositoryNeutralMutedHigher: ColorSemanticToken { get }
+    var repositoryNeutralMutedHighest: ColorSemanticToken { get }
+    var repositoryNeutralMutedMedium: ColorSemanticToken { get }
+    var repositoryNeutralMutedLow: ColorSemanticToken { get }
     var repositoryNeutralMutedLower: ColorSemanticToken { get }
     var repositoryNeutralMutedLowest: ColorSemanticToken { get }
     var repositoryNeutralMutedWhite: ColorSemanticToken { get }
@@ -355,6 +421,16 @@ public protocol ColorSemanticTokens {
     var repositoryOpacityBlackMediumHigh: ColorSemanticToken { get }
     var repositoryOpacityBlackTransparent: ColorSemanticToken { get }
 
+    var repositoryOpacityWhiteHigh: ColorSemanticToken { get }
+    var repositoryOpacityWhiteHigher: ColorSemanticToken { get }
+    var repositoryOpacityWhiteHighest: ColorSemanticToken { get }
+    var repositoryOpacityWhiteMedium: ColorSemanticToken { get }
+    var repositoryOpacityWhiteMediumLow: ColorSemanticToken { get }
+    var repositoryOpacityWhiteLow: ColorSemanticToken { get }
+    var repositoryOpacityWhiteLower: ColorSemanticToken { get }
+    var repositoryOpacityWhiteLowest: ColorSemanticToken { get }
+    var repositoryOpacityWhiteTransparent: ColorSemanticToken { get }
+
     var repositoryOpacityInfoLow: ColorSemanticToken { get }
     var repositoryOpacityInfoMedium: ColorSemanticToken { get }
     var repositoryOpacityAccentLow: ColorSemanticToken { get }
@@ -365,15 +441,8 @@ public protocol ColorSemanticTokens {
     var repositoryOpacityPositiveMedium: ColorSemanticToken { get }
     var repositoryOpacityWarningLow: ColorSemanticToken { get }
     var repositoryOpacityWarningMedium: ColorSemanticToken { get }
-    var repositoryOpacityWhiteHigh: ColorSemanticToken { get }
-    var repositoryOpacityWhiteHigher: ColorSemanticToken { get }
-    var repositoryOpacityWhiteHighest: ColorSemanticToken { get }
-    var repositoryOpacityWhiteMedium: ColorSemanticToken { get }
-    var repositoryOpacityWhiteMediumLow: ColorSemanticToken { get }
-    var repositoryOpacityWhiteLow: ColorSemanticToken { get }
-    var repositoryOpacityWhiteLower: ColorSemanticToken { get }
-    var repositoryOpacityWhiteLowest: ColorSemanticToken { get }
-    var repositoryOpacityWhiteTransparent: ColorSemanticToken { get }
+
+    var repositoryOpacityPrimaryTransparent: ColorSemanticToken { get }
     var repositoryOpacityPrimaryLow: ColorSemanticToken { get }
     var repositoryOpacityPrimaryLower: ColorSemanticToken { get }
     var repositoryOpacityPrimaryLowest: ColorSemanticToken { get }
@@ -413,14 +482,6 @@ public protocol ColorSemanticTokens {
     var repositoryTertiaryLow: ColorSemanticToken { get }
     var repositoryTertiaryLower: ColorSemanticToken { get }
     var repositoryTertiaryLowest: ColorSemanticToken { get }
-
-    var repositoryWarningMedium: ColorSemanticToken { get }
-    var repositoryWarningHigh: ColorSemanticToken { get }
-    var repositoryWarningHigher: ColorSemanticToken { get }
-    var repositoryWarningHighest: ColorSemanticToken { get }
-    var repositoryWarningLow: ColorSemanticToken { get }
-    var repositoryWarningLower: ColorSemanticToken { get }
-    var repositoryWarningLowest: ColorSemanticToken { get }
 }
 
 // swiftlint:enable missing_docs


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1206 

### Description

<!-- Describe your changes in detail -->
- Add missing tokens of color in protocols to exposed theme through abstraction layer

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
