### PR TITLE
Refactor OUDSTabBar to reuse TabView instance to avoid attribute graph cycle

### DIFF
--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -242,14 +242,16 @@ public struct OUDSTabBar<Content>: View where Content: View {
     /// Warning: rendering wil change depending to OS version!
     public var body: some View {
         #if os(iOS)
+        let tabView = TabView(selection: $selectedTab) {
+            content()
+        }
+        .modifier(TabBarViewModifier())
+
         // Without Liquid Glass, an indicator for the tab bar is mandatory for iPhones in portrait mode only,
         // not for iPhone in landscape mode nor iPads.
         if hasLegacyLayout {
             ZStack(alignment: .bottom) {
-                TabView(selection: $selectedTab) {
-                    content()
-                }
-                .modifier(TabBarViewModifier())
+                tabView
 
                 TabBarTopDivider()
 
@@ -268,9 +270,7 @@ public struct OUDSTabBar<Content>: View where Content: View {
             }
             // Liquid Glass or iPadOS > 18
         } else {
-            TabView(selection: $selectedTab) {
-                content()
-            }.modifier(TabBarViewModifier())
+            tabView
         }
         #else // visionOS, macOS
         TabView(selection: $selectedTab) {


### PR DESCRIPTION
### Motivation
- iOS 26 (Liquid Glass) builds can emit "AttributeGraph: cycle detected" when multiple `TabView` instances are created across conditional branches, which breaks accessibility and UI tests.
- The `OUDSTabBar` previously built a `TabView` in each branch of an `if/else`, which is a likely trigger for the attribute graph cycle on modern SDKs.
- Reusing a single `TabView` instance across branches reduces duplicated view construction and aims to prevent the attribute graph cycle.
- Keep existing legacy layout behavior intact while avoiding duplicate `TabView` creation.

### Description
- Reused a single `TabView(selection: $selectedTab) { content() }` instance assigned to `tabView` and applied `.modifier(TabBarViewModifier())` once, then referenced `tabView` in both branches of the conditional in `OUDSTabBar`.
- Preserved the legacy `ZStack` layout and `SelectedTabIndicator` logic for pre-iOS 26 layouts and left non-iOS paths unchanged.
- Made no changes to `TabBarViewModifier` behavior in this patch to limit scope to view construction.
- Committed the refactor with the message `Refactor OUDSTabBar TabView usage`.

### Testing
- Attempted `bundle exec fastlane format` but it failed due to missing fastlane/bundler environment (bundler: command not found).
- Attempted `bundle exec fastlane build` but it failed for the same reason (bundler: command not found).
- Attempted `bundle exec fastlane test_unit` and `bundle exec fastlane lint` and both failed due to the missing bundler/fastlane setup.
- No unit or integration tests were executed successfully in this environment because the Ruby/gem tooling is not installed. Please run the project CI (`bundle install` then `bundle exec fastlane test_unit`) in the normal build environment to validate.]

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696179c706d883278478693898e42b6d)