### PR TITLE
[#1296] Update the loader size on `button` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Library] Size of the bullet for unordered and bare bullet list component (Orange-OpenSource/ouds-ios#1300)
+- Update the loader size on `button` component (Orange-OpenSource/ouds-ios#1296)
+- Size of the bullet for unordered and bare bullet list component (Orange-OpenSource/ouds-ios#1300)
 
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.1.0...1.2.0) - 2026-02-12
 
@@ -27,9 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `fastlane` gem from v2.231.1 to v2.232.1
 - **BREAKING**: Rename of *Orange Business Tools*  theme to *Orange Compact* (Orange-OpenSource/ouds-ios#1292)
 
-### Fixed
-
-- Update the loader size on `button` component (Orange-OpenSource/ouds-ios#1296)
 
 ## [1.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.0.0...1.1.0) - 2026-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update `fastlane` gem from v2.231.1 to v2.232.1
 - **BREAKING**: Rename of *Orange Business Tools*  theme to *Orange Compact* (Orange-OpenSource/ouds-ios#1292)
 
+### Fixed
+
+- Update the loader size on `button` component (Orange-OpenSource/ouds-ios#1296)
+
 ## [1.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.0.0...1.1.0) - 2026-01-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Update the loader size on `button` component (Orange-OpenSource/ouds-ios#1296)
-- Size of the bullet for unordered and bare bullet list component (Orange-OpenSource/ouds-ios#1300)
+- Size of loader for `button` component (Orange-OpenSource/ouds-ios#1296)
+- Size of the bullet for unordered and bare `bullet list` component (Orange-OpenSource/ouds-ios#1300)
 
 ## [1.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.1.0...1.2.0) - 2026-02-12
 

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
@@ -16,6 +16,8 @@ import OUDSTokensComponent
 import OUDSTokensSemantic
 import SwiftUI
 
+// MARK: - Button Loading Content Modifier
+
 /// Used to add a progress indicator instead of content (Text, Icon)
 /// As the button must keep the size of the content, the indicator is
 /// added as overlay on top, and the content is hidden applying an opacity.
@@ -41,7 +43,7 @@ struct ButtonLoadingContentModifier: ViewModifier {
             }
     }
 
-    // MARK: Private helper
+    // MARK: Private helpers
 
     private var colorToken: MultipleColorSemanticToken {
         switch appearance {
@@ -65,7 +67,10 @@ struct ButtonLoadingContentModifier: ViewModifier {
     }
 }
 
-struct LoaderSizeModifier: ViewModifier {
+// MARK: - Loader Size Modifier
+
+private struct LoaderSizeModifier: ViewModifier {
+
     @ScaledMetric var size: CGFloat
 
     func body(content: Content) -> some View {

--- a/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/Internal/ButtonStyle+LoadingModifiers.swift
@@ -22,14 +22,14 @@ import SwiftUI
 /// If the device has the high contrast mode enabled, changes the loader color.
 struct ButtonLoadingContentModifier: ViewModifier {
 
+    // MARK: Stored Properties
+
+    let appearance: OUDSButton.Appearance
+
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     @Environment(\.oudsUseMonochrome) private var useMonochrome
-
-    // MARK: Stored Properties
-
-    let appearance: OUDSButton.Appearance
 
     // MARK: Body
 
@@ -37,7 +37,7 @@ struct ButtonLoadingContentModifier: ViewModifier {
         content
             .overlay {
                 LoaderIndicator(color: colorToken.color(for: colorScheme))
-                    .padding(.vertical, theme.button.spacePaddingBlock)
+                    .modifier(LoaderSizeModifier(size: size))
             }
     }
 
@@ -58,5 +58,17 @@ struct ButtonLoadingContentModifier: ViewModifier {
         case .negative:
             theme.colors.contentOnStatusNegativeEmphasized
         }
+    }
+
+    private var size: CGFloat {
+        theme.button.sizeLoader
+    }
+}
+
+struct LoaderSizeModifier: ViewModifier {
+    @ScaledMetric var size: CGFloat
+
+    func body(content: Content) -> some View {
+        content.frame(width: size, height: size, alignment: .center)
     }
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1296

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- NA Accessibility review has been done
- [x] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
