### PR TITLE
[#1222] Add an accessibility label for badge "standard" and "count" types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Add an accessibility label for badge "standard" and "count" types (V2) (Orange-OpenSource/ouds-ios#1222)
+- Missing accessibility label for badge `standard` and `count` types (Orange-OpenSource/ouds-ios#1060) (Orange-OpenSource/ouds-ios#1222)
 - Set own accessibility label to trailing action in `TextInput` (Orange-OpenSource/ouds-ios#1087)
 - Scale icons with information for tag and badge components (Orange-OpenSource/ouds-ios#1179)
-- Add an accessibility label for badge `standard` and `count` types (Orange-OpenSource/ouds-ios#1060)
 
 ## [0.22.0](https://github.com/Orange-OpenSource/ouds-ios/compare/0.21.0...0.22.0) - 2025-11-28
 

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -215,7 +215,7 @@ public struct OUDSBadge: View {
 
     private init(layout: BadgeLayout, accessibilityLabel: String) {
         if accessibilityLabel.isEmpty {
-            OL.warning("The OUDSBadge with an icon should not have an empty accessibility label, think about your disabled users!")
+            OL.warning("The OUDSBadge should not have an empty accessibility label, think about your disabled users!")
         }
         self.layout = layout
         self.accessibilityLabel = accessibilityLabel

--- a/OUDS/Core/ComponentsUIKit/Sources/Indicators/_OUDSBadge.swift
+++ b/OUDS/Core/ComponentsUIKit/Sources/Indicators/_OUDSBadge.swift
@@ -24,13 +24,15 @@ extension OUDSUIKitBrige {
     /// **This is an experimental feature, feedback and support is appreciated**
     ///
     /// - Parameters:
+    ///    - accessibilityLabel: The accessibility label the badge should have, describing the icon or bringing meanings
     ///    - status: The status of this badge. The background color of the badge is based on this status, *neutral* by default
     ///    - size: The size of this badge, *medium* by default
-    @MainActor public static func createBadge(status: OUDSBadge.Status = .neutral,
+    @MainActor public static func createBadge(accessibilityLabel: String,
+                                              status: OUDSBadge.Status = .neutral,
                                               size: OUDSBadge.StandardSize = .medium) -> UIViewController
     {
         OL.warning("Avoid UIKit wrapper and prefer SwiftUI component instead OUDSBadge(status:size)")
-        let swiftUIBadge = OUDSBadge(status: status, size: size)
+        let swiftUIBadge = OUDSBadge(accessibilityLabel: accessibilityLabel, status: status, size: size)
         return wrap(component: swiftUIBadge)
     }
 
@@ -42,15 +44,17 @@ extension OUDSUIKitBrige {
     /// **This is an experimental feature, feedback and support is appreciated**
     ///
     /// - Parameters:
-    ///    - count:The number displayed in the badge.
+    ///    - count:The number displayed in the badge
+    ///    - accessibilityLabel: The accessibility label bringing meanings about the count value
     ///    - status: The status of this badge, default set to *neutral*
     ///    - size: The size of this badge, default set to *medium*
     @MainActor public static func createBadge(count: UInt,
+                                              accessibilityLabel: String,
                                               status: OUDSBadge.Status = .neutral,
                                               size: OUDSBadge.IllustrationSize = .medium) -> UIViewController
     {
         OL.warning("Avoid UIKit wrapper and prefer SwiftUI component instead OUDSBadge(count:status:size)")
-        let swiftUIBadge = OUDSBadge(count: count, status: status, size: size)
+        let swiftUIBadge = OUDSBadge(count: count, accessibilityLabel: accessibilityLabel, status: status, size: size)
         return wrap(component: swiftUIBadge)
     }
 
@@ -62,7 +66,7 @@ extension OUDSUIKitBrige {
     ///
     /// - Parameters:
     ///    - status: The status of this badge, with a predefined icon or not
-    ///    - accessibilityLabel: The accessibility label the badge should have, describing the icon or brining meanings
+    ///    - accessibilityLabel: The accessibility label the badge should have, describing the icon or bringing meanings
     ///    - size: The size of this badge, default set to *medium*
     @MainActor public static func createBadge(status: OUDSBadge.StatusWithIcon,
                                               accessibilityLabel: String,


### PR DESCRIPTION
 _Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1060
Orange-OpenSource/ouds-ios#1222

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

Ajout d'un accessibilityLable dans l'API d'init pout forcer le developper à en fournir un.
Pour le badge :
- de type count, cet paramètre lui permet de mettre un text plus riche que juste la valeur du compteur (exemple 3 messages reçus).
- de type standard permet de mettre un message du type (nouvelle fonctionnalité disponible)

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- [ ] Accessibility review has been done
- [ ] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
