### PR TITLE
[#1300] Bullet list component, the size of the bullet for unordered and bare must be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- With the bullet list component, the size of the bullet for unordered and bare must be updated (Orange-OpenSource/ouds-ios#1300)
 - `SwiftFormat` Swift package plugin from v0.59.0 to v0.59.1
 - `ruby/setup-ruby` action from v1.286.0 to v1.288.0 for `build-and-test` workflow
 - `github/codeql-action/upload-sarif` action for `scorecard` workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/1.2.0...develop)
+
+### Changed
+
+- [DesignToolbox] With the bullet list component, the size of the bullet for unordered and bare must be updated (Orange-OpenSource/ouds-ios#1300)
+
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.1.0...1.2.0) - 2026-02-12
 
 ### Added
@@ -14,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- With the bullet list component, the size of the bullet for unordered and bare must be updated (Orange-OpenSource/ouds-ios#1300)
 - `SwiftFormat` Swift package plugin from v0.59.0 to v0.59.1
 - `ruby/setup-ruby` action from v1.286.0 to v1.288.0 for `build-and-test` workflow
 - `github/codeql-action/upload-sarif` action for `scorecard` workflow

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/1.2.0...develop)
 
-### Changed
+### Fixed
 
-- [DesignToolbox] With the bullet list component, the size of the bullet for unordered and bare must be updated (Orange-OpenSource/ouds-ios#1300)
+- [Library] Size of the bullet for unordered and bare bullet list component (Orange-OpenSource/ouds-ios#1300)
 
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.1.0...1.2.0) - 2026-02-12
 

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
@@ -42,7 +42,7 @@ struct Bullet: View {
             case .ordered:
                 OrderedBullet(level: level, textStyle: textStyle, isBold: isBold, index: index)
             case .bare:
-                Rectangle().fill(.clear)
+                Rectangle().fill(.clear).frame(width: minWidth)
             }
         }
         .frame(minWidth: minWidth, alignment: .trailing)
@@ -59,15 +59,9 @@ struct Bullet: View {
             theme.sizes.iconWithBodyMediumSizeMedium
         }
 
+        // To follow the dynamic font, the width of the container must be adjusted.
         let rawSize = token.dimension(for: horizontalSizeClass ?? .regular)
-
-        // Ordered type, means bullet is a text, so for dynamic font the
-        // width of the container must be adjusted.
-        if case .ordered = type {
-            return rawSize * dynamicTypeSize.percentageRate / 100
-        } else {
-            return rawSize
-        }
+        return rawSize * dynamicTypeSize.percentageRate / 100
     }
 
     private var maxHeight: CGFloat {
@@ -78,6 +72,7 @@ struct Bullet: View {
             theme.fonts.lineHeightBodyMedium
         }
 
+        // To follow the dynamic font, the height of the container must be adjusted.
         let rawSize = token.lineHeight(for: verticalSizeClass ?? .regular)
         return rawSize * dynamicTypeSize.percentageRate / 100
     }
@@ -100,11 +95,8 @@ struct UnorderedBullet: View {
     // MARK: Body
 
     var body: some View {
-        asset
-            .resizable()
-            .renderingMode(.template)
+        ScaledIcon(icon: asset.renderingMode(.template), size: assetSize)
             .oudsForegroundColor(color)
-            .frame(width: assetSize, height: assetSize, alignment: .center)
     }
 
     // MARK: Private helpers


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1300

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] I checked I am using the last version of OUDS iOS library
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios-design-system-toolbox/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
