### PR TITLE
Fix OUDSTabBar attribute graph cycle on iOS 26

### DIFF
--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -268,9 +268,17 @@ public struct OUDSTabBar<Content>: View where Content: View {
             }
             // Liquid Glass or iPadOS > 18
         } else {
-            TabView(selection: $selectedTab) {
-                content()
-            }.modifier(TabBarViewModifier())
+            if #available(iOS 26.0, *) {
+                TabView {
+                    content()
+                }
+                .modifier(TabBarViewModifier())
+            } else {
+                TabView(selection: $selectedTab) {
+                    content()
+                }
+                .modifier(TabBarViewModifier())
+            }
         }
         #else // visionOS, macOS
         TabView(selection: $selectedTab) {


### PR DESCRIPTION
### Motivation

- Xcode 26 / iOS 26 triggers `AttributeGraph` cycles when `OUDSTabBar` applies UIKit appearance side-effects, breaking environment values and UI tests. 
- The change aims to avoid those side-effects on iOS 26+ (Liquid Glass) while preserving legacy behavior for older OS versions. 

### Description

- Skip applying `setupTabBarAppearance` inside `TabBarViewModifier` when running on iOS 26+ to avoid attribute graph interactions. 
- Use an unbound `TabView` (no `selection` binding) for the non-legacy iOS 26+ path in `OUDSTabBar` to prevent SwiftUI attribute cycles. 
- Preserve existing behavior for legacy layouts (iOS < 26 / iPadOS < 18) including the selected tab indicator and appearance updates. 
- Files changed: `OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarViewModifier.swift` and `OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift`.

### Testing

- Attempted formatting with `bundle exec fastlane format`, but it failed because `bundle install` could not complete due to Rubygems 403 Forbidden so Fastlane is not available. 
- Attempted build with `bundle exec fastlane build` and unit tests with `bundle exec fastlane test_unit`, both failed because Fastlane is not installed. 
- Lint run `bundle exec fastlane lint` also failed for the same bundler / Fastlane installation issue. 
- No UI tests were run in this environment; validation should be performed on an iOS 26.2 environment with the UI test suite to confirm the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961309f688883279d482576d81f81e7)