### PR TITLE
Add top & bottom toolbar components (OUDSToolBarTop / OUDSToolBarBottom) and docs

### DIFF
--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomAppearanceModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomAppearanceModifier.swift
@@ -1,0 +1,108 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@available(iOS 15, macOS 15, visionOS 1, *)
+struct ToolBarBottomAppearanceModifier: ViewModifier {
+
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                setupToolBarAppearance()
+            }
+        #if os(iOS)
+            .onChange(of: colorScheme) { newColorScheme in
+                setupToolBarAppearance(withColor: newColorScheme)
+            }
+            .onChange(of: theme) { newTheme in
+                setupToolBarAppearance(withTheme: newTheme)
+            }
+        #endif
+        #if os(visionOS)
+        // Conflict between SwiftLint and SwiftFormat
+        // swiftlint:disable closure_end_indentation
+            .onChange(of: colorScheme) { _, newColorScheme in
+                setupToolBarAppearance(withColor: newColorScheme)
+        }
+        .onChange(of: theme) { _, newTheme in
+            setupToolBarAppearance(withTheme: newTheme)
+        }
+        // swiftlint:enable closure_end_indentation
+        #endif
+    }
+
+    private func setupToolBarAppearance(withColor scheme: ColorScheme? = nil,
+                                        withTheme theme: OUDSTheme? = nil)
+    {
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            return
+        }
+
+        let schemeToApply = scheme ?? colorScheme
+        let themeToApply = theme ?? self.theme
+        let appearance = UIToolbarAppearance()
+
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .regular)
+        appearance.backgroundColor = themeToApply.bar.colorBgTranslucent.color(for: schemeToApply).uiColor
+
+        let toolBar = UIToolbar.appearance()
+        toolBar.standardAppearance = appearance
+        toolBar.scrollEdgeAppearance = appearance
+
+        DispatchQueue.main.async {
+            updateExistingToolBars(with: appearance)
+        }
+        #endif
+    }
+
+    #if os(iOS)
+    private func updateExistingToolBars(with appearance: UIToolbarAppearance) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+
+        for window in windowScene.windows {
+            updateToolBars(in: window.rootViewController, with: appearance)
+        }
+    }
+
+    private func updateToolBars(in viewController: UIViewController?, with appearance: UIToolbarAppearance) {
+        guard let viewController else { return }
+
+        if let navigationController = viewController as? UINavigationController {
+            navigationController.toolbar.standardAppearance = appearance
+            navigationController.toolbar.scrollEdgeAppearance = appearance
+
+            navigationController.toolbar.setNeedsLayout()
+            navigationController.toolbar.layoutIfNeeded()
+        }
+
+        for child in viewController.children {
+            updateToolBars(in: child, with: appearance)
+        }
+
+        if let presented = viewController.presentedViewController {
+            updateToolBars(in: presented, with: appearance)
+        }
+    }
+    #endif
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItemStyleModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItemStyleModifier.swift
@@ -1,0 +1,51 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+@available(iOS 15, macOS 15, visionOS 1, *)
+struct ToolBarItemStyleModifier: ViewModifier {
+
+    let placement: OUDSToolBarItemPlacement
+
+    @Environment(\.theme) private var theme
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        switch placement {
+        case .leading:
+            content
+                .oudsForegroundColor(theme.colors.contentDefault)
+        case .trailing:
+            trailingItem(content: content)
+        }
+    }
+
+    @ViewBuilder
+    private func trailingItem(content: Content) -> some View {
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            content
+                .oudsForegroundColor(theme.colors.contentDefault)
+                .oudsBackground(theme.colors.actionAccent)
+        } else {
+            content
+                .oudsForegroundColor(theme.colors.contentDefault)
+        }
+        #else
+        content
+            .oudsForegroundColor(theme.colors.contentDefault)
+        #endif
+    }
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTitleView.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTitleView.swift
@@ -1,0 +1,39 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+@available(iOS 15, macOS 15, visionOS 1, *)
+struct ToolBarTitleView: View {
+
+    let title: String
+    let subtitle: String?
+
+    @Environment(\.theme) private var theme
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(LocalizedStringKey(title))
+                .headingSmall(theme)
+                .oudsForegroundColor(theme.colors.contentDefault)
+
+            if let subtitle {
+                Text(LocalizedStringKey(subtitle))
+                    .bodyDefaultSmall(theme)
+                    .oudsForegroundColor(theme.colors.contentDefault)
+            }
+        }
+        .multilineTextAlignment(.center)
+    }
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopAppearanceModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopAppearanceModifier.swift
@@ -1,0 +1,114 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@available(iOS 15, macOS 15, visionOS 1, *)
+struct ToolBarTopAppearanceModifier: ViewModifier {
+
+    @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                setupNavigationBarAppearance()
+            }
+        #if os(iOS)
+            .onChange(of: colorScheme) { newColorScheme in
+                setupNavigationBarAppearance(withColor: newColorScheme)
+            }
+            .onChange(of: theme) { newTheme in
+                setupNavigationBarAppearance(withTheme: newTheme)
+            }
+        #endif
+        #if os(visionOS)
+        // Conflict between SwiftLint and SwiftFormat
+        // swiftlint:disable closure_end_indentation
+            .onChange(of: colorScheme) { _, newColorScheme in
+                setupNavigationBarAppearance(withColor: newColorScheme)
+        }
+        .onChange(of: theme) { _, newTheme in
+            setupNavigationBarAppearance(withTheme: newTheme)
+        }
+        // swiftlint:enable closure_end_indentation
+        #endif
+    }
+
+    private func setupNavigationBarAppearance(withColor scheme: ColorScheme? = nil,
+                                              withTheme theme: OUDSTheme? = nil)
+    {
+        #if os(iOS)
+        if #available(iOS 26.0, *) {
+            return
+        }
+
+        let schemeToApply = scheme ?? colorScheme
+        let themeToApply = theme ?? self.theme
+        let appearance = UINavigationBarAppearance()
+
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .regular)
+        appearance.backgroundColor = themeToApply.bar.colorBgTranslucent.color(for: schemeToApply).uiColor
+
+        let titleColor = themeToApply.colors.contentDefault.color(for: schemeToApply).uiColor
+        appearance.titleTextAttributes = [.foregroundColor: titleColor]
+        appearance.largeTitleTextAttributes = [.foregroundColor: titleColor]
+
+        let navigationBar = UINavigationBar.appearance()
+        navigationBar.standardAppearance = appearance
+        navigationBar.scrollEdgeAppearance = appearance
+        navigationBar.compactAppearance = appearance
+
+        DispatchQueue.main.async {
+            updateExistingNavigationBars(with: appearance)
+        }
+        #endif
+    }
+
+    #if os(iOS)
+    private func updateExistingNavigationBars(with appearance: UINavigationBarAppearance) {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else { return }
+
+        for window in windowScene.windows {
+            updateNavigationBars(in: window.rootViewController, with: appearance)
+        }
+    }
+
+    private func updateNavigationBars(in viewController: UIViewController?, with appearance: UINavigationBarAppearance) {
+        guard let viewController else { return }
+
+        if let navigationController = viewController as? UINavigationController {
+            navigationController.navigationBar.standardAppearance = appearance
+            navigationController.navigationBar.scrollEdgeAppearance = appearance
+            navigationController.navigationBar.compactAppearance = appearance
+
+            navigationController.navigationBar.setNeedsLayout()
+            navigationController.navigationBar.layoutIfNeeded()
+        }
+
+        for child in viewController.children {
+            updateNavigationBars(in: child, with: appearance)
+        }
+
+        if let presented = viewController.presentedViewController {
+            updateNavigationBars(in: presented, with: appearance)
+        }
+    }
+    #endif
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarBottom.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarBottom.swift
@@ -1,0 +1,116 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// The bottom toolbar is a navigation component displayed at the bottom of the screen.
+/// It lets you provide leading and trailing toolbar items.
+///
+/// ## Appearances
+///
+/// - For iOS 26 and later, Liquid Glass is used and the system manages the background style.
+/// - For iOS versions lower than 26, the bar uses a regular blur and applies `bar.colorBgTranslucent`.
+/// - Items always use `colors.contentDefault` as foreground color.
+/// - On iOS 26+, items also use `colors.actionAccent` as background color.
+///
+/// ## Usage
+///
+/// ```swift
+/// OUDSToolBarBottom {
+///     ContentView()
+/// } leadingItems: {
+///     OUDSToolBarItem(placement: .leading) {
+///         Button(action: {}) {
+///             Image(systemName: "square.and.arrow.up")
+///         }
+///     }
+/// } trailingItems: {
+///     OUDSToolBarItem(placement: .trailing) {
+///         Button(action: {}) {
+///             Image(systemName: "trash")
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Platform considerations
+///
+/// - Available on iOS 15, macOS 15, and visionOS 1.
+/// - Not available on watchOS or tvOS.
+///
+/// - Since: 1.1.0
+@available(iOS 15, macOS 15, visionOS 1, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct OUDSToolBarBottom<Content: View, Leading: View, Trailing: View>: View {
+
+    // MARK: Properties
+
+    @ViewBuilder private let content: () -> Content
+    @ViewBuilder private let leadingItems: () -> Leading
+    @ViewBuilder private let trailingItems: () -> Trailing
+
+    // MARK: Init
+
+    /// Creates a bottom toolbar with leading and trailing items.
+    ///
+    /// - Parameters:
+    ///   - content: The main content view.
+    ///   - leadingItems: Items displayed on the leading edge of the toolbar.
+    ///   - trailingItems: Items displayed on the trailing edge of the toolbar.
+    public init(@ViewBuilder content: @escaping () -> Content,
+                @ViewBuilder leadingItems: @escaping () -> Leading = { EmptyView() },
+                @ViewBuilder trailingItems: @escaping () -> Trailing = { EmptyView() })
+    {
+        self.content = content
+        self.leadingItems = leadingItems
+        self.trailingItems = trailingItems
+    }
+
+    // MARK: Body
+
+    public var body: some View {
+        content()
+            .modifier(ToolBarBottomAppearanceModifier())
+            .toolbar {
+                leadingToolbarItems
+                trailingToolbarItems
+            }
+    }
+
+    @ToolbarContentBuilder
+    private var leadingToolbarItems: some ToolbarContent {
+        #if os(macOS)
+        ToolbarItemGroup(placement: .automatic) {
+            leadingItems()
+        }
+        #else
+        ToolbarItemGroup(placement: .bottomBar) {
+            leadingItems()
+        }
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var trailingToolbarItems: some ToolbarContent {
+        #if os(macOS)
+        ToolbarItemGroup(placement: .primaryAction) {
+            trailingItems()
+        }
+        #else
+        ToolbarItemGroup(placement: .bottomBar) {
+            trailingItems()
+        }
+        #endif
+    }
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -1,0 +1,160 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+/// Placement of a toolbar item.
+///
+/// - Since: 1.1.0
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public enum OUDSToolBarItemPlacement {
+    case leading
+    case trailing
+}
+
+/// A strongly typed toolbar item wrapper used with ``OUDSToolBarTop`` and ``OUDSToolBarBottom``.
+/// It applies the correct OUDS foreground and background tokens depending on the toolbar placement.
+///
+/// - Since: 1.1.0
+@available(iOS 15, macOS 15, visionOS 1, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct OUDSToolBarItem<Content: View>: View {
+
+    // MARK: Properties
+
+    private let placement: OUDSToolBarItemPlacement
+    @ViewBuilder private let content: () -> Content
+
+    // MARK: Init
+
+    /// Creates an OUDS toolbar item.
+    ///
+    /// - Parameters:
+    ///   - placement: The placement of the toolbar item.
+    ///   - content: The content of the toolbar item.
+    public init(placement: OUDSToolBarItemPlacement, @ViewBuilder content: @escaping () -> Content) {
+        self.placement = placement
+        self.content = content
+    }
+
+    // MARK: Body
+
+    public var body: some View {
+        content()
+            .modifier(ToolBarItemStyleModifier(placement: placement))
+    }
+}
+
+/// Predefined navigation leading items for ``OUDSToolBarTop``.
+///
+/// - Since: 1.1.0
+@available(iOS 15, macOS 15, visionOS 1, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct OUDSToolBarNavigationItem: View {
+
+    // MARK: Types
+
+    /// Supported navigation icons for leading items.
+    public enum Icon {
+        case back
+        case close
+        case menu
+    }
+
+    // MARK: Properties
+
+    private let icon: Icon
+    private let label: String?
+    private let accessibilityLabel: String?
+    private let action: () -> Void
+
+    @Environment(\.theme) private var theme
+    @Environment(\.layoutDirection) private var layoutDirection
+
+    // MARK: Init
+
+    /// Creates an icon-only navigation item.
+    ///
+    /// - Parameters:
+    ///   - icon: The icon to display.
+    ///   - accessibilityLabel: The accessibility label for the icon-only item.
+    ///   - action: The action to perform.
+    public init(icon: Icon, accessibilityLabel: String, action: @escaping () -> Void) {
+        self.icon = icon
+        label = nil
+        self.accessibilityLabel = accessibilityLabel
+        self.action = action
+    }
+
+    /// Creates a navigation item with an icon and a label.
+    ///
+    /// - Parameters:
+    ///   - icon: The icon to display.
+    ///   - label: The label text to display.
+    ///   - action: The action to perform.
+    public init(icon: Icon, label: String, action: @escaping () -> Void) {
+        self.icon = icon
+        self.label = label
+        accessibilityLabel = nil
+        self.action = action
+    }
+
+    // MARK: Body
+
+    public var body: some View {
+        OUDSToolBarItem(placement: .leading) {
+            let button = Button(action: action) {
+                if let label {
+                    Label {
+                        Text(LocalizedStringKey(label))
+                    } icon: {
+                        iconImage
+                    }
+                } else {
+                    iconImage
+                }
+            }
+
+            if let accessibilityLabel {
+                button.accessibilityLabel(LocalizedStringKey(accessibilityLabel))
+            } else {
+                button
+            }
+        }
+    }
+
+    // MARK: Helpers
+
+    private var iconImage: some View {
+        Image(decorative: iconResourceName, bundle: theme.resourcesBundle)
+            .renderingMode(.template)
+            .resizable()
+            .frame(width: 20, height: 20)
+            .toFlip(layoutDirection == .rightToLeft)
+    }
+
+    private var iconResourceName: String {
+        switch icon {
+        case .back:
+            "ic_toolbar_back"
+        case .close:
+            "ic_toolbar_close"
+        case .menu:
+            "ic_toolbar_menu"
+        }
+    }
+}

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -1,0 +1,129 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// The top toolbar is a navigation bar component, displayed at the top of the screen.
+/// It presents a mandatory title and an optional subtitle, and lets you provide leading and trailing toolbar items.
+///
+/// ## Appearances
+///
+/// - For iOS 26 and later, Liquid Glass is used and the system manages the background style.
+/// - For iOS versions lower than 26, the bar uses a regular blur and applies `bar.colorBgTranslucent`.
+/// - The title and subtitle always use `colors.contentDefault`.
+/// - Leading items use `colors.contentDefault`.
+/// - Trailing items use `colors.contentDefault`, and on iOS 26+ they also use `colors.actionAccent` as background.
+///
+/// ## Usage
+///
+/// ```swift
+/// OUDSToolBarTop(title: "Dashboard", subtitle: "Overview") {
+///     ContentView()
+/// } leadingItems: {
+///     OUDSToolBarNavigationItem(icon: .back, label: "Back") {
+///         // Handle back
+///     }
+/// } trailingItems: {
+///     OUDSToolBarItem(placement: .trailing) {
+///         Button(action: {}) {
+///             Image(systemName: "magnifyingglass")
+///         }
+///     }
+/// }
+/// ```
+///
+/// ## Platform considerations
+///
+/// - Available on iOS 15, macOS 15, and visionOS 1.
+/// - Not available on watchOS or tvOS.
+///
+/// - Since: 1.1.0
+@available(iOS 15, macOS 15, visionOS 1, *)
+@available(watchOS, unavailable)
+@available(tvOS, unavailable)
+public struct OUDSToolBarTop<Content: View, Leading: View, Trailing: View>: View {
+
+    // MARK: Properties
+
+    private let title: String
+    private let subtitle: String?
+    @ViewBuilder private let content: () -> Content
+    @ViewBuilder private let leadingItems: () -> Leading
+    @ViewBuilder private let trailingItems: () -> Trailing
+
+    // MARK: Init
+
+    /// Creates a top toolbar with leading and trailing items.
+    ///
+    /// - Parameters:
+    ///   - title: The toolbar title.
+    ///   - subtitle: An optional subtitle displayed below the title.
+    ///   - content: The main content view.
+    ///   - leadingItems: Items displayed on the leading edge of the toolbar.
+    ///   - trailingItems: Items displayed on the trailing edge of the toolbar.
+    public init(title: String,
+                subtitle: String? = nil,
+                @ViewBuilder content: @escaping () -> Content,
+                @ViewBuilder leadingItems: @escaping () -> Leading = { EmptyView() },
+                @ViewBuilder trailingItems: @escaping () -> Trailing = { EmptyView() })
+    {
+        self.title = title
+        self.subtitle = subtitle
+        self.content = content
+        self.leadingItems = leadingItems
+        self.trailingItems = trailingItems
+    }
+
+    // MARK: Body
+
+    public var body: some View {
+        content()
+            .modifier(ToolBarTopAppearanceModifier())
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    ToolBarTitleView(title: title, subtitle: subtitle)
+                }
+                leadingToolbarItems
+                trailingToolbarItems
+            }
+        #if os(iOS) || os(visionOS)
+            .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var leadingToolbarItems: some ToolbarContent {
+        #if os(macOS)
+        ToolbarItemGroup(placement: .navigation) {
+            leadingItems()
+        }
+        #else
+        ToolbarItemGroup(placement: .navigationBarLeading) {
+            leadingItems()
+        }
+        #endif
+    }
+
+    @ToolbarContentBuilder
+    private var trailingToolbarItems: some ToolbarContent {
+        #if os(macOS)
+        ToolbarItemGroup(placement: .primaryAction) {
+            trailingItems()
+        }
+        #else
+        ToolbarItemGroup(placement: .navigationBarTrailing) {
+            trailingItems()
+        }
+        #endif
+    }
+}

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -111,3 +111,67 @@ OUDSTabBar(selected: 0, count: 3) {
         .tag(2)
 }
 ```
+
+### Toolbars
+
+Toolbars are navigation components displayed at the top or bottom of the screen.
+They rely on native SwiftUI toolbars and apply OUDS tokens for colors and typography.
+
+For iOS 26 and later, Liquid Glass is used and the system manages the background appearance.
+For iOS versions lower than 26, toolbars use a regular blur and the `bar.colorBgTranslucent` token as background color.
+
+@TabNavigator {
+    @Tab("Top toolbar (Liquid Glass)") {
+        ![A top toolbar with Liquid Glass in light mode](component_toolbarTop_LiquidGlass_light)
+        ![A top toolbar with Liquid Glass in dark mode](component_toolbarTop_LiquidGlass_dark)
+    }
+    @Tab("Top toolbar") {
+        ![A top toolbar without Liquid Glass in light mode](component_toolbarTop_light)
+        ![A top toolbar without Liquid Glass in dark mode](component_toolbarTop_dark)
+    }
+}
+
+@TabNavigator {
+    @Tab("Bottom toolbar (Liquid Glass)") {
+        ![A bottom toolbar with Liquid Glass in light mode](component_toolbarBottom_LiquidGlass_light)
+        ![A bottom toolbar with Liquid Glass in dark mode](component_toolbarBottom_LiquidGlass_dark)
+    }
+    @Tab("Bottom toolbar") {
+        ![A bottom toolbar without Liquid Glass in light mode](component_toolbarBottom_light)
+        ![A bottom toolbar without Liquid Glass in dark mode](component_toolbarBottom_dark)
+    }
+}
+
+```swift
+OUDSToolBarTop(title: "Title", subtitle: "Subtitle") {
+    ContentView()
+} leadingItems: {
+    OUDSToolBarNavigationItem(icon: .back, label: "Back") {
+        // Handle back
+    }
+} trailingItems: {
+    OUDSToolBarItem(placement: .trailing) {
+        Button(action: {}) {
+            Image(systemName: "ellipsis")
+        }
+    }
+}
+```
+
+```swift
+OUDSToolBarBottom {
+    ContentView()
+} leadingItems: {
+    OUDSToolBarItem(placement: .leading) {
+        Button(action: {}) {
+            Image(systemName: "square.and.arrow.up")
+        }
+    }
+} trailingItems: {
+    OUDSToolBarItem(placement: .trailing) {
+        Button(action: {}) {
+            Image(systemName: "trash")
+        }
+    }
+}
+```


### PR DESCRIPTION
### Motivation

- Provide first implementation of top and bottom toolbars so navigation bars/toolbars are available as OUDS SwiftUI components.
- Offer a strongly typed item API so consumers can pass leading/trailing content with OUDS styling and predefined navigation items.

### Description

- Add `OUDSToolBarTop` and `OUDSToolBarBottom` SwiftUI components plus `OUDSToolBarItem` and `OUDSToolBarNavigationItem` helpers for leading/trailing items and common icons (`back`, `close`, `menu`).
- Implement appearance modifiers `ToolBarTopAppearanceModifier` and `ToolBarBottomAppearanceModifier` that apply blur and `bar.colorBgTranslucent` for iOS < 26 while deferring to system (Liquid Glass) behavior on iOS 26+.
- Add `ToolBarItemStyleModifier` to apply `colors.contentDefault` and to apply `colors.actionAccent` as trailing background on iOS 26+, and introduce `ToolBarTitleView` to render title + optional subtitle using OUDS typography tokens.
- Update documentation in `OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md` with usage samples and notes about Liquid Glass and platform availability (`iOS 15`, `macOS 15`, `visionOS 1`, unavailable on `watchOS`/`tvOS`).

### Testing

- Attempted to run formatting via `bundle exec fastlane format` but it failed because `fastlane` is not available due to `bundle install` failing with a `403 Forbidden` from rubygems.org.
- Attempted `bundle install` but it failed with a `403 Forbidden` error while fetching gems, so automatic format/build/test/lint pipelines were not executed.
- No unit or snapshot tests were run in this environment due to the dependency installation failure.
- The changes were locally compiled/committed in the working branch (file creation and integration points added) but CI validation still needs to be executed after dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a210f5a9c8327a9af960d7e607d0f)