### PR TITLE
[#1314] In library update signature of control item components to be consistant

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,8 +564,8 @@ OUDSCheckbox(isOn: $isOn, accessibilityLabel: "Some label to vocalize")
 or with texts and image:
 ```swift
 @Published var isOn: Bool = true
-OUDSCheckboxItem(isOn: $isOn,
-                 label: "An important text",
+OUDSCheckboxItem(label: "An important text",
+                 isOn: $isOn,
                  description: "A secondary text",
                  icon: Image(decorative: "image_name"))
 ```
@@ -573,7 +573,7 @@ OUDSCheckboxItem(isOn: $isOn,
 or only with one text:
 ```swift
 @Published var isOn: Bool = true
-OUDSCheckboxItem(isOn: $isOn, label: "Hello world")
+OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
 ```
 
 Checkboxes can be wrapped inside a checkbox picker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -615,15 +615,15 @@ OUDSRadio(isOn: $selection, accessibilityLabel: "Some label to vocalized")
 or with texts and image:
 ```swift
 @Published var isOn: Bool = true
-OUDSRadioItem(isOn: $isOn,
-              label: "Some text",
+OUDSRadioItem(label: "Some text",
+              isOn: $isOn,
               icon: Image(decorative: "image_name"))
 ```
 
 or only with one text:
 ```swift
 @Published var isOn: Bool = true
-OUDSRadioItem(isOn: $isOn, label: "Some text")
+OUDSRadioItem(label: "Some text", isOn: $isOn)
 ```
 
 Radio buttons can be wrapped inside a radio picker.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -564,7 +564,7 @@ OUDSCheckbox(isOn: $isOn, accessibilityLabel: "Some label to vocalize")
 or with texts and image:
 ```swift
 @Published var isOn: Bool = true
-OUDSCheckboxItem(label: "An important text",
+OUDSCheckboxItem("An important text",
                  isOn: $isOn,
                  description: "A secondary text",
                  icon: Image(decorative: "image_name"))
@@ -573,7 +573,7 @@ OUDSCheckboxItem(label: "An important text",
 or only with one text:
 ```swift
 @Published var isOn: Bool = true
-OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
+OUDSCheckboxItem("Hello world", isOn: $isOn)
 ```
 
 Checkboxes can be wrapped inside a checkbox picker.
@@ -615,7 +615,7 @@ OUDSRadio(isOn: $selection, accessibilityLabel: "Some label to vocalized")
 or with texts and image:
 ```swift
 @Published var isOn: Bool = true
-OUDSRadioItem(label: "Some text",
+OUDSRadioItem("Some text",
               isOn: $isOn,
               icon: Image(decorative: "image_name"))
 ```
@@ -623,7 +623,7 @@ OUDSRadioItem(label: "Some text",
 or only with one text:
 ```swift
 @Published var isOn: Bool = true
-OUDSRadioItem(label: "Some text", isOn: $isOn)
+OUDSRadioItem("Some text", isOn: $isOn)
 ```
 
 Radio buttons can be wrapped inside a radio picker.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `alert message` component (Orange-OpenSource/ouds-ios#1159)
 
+### Changed
+
+- Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)
+
 ### Fixed
 
 - Size of loader for `button` component (Orange-OpenSource/ouds-ios#1296)

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckbox.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckbox.swift
@@ -110,7 +110,7 @@ public struct OUDSCheckbox: View {
     /// **The design system does not allow to have both an error or read only situation and a disabled state for the component.**
     ///
     /// - Parameters:
-    ///    - isOn: A binding to a property that determines wether the indicator is ticked (selected) or not (not selected)
+    ///    - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (not selected)
     ///    - accessibilityLabel: The accessibility label the component must have
     ///    - isError: True if the look and feel of the component must reflect an error state, default set to `false`
     ///    - isReadOnly: True if the look and feel of the component must reflect a read only state, default set to `false`

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxIndeterminate.swift
@@ -110,7 +110,7 @@ public struct OUDSCheckboxIndeterminate: View {
     /// **The design system does not allow to have both an error situation and a disabled state for the component.**
     ///
     /// - Parameters:
-    ///    - selection: A binding to a property that determines wether the indicator is ticked, unticked or preticked.
+    ///    - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked.
     ///    - accessibilityLabel: The accessibility label the component must have
     ///    - isError: True if the look and feel of the component must reflect an error state, default set to `false`
     ///    - isReadOnly: True if the look and feel of the component must reflect a read only state, default set to `false`

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -175,9 +175,9 @@ public struct OUDSCheckboxItem: View {
     /// - Parameters:
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional icon,  default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true` to reverse the image (i.e. flip vertically)
+    ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
+    ///   - icon: An optional icon, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -205,6 +205,7 @@ public struct OUDSCheckboxItem: View {
         self.init(label,
                   isOn: isOn,
                   description: description,
+                  icon: icon,
                   flipIcon: flipIcon,
                   isReversed: isReversed,
                   isError: isError,
@@ -232,9 +233,9 @@ public struct OUDSCheckboxItem: View {
     /// - Parameters:
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
-    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional icon,  default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true` to reverse the image (i.e. flip vertically)
+    ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
+    ///   - icon: An optional icon, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -68,26 +68,26 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
+///     OUDSCheckboxItem("Hello world", isOn: $isOn)
 ///
 ///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isReadOnly: true)
+///     OUDSCheckboxItem("Hello world", isOn: $isOn, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(label: "Bazinga!", isOn: $isOn, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
+///     OUDSCheckboxItem("Bazinga!", isOn: $isOn, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
 ///     // A trailing checkbox with a label, a description and an icon.
 ///     // The reversed layout will be used here.
-///     OUDSCheckboxItem(label: "We live in a fabled world",
+///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
 ///                      isReversed: true,
 ///                      icon: Image(decorative: "ic_heart"))
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSCheckboxItem(label: "We live in a fabled world",
+///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      isError: true,
 ///                      errorText: "Something wrong",
@@ -95,20 +95,20 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
+///     OUDSCheckboxItem("Hello world", isOn: $isOn)
 ///         .disabled(true)
 ///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
-///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isError: true).disabled(true) // fatal error
-///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isReadyOnly: true).disabled(true) // fatal error
+///     OUDSCheckboxItem("Hello world", isOn: $isOn, isError: true).disabled(true) // fatal error
+///     OUDSCheckboxItem("Hello world", isOn: $isOn, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSCheckboxItem(label: "Cocorico !",
+///     OUDSCheckboxItem("Cocorico !",
 ///                      isOn: $selection,
 ///                      icon: Image(systemName: "figure.handball"),
 ///                      flipIcon: layoutDirection == .rightToLeft,
@@ -188,7 +188,7 @@ public struct OUDSCheckboxItem: View {
     ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
     ///     modifier. Defaults to `false`.
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use instead OUDSCheckboxItem(label:isOn)")
+    @available(*, deprecated, message: "Use instead OUDSCheckboxItem(:isOn:)")
     public init(isOn: Binding<Bool>,
                 label: String,
                 description: String? = nil,
@@ -202,7 +202,7 @@ public struct OUDSCheckboxItem: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
-        self.init(label: label,
+        self.init(label,
                   isOn: isOn,
                   description: description,
                   flipIcon: flipIcon,
@@ -218,7 +218,7 @@ public struct OUDSCheckboxItem: View {
     /// Creates a checkbox with label and optional helper text, icon, divider.
     ///
     /// ```swift
-    ///     OUDSCheckboxItem(label: "Virgin Holy Lava",
+    ///     OUDSCheckboxItem("Virgin Holy Lava",
     ///                      isOn: $isOn,
     ///                      description: "Very spicy",
     ///                      icon: Image(systemName: "flame")
@@ -245,7 +245,7 @@ public struct OUDSCheckboxItem: View {
     ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
     ///     modifier. Defaults to `false`.
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    public init(label: String,
+    public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
                 icon: Image? = nil,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -68,48 +68,48 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn, label: "Hello world")
+///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
 ///
 ///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn, label: "Hello world", isReadOnly: true)
+///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn, label: "Bazinga!", description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
+///     OUDSCheckboxItem(label: "Bazinga!", isOn: $isOn, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
 ///     // A trailing checkbox with a label, a description and an icon.
 ///     // The reversed layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn,
-///                      label: "We live in a fabled world",
+///     OUDSCheckboxItem(label: "We live in a fabled world",
+///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
 ///                      isReversed: true,
 ///                      icon: Image(decorative: "ic_heart"))
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSCheckboxItem(isOn: $isOn,
-///                      label: "We live in a fabled world",
+///     OUDSCheckboxItem(label: "We live in a fabled world",
+///                      isOn: $isOn,
 ///                      isError: true,
 ///                      errorText: "Something wrong",
 ///                      hasDivider: true)
 ///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItem(isOn: $isOn, label: "Hello world")
+///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
 ///         .disabled(true)
 ///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
-///     OUDSCheckboxItem(isOn: $isOn, label: "Hello world", isError: true).disabled(true) // fatal error
-///     OUDSCheckboxItem(isOn: $isOn, label: "Hello world", isReadyOnly: true).disabled(true) // fatal error
+///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isError: true).disabled(true) // fatal error
+///     OUDSCheckboxItem(label: "Hello world", isOn: $isOn, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSCheckboxItem(isOn: $selection,
-///                      label: "Cocorico !",
+///     OUDSCheckboxItem(label: "Cocorico !",
+///                      isOn: $selection,
 ///                      icon: Image(systemName: "figure.handball"),
 ///                      flipIcon: layoutDirection == .rightToLeft,
 ///                      isInversed: layoutDirection == .rightToLeft)
@@ -188,8 +188,65 @@ public struct OUDSCheckboxItem: View {
     ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
     ///     modifier. Defaults to `false`.
     ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use instead OUDSCheckboxItem(label:isOn)")
     public init(isOn: Binding<Bool>,
                 label: String,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(label: label,
+                  isOn: isOn,
+                  description: description,
+                  flipIcon: flipIcon,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a checkbox with label and optional helper text, icon, divider.
+    ///
+    /// ```swift
+    ///     OUDSCheckboxItem(label: "Virgin Holy Lava",
+    ///                      isOn: $isOn,
+    ///                      description: "Very spicy",
+    ///                      icon: Image(systemName: "flame")
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the checkbox, must not be empty
+    ///   - isOn: A binding to a property that determines wether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be repalced by `errorText` in case of error.
+    ///   - icon: An optional icon,  default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to true` to reverse the image (i.e. flip vertically)
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   The `errorText`can be different if switch is selected or not.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    public init(label: String,
+                isOn: Binding<Bool>,
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -173,12 +173,12 @@ public struct OUDSCheckboxItem: View {
     /// provide the localized string if key is stored in another bundle.**
     ///
     /// - Parameters:
-    ///   - isOn: A binding to a property that determines wether the indicator is ticked (selected) or not (unselected)
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be repalced by `errorText` in case of error.
+    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
     ///   - icon: An optional icon,  default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true` to reverse the image (i.e. flip vertically)
-    ///   - isReversed: `true` if the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.
@@ -231,11 +231,11 @@ public struct OUDSCheckboxItem: View {
     ///
     /// - Parameters:
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - isOn: A binding to a property that determines wether the indicator is ticked (selected) or not (unselected)
-    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be repalced by `errorText` in case of error.
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additonal helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
     ///   - icon: An optional icon,  default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true` to reverse the image (i.e. flip vertically)
-    ///   - isReversed: `true` if the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -68,54 +68,54 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Hello world")
+///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection)
 ///
 ///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Hello world", isReadOnly: true)
+///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Bazinga!", description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
+///     OUDSCheckboxItemIndeterminate(label: "Bazinga!", selection: $selection, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
 ///     // A trailing checkbox with a label, an helper text and an icon.
 ///     // The reversed layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection,
-///                                   label: "We live in a fabled world",
+///     OUDSCheckboxItemIndeterminate(label: "We live in a fabled world",
+///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
 ///                                   isReversed: true,
 ///                                   icon: Image(decorative: "ic_heart"))
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSCheckboxItemIndeterminate(selection: $selection,
-///                                   label: "We live in a fabled world",
+///     OUDSCheckboxItemIndeterminate(label: "We live in a fabled world",
+///                                   selection: $selection,
 ///                                   isError: true,
 ///                                   errorText: "Something wrong",
 ///                                   hasDivider: true)
 ///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Hello world")
+///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection)
 ///         .disabled(true)
 ///
 ///     // A leading checkbox with a label and and icon but with the icon flipped vertically
-///     OUDSCheckboxItemIndeterminate(isOn: $selection,
-///                                   label: "Cocorico !",
+///     OUDSCheckboxItemIndeterminate(label: "Cocorico !",
+///                                   selection: $selection,
 ///                                   icon: Image(systemName: "figure.handball"),
 ///                                   flipIcon: true)
 ///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Hello world", isError: true).disabled(true) // fatal error
-///     OUDSCheckboxItemIndeterminate(selection: $selection, label: "Hello world", isReadyOnly: true).disabled(true) // fatal error
+///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isError: true).disabled(true) // fatal error
+///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSCheckboxItemIndeterminate(isOn: $selection,
-///                                   label: "Cocorico !",
+///     OUDSCheckboxItemIndeterminate(label: "Cocorico !",
+///                                   isOn: $selection,
 ///                                   icon: Image(systemName: "figure.handball"),
 ///                                   flipIcon: layoutDirection == .rightToLeft,
 ///                                   isInversed: layoutDirection == .rightToLeft)
@@ -186,8 +186,59 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///
     /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use instead OUDSCheckboxItemIndeterminate(label:selection)")
     public init(selection: Binding<OUDSCheckboxIndicatorState>,
                 label: String,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(label: label,
+                  selection: selection,
+                  description: description,
+                  icon: icon,
+                  flipIcon: flipIcon,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a checkbox with label and optional helper text, icon, divider.
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the checkbox, must not be empty
+    ///   - selection: A binding to a property that determines wether the indicator is ticked, unticker or preticked.
+    ///   - description: A description, an additonal helper text, should not be empty
+    ///   - icon: An optional icon
+    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - isReversed: `true` of the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   The `errorText`can be different if switch is selected or not.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the checkbox has been pressed, default set to `nil`
+    ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    public init(label: String,
+                selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -168,12 +168,12 @@ public struct OUDSCheckboxItemIndeterminate: View {
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
     ///
     /// - Parameters:
-    ///   - selection: A binding to a property that determines wether the indicator is ticked, unticker or preticked.
+    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked).
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - description: A description, an additonal helper text, should not be empty
     ///   - icon: An optional icon
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - isReversed: `true` of the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.
@@ -220,11 +220,11 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///
     /// - Parameters:
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - selection: A binding to a property that determines wether the indicator is ticked, unticker or preticked.
+    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked).
     ///   - description: A description, an additonal helper text, should not be empty
     ///   - icon: An optional icon
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - isReversed: `true` of the checkbox indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -68,26 +68,26 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection)
+///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection)
 ///
 ///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isReadOnly: true)
+///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(label: "Bazinga!", selection: $selection, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
+///     OUDSCheckboxItemIndeterminate("Bazinga!", selection: $selection, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
 ///     // A trailing checkbox with a label, an helper text and an icon.
 ///     // The reversed layout will be used here.
-///     OUDSCheckboxItemIndeterminate(label: "We live in a fabled world",
+///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
 ///                                   isReversed: true,
 ///                                   icon: Image(decorative: "ic_heart"))
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSCheckboxItemIndeterminate(label: "We live in a fabled world",
+///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   isError: true,
 ///                                   errorText: "Something wrong",
@@ -95,26 +95,26 @@ import SwiftUI
 ///
 ///     // A leading checkbox with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection)
+///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection)
 ///         .disabled(true)
 ///
 ///     // A leading checkbox with a label and and icon but with the icon flipped vertically
-///     OUDSCheckboxItemIndeterminate(label: "Cocorico !",
+///     OUDSCheckboxItemIndeterminate("Cocorico !",
 ///                                   selection: $selection,
 ///                                   icon: Image(systemName: "figure.handball"),
 ///                                   flipIcon: true)
 ///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
-///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isError: true).disabled(true) // fatal error
-///     OUDSCheckboxItemIndeterminate(label: "Hello world", selection: $selection, isReadyOnly: true).disabled(true) // fatal error
+///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isError: true).disabled(true) // fatal error
+///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSCheckboxItemIndeterminate(label: "Cocorico !",
+///     OUDSCheckboxItemIndeterminate("Cocorico !",
 ///                                   isOn: $selection,
 ///                                   icon: Image(systemName: "figure.handball"),
 ///                                   flipIcon: layoutDirection == .rightToLeft,
@@ -186,7 +186,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///
     /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
-    @available(*, deprecated, message: "Use instead OUDSCheckboxItemIndeterminate(label:selection)")
+    @available(*, deprecated, message: "Use instead OUDSCheckboxItemIndeterminate(:selection:)")
     public init(selection: Binding<OUDSCheckboxIndicatorState>,
                 label: String,
                 description: String? = nil,
@@ -200,7 +200,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
-        self.init(label: label,
+        self.init(label,
                   selection: selection,
                   description: description,
                   icon: icon,
@@ -237,7 +237,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///
     /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
-    public init(label: String,
+    public init(_ label: String,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
                 icon: Image? = nil,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -170,7 +170,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     /// - Parameters:
     ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked).
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - description: A description, an additonal helper text, should not be empty
+    ///   - description: A description, an additional helper text, should not be empty
     ///   - icon: An optional icon
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
@@ -221,7 +221,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     /// - Parameters:
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked).
-    ///   - description: A description, an additonal helper text, should not be empty
+    ///   - description: A description, an additional helper text, should not be empty
     ///   - icon: An optional icon
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -192,7 +192,7 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
     ///    - text: The text to display in the root view
     ///    - type: The type of display for the root label
     private func rootItem(labeled text: String, of type: OUDSCheckboxPickerPlacement.DisplayType) -> some View {
-        OUDSCheckboxItemIndeterminate(label: rootLabel(for: text, of: type),
+        OUDSCheckboxItemIndeterminate(rootLabel(for: text, of: type),
                                       selection: $coordinator.selectionRootState,
                                       isReversed: isReversed,
                                       isError: isError,
@@ -233,7 +233,7 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
     ///    - noDivider: If true, do not add divider to the item
     /// - Returns: The view
     private func content(for checkbox: OUDSCheckboxPickerData<Tag>, noDivider: Bool) -> some View {
-        OUDSCheckboxItem(label: checkbox.label,
+        OUDSCheckboxItem(checkbox.label,
                          isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
                          description: checkbox.description,
                          icon: checkbox.icon,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -192,8 +192,8 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
     ///    - text: The text to display in the root view
     ///    - type: The type of display for the root label
     private func rootItem(labeled text: String, of type: OUDSCheckboxPickerPlacement.DisplayType) -> some View {
-        OUDSCheckboxItemIndeterminate(selection: $coordinator.selectionRootState,
-                                      label: rootLabel(for: text, of: type),
+        OUDSCheckboxItemIndeterminate(label: rootLabel(for: text, of: type),
+                                      selection: $coordinator.selectionRootState,
                                       isReversed: isReversed,
                                       isError: isError,
                                       isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -233,8 +233,8 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
     ///    - noDivider: If true, do not add divider to the item
     /// - Returns: The view
     private func content(for checkbox: OUDSCheckboxPickerData<Tag>, noDivider: Bool) -> some View {
-        OUDSCheckboxItem(isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
-                         label: checkbox.label,
+        OUDSCheckboxItem(label: checkbox.label,
+                         isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
                          description: checkbox.description,
                          icon: checkbox.icon,
                          isReversed: isReversed ? true : checkbox.isReversed,

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -177,12 +177,12 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off.
     ///   - label: The main label text of the radio, must not be empty
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: An description, like an helper text, should not be empty, default set to `nil`
+    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `True` of the radio indicator must be in trailing position,` false` otherwise. Default to `false`
-    ///   - isError: `True` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
@@ -245,12 +245,12 @@ public struct OUDSRadioItem: View {
     ///   - label: The main label text of the radio, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off.
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: An description, like an helper text, should not be empty, default set to `nil`
+    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `True` of the radio indicator must be in trailing position,` false` otherwise. Default to `false`
-    ///   - isError: `True` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -69,24 +69,24 @@ import SwiftUI
 ///
 ///     // A leading radio with a label.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds")
+///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection)
 ///
 ///     // A leading radio with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", isReadOnly: true)
+///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, isReadOnly: true)
 ///
 ///     // A leading radio with a label, and an additional label but without text.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", extraLabel: "The Beatles")
+///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles")
 ///
 ///     // A leading radio with an additional label.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Lucy in the Sky with Diamonds", extraLabel: "The Beatles", description: "1967")
+///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles", description: "1967")
 ///
 ///     // A trailing radio with a label, a description, an icon, a divider and is about an error.
 ///     // The reversed layout will be used here.
-///     OUDSRadioItem(isOn: $selection,
-///                   label: "Rescue from this world!",
+///     OUDSRadioItem(label: "Rescue from this world!",
+///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
 ///                   icon: Image(decorative: "ic_heart"),
 ///                   isReversed: true,
@@ -94,29 +94,29 @@ import SwiftUI
 ///                   hasDivider: true)
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSRadioItem(isOn: $selection,
-///                   label: "Rescue from this world!",
+///     OUDSRadioItem(label: "Rescue from this world!",
+///                   isOn: $selection,
 ///                   isError: true,
 ///                   errorText: "Something wrong",
 ///                   hasDivider: true)
 ///
 ///     // A leading radio with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(isOn: $selection, label: "Rescue from this world!")
+///     OUDSRadioItem(label: "Rescue from this world!", isOn: $selection)
 ///         .disabled(true)
 ///
 ///     // Never disable a read only or an error-related radio as it will crash
 ///     // This is forbidden by design!
-///     OUDSRadioItem(isOn: $selection, label: "Kaboom!", isError: true).disabled(true) // fatal error
-///     OUDSRadioItem(isOn: $selection, label: "Kaboom!", isReadyOnly: true).disabled(true) // fatal error
+///     OUDSRadioItem(label: "Kaboom!", isOn: $selection, isError: true).disabled(true) // fatal error
+///     OUDSRadioItem(label: "Kaboom!", isOn: $selection, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSRadioItem(isOn: $selection,
-///                   labelText: "Cocorico !",
+///     OUDSRadioItem(labelText: "Cocorico !",
+///                   isOn: $selection,
 ///                   icon: Image(systemName: "figure.handball"),
 ///                   flipIcon: layoutDirection == .rightToLeft,
 ///                   isInversed: layoutDirection == .rightToLeft)
@@ -196,8 +196,76 @@ public struct OUDSRadioItem: View {
     ///
     /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use instead OUDSRadioItem(label:isOn)")
     public init(isOn: Binding<Bool>,
                 label: String,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(label: label,
+                  isOn: isOn,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: icon,
+                  flipIcon: flipIcon,
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a radio with label and optional helper text as description, icon, divider.
+    /// Supposed to be integrated inside a ``OUDSRadioPicker``.
+    ///
+    /// ```swift
+    ///     OUDSRadioItem(label: "Virgin Holy Lava",
+    ///                   isOn: $selection,
+    ///                   extraLabel: "Very spicy",
+    ///                   description: "No alcohol, only tasty flavors",
+    ///                   icon: Image(systemName: "flame")
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the radio, must not be empty
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off.
+    ///   - extraLabel: An additional label text of the radio, default set to `nil`
+    ///   - description: An description, like an helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - isOutlined: Flag to get an outlined radio, default set to `false`
+    ///   - isReversed: `True` of the radio indicator must be in trailing position,` false` otherwise. Default to `false`
+    ///   - isError: `True` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   The `errorText`can be different if switch is selected or not.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view.
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the radio button has been pressed
+    ///
+    /// **Remark 1: As divider and outline effect are not supposed to be displayed at the same time, the divider is not displayed if the outline effect is active.**
+    ///
+    /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    public init(label: String,
+                isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,
                 icon: Image? = nil,

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -69,23 +69,23 @@ import SwiftUI
 ///
 ///     // A leading radio with a label.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection)
+///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection)
 ///
 ///     // A leading radio with a label, but in read only mode (user cannot interact yet, but not disabled).
 ///     // The default layout will be used here.
-///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, isReadOnly: true)
+///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, isReadOnly: true)
 ///
 ///     // A leading radio with a label, and an additional label but without text.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles")
+///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles")
 ///
 ///     // A leading radio with an additional label.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles", description: "1967")
+///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles", description: "1967")
 ///
 ///     // A trailing radio with a label, a description, an icon, a divider and is about an error.
 ///     // The reversed layout will be used here.
-///     OUDSRadioItem(label: "Rescue from this world!",
+///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
 ///                   icon: Image(decorative: "ic_heart"),
@@ -94,7 +94,7 @@ import SwiftUI
 ///                   hasDivider: true)
 ///
 ///     // If on error, add an error message can help user to understand error context
-///     OUDSRadioItem(label: "Rescue from this world!",
+///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   isError: true,
 ///                   errorText: "Something wrong",
@@ -102,20 +102,20 @@ import SwiftUI
 ///
 ///     // A leading radio with a label, but disabled.
 ///     // The default layout will be used here.
-///     OUDSRadioItem(label: "Rescue from this world!", isOn: $selection)
+///     OUDSRadioItem("Rescue from this world!", isOn: $selection)
 ///         .disabled(true)
 ///
 ///     // Never disable a read only or an error-related radio as it will crash
 ///     // This is forbidden by design!
-///     OUDSRadioItem(label: "Kaboom!", isOn: $selection, isError: true).disabled(true) // fatal error
-///     OUDSRadioItem(label: "Kaboom!", isOn: $selection, isReadyOnly: true).disabled(true) // fatal error
+///     OUDSRadioItem("Kaboom!", isOn: $selection, isError: true).disabled(true) // fatal error
+///     OUDSRadioItem("Kaboom!", isOn: $selection, isReadyOnly: true).disabled(true) // fatal error
 /// ```
 ///
 /// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSRadioItem(labelText: "Cocorico !",
+///     OUDSRadioItem("Cocorico !",
 ///                   isOn: $selection,
 ///                   icon: Image(systemName: "figure.handball"),
 ///                   flipIcon: layoutDirection == .rightToLeft,
@@ -196,7 +196,7 @@ public struct OUDSRadioItem: View {
     ///
     /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
-    @available(*, deprecated, message: "Use instead OUDSRadioItem(label:isOn)")
+    @available(*, deprecated, message: "Use instead OUDSRadioItem(:isOn:)")
     public init(isOn: Binding<Bool>,
                 label: String,
                 extraLabel: String? = nil,
@@ -212,7 +212,7 @@ public struct OUDSRadioItem: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
-        self.init(label: label,
+        self.init(label,
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
@@ -232,7 +232,7 @@ public struct OUDSRadioItem: View {
     /// Supposed to be integrated inside a ``OUDSRadioPicker``.
     ///
     /// ```swift
-    ///     OUDSRadioItem(label: "Virgin Holy Lava",
+    ///     OUDSRadioItem("Virgin Holy Lava",
     ///                   isOn: $selection,
     ///                   extraLabel: "Very spicy",
     ///                   description: "No alcohol, only tasty flavors",
@@ -264,7 +264,7 @@ public struct OUDSRadioItem: View {
     ///
     /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
     /// provide the localized string if key is stored in another bundle.**
-    public init(label: String,
+    public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
@@ -198,8 +198,8 @@ public struct OUDSRadioPicker<Tag>: View where Tag: Hashable {
     }
 
     private func content(for radio: OUDSRadioPickerData<Tag>, noDivider: Bool) -> some View {
-        OUDSRadioItem(isOn: selection.wrappedValue == radio.tag ? .constant(true) : .constant(false),
-                      label: radio.label,
+        OUDSRadioItem(label: radio.label,
+                      isOn: selection.wrappedValue == radio.tag ? .constant(true) : .constant(false),
                       extraLabel: radio.extraLabel,
                       description: radio.description,
                       icon: radio.icon,

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
@@ -198,7 +198,7 @@ public struct OUDSRadioPicker<Tag>: View where Tag: Hashable {
     }
 
     private func content(for radio: OUDSRadioPickerData<Tag>, noDivider: Bool) -> some View {
-        OUDSRadioItem(label: radio.label,
+        OUDSRadioItem(radio.label,
                       isOn: selection.wrappedValue == radio.tag ? .constant(true) : .constant(false),
                       extraLabel: radio.extraLabel,
                       description: radio.description,

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -161,8 +161,8 @@ public struct OUDSSwitchItem: View {
     ///   - description: An additonal helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - isReversed: `True` of the switch indicator must be in trailing position,` false` otherwise. Default to `true`
-    ///   - isError: `True` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   The `errorText`can be different if switch is selected or not.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -72,7 +72,7 @@ import SwiftUI
 ///     // The default layout will be used here.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, description: "The Beatles")
 ///
-///     // A trailing switch with a label, an additonal label, a description text and an icon.
+///     // A trailing switch with a label, an additional label, a description text and an icon.
 ///     // The inverse layout will be used here.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
@@ -158,7 +158,7 @@ public struct OUDSSwitchItem: View {
     /// - Parameters:
     ///   - label: The main label text of the switch, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off.
-    ///   - description: An additonal helper text, a description, should not be empty
+    ///   - description: An additional helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
     ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -48,7 +48,7 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
 /// `ViewModifier` to apply on a `View` so as to request the focus after a given time.
 struct RequestAccessibleFocusModifier: ViewModifier {
 
-    /// Flag to listen saying wether or not the `View` got the focus
+    /// Flag to listen saying whether or not the `View` got the focus
     @AccessibilityFocusState var requestFocus: Bool
     // NOTE: "never used" false positive with periphery (https://github.com/peripheryapp/periphery/issues/979)
 
@@ -90,7 +90,7 @@ public enum AccessibilityFocusable: Hashable {
 /// `ViewModifier` to apply on a `View` to request the focus on that `View` after a given time
 struct RestrictedRequestAccessibleFocusModifier: ViewModifier {
 
-    /// Flag to listen saying wether or not the `View` got the focus
+    /// Flag to listen saying whether or not the `View` got the focus
     @AccessibilityFocusState var requestFocus: AccessibilityFocusable?
     // NOTE: "never used" false positive with periphery (https://github.com/peripheryapp/periphery/issues/979)
 

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/TypographyModifiers/TypographyModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/TypographyModifiers/TypographyModifier.swift
@@ -43,7 +43,7 @@ struct TypographyModifier: ViewModifier {
     /// Environment variable to observe Dynamic Type changes in accessibility settings
     @Environment(\.sizeCategory) private var sizeCategory
 
-    /// Says wether or not the layout is in *compact mode*
+    /// Says whether or not the layout is in *compact mode*
     private var isCompactMode: Bool {
         horizontalSizeClass == .compact || verticalSizeClass == .compact
     }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -73,16 +73,16 @@ It can be be used for two-states (``OUDSCheckboxItem``) or three-states manageme
     @Tab("SwiftUI") {
         ```swift
         // A leading checkbox with a label, with only two states
-        OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
+        OUDSCheckboxItem("Hello world", isOn: $isOn)
 
         // A leading checkbox with a label, an helper text, and exposing a three-values-based state with selection binding
-        OUDSCheckboxItemIndeterminate(label: "Dead Robot Zombie Cop",
+        OUDSCheckboxItemIndeterminate("Dead Robot Zombie Cop",
                                       selection: $selection,
                                       description: "from Outer Space II")
 
         // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error
         // with a reversed layout, and exposing only two states through isOn binding
-        OUDSCheckboxItem(label: "We live in a fabled world",
+        OUDSCheckboxItem("We live in a fabled world",
                          isOn: $isOn,
                          description: "Of dreaming boys and wide-eyed girls",
                          icon: Image(decorative: "ic_heart"),
@@ -212,11 +212,11 @@ The indicator can be leading or trailing.
     @Tab("SwiftUI") {
         ```swift        
         // A leading radio with a label
-        OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $isOn)
+        OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $isOn)
 
         // A trailing radio with a label, an additional label, a descrption, an icon, a divider and is about an
         // error with a reversed layout
-        OUDSRadioItem(label: "Lucy in the Sky with Diamonds",
+        OUDSRadioItem("Lucy in the Sky with Diamonds",
                       isOn: $isOn,
                       extraLabel: "The Beatles"
                       description: "1967",

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -212,12 +212,12 @@ The indicator can be leading or trailing.
     @Tab("SwiftUI") {
         ```swift        
         // A leading radio with a label
-        OUDSRadioItem(isOn: $isOn, label: "Lucy in the Sky with Diamonds")
+        OUDSRadioItem(label: "Lucy in the Sky with Diamonds", isOn: $isOn)
 
         // A trailing radio with a label, an additional label, a descrption, an icon, a divider and is about an
         // error with a reversed layout
-        OUDSRadioItem(isOn: $isOn,
-                      label: "Lucy in the Sky with Diamonds",
+        OUDSRadioItem(label: "Lucy in the Sky with Diamonds",
+                      isOn: $isOn,
                       extraLabel: "The Beatles"
                       description: "1967",
                       icon: Image(decorative: "ic_heart"),

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -76,8 +76,8 @@ It can be be used for two-states (``OUDSCheckboxItem``) or three-states manageme
         OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
 
         // A leading checkbox with a label, an helper text, and exposing a three-values-based state with selection binding
-        OUDSCheckboxItemIndeterminate(selection: $selection, 
-                                      label: "Dead Robot Zombie Cop",
+        OUDSCheckboxItemIndeterminate(label: "Dead Robot Zombie Cop",
+                                      selection: $selection,
                                       description: "from Outer Space II")
 
         // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -73,7 +73,7 @@ It can be be used for two-states (``OUDSCheckboxItem``) or three-states manageme
     @Tab("SwiftUI") {
         ```swift
         // A leading checkbox with a label, with only two states
-        OUDSCheckboxItem(isOn: $isOn, label: "Hello world")
+        OUDSCheckboxItem(label: "Hello world", isOn: $isOn)
 
         // A leading checkbox with a label, an helper text, and exposing a three-values-based state with selection binding
         OUDSCheckboxItemIndeterminate(selection: $selection, 
@@ -82,8 +82,8 @@ It can be be used for two-states (``OUDSCheckboxItem``) or three-states manageme
 
         // A trailing checkbox with a label, an helper text, an icon, a divider and is about an error
         // with a reversed layout, and exposing only two states through isOn binding
-        OUDSCheckboxItem(isOn: $isOn,
-                         label: "We live in a fabled world",
+        OUDSCheckboxItem(label: "We live in a fabled world",
+                         isOn: $isOn,
                          description: "Of dreaming boys and wide-eyed girls",
                          icon: Image(decorative: "ic_heart"),
                          isReversed: true,

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -52,7 +52,7 @@ public static let bottom_3_500 = ElevationCompositeRawToken(x: x0, y: y300, blur
 
 Your application identity can be strongly based on the *typography* you use, i.e. the font family you choose and other configuration details like the font size or the font weight.
 
-With OUDS, typography depends to the class size, i.e. wether or not the application is in _compact mode_ or in _regular mode_, and is defined with a [`MultipleFontCompositeSemanticToken`](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/MultipleFontCompositeSemanticToken) defined in the [`FontSemanticTokens`](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/fontsemantictokens/).
+With OUDS, typography depends to the class size, i.e. whether or not the application is in _compact mode_ or in _regular mode_, and is defined with a [`MultipleFontCompositeSemanticToken`](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/MultipleFontCompositeSemanticToken) defined in the [`FontSemanticTokens`](https://ios.unified-design-system.orange.com/documentation/oudstokenssemantic/fontsemantictokens/).
 
 The _theme_ contains lots of `MultipleFontCompositeSemanticToken` listing all the combinations of typography you can apply, and these *composite semantic tokens* use *composite raw tokens*. For example:
 

--- a/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemCrashTests.swift
@@ -28,7 +28,7 @@ struct OUDSCheckboxItemCrashTests {
     @Test
     func checkboxItemCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
-            _ = OUDSCheckboxItem(label: "Test",
+            _ = OUDSCheckboxItem("Test",
                                  isOn: .constant(false),
                                  isError: true,
                                  isReadOnly: true)

--- a/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemCrashTests.swift
@@ -28,8 +28,8 @@ struct OUDSCheckboxItemCrashTests {
     @Test
     func checkboxItemCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
-            _ = OUDSCheckboxItem(isOn: .constant(false),
-                                 label: "Test",
+            _ = OUDSCheckboxItem(label: "Test",
+                                 isOn: .constant(false),
                                  isError: true,
                                  isReadOnly: true)
         }

--- a/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemIndeterminateCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemIndeterminateCrashTests.swift
@@ -29,8 +29,8 @@ struct OUDSCheckboxItemIndeterminateCrashTests {
     func checkboxItemIndeterminateCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
             let selection = OUDSCheckboxIndicatorState.indeterminate
-            _ = OUDSCheckboxItemIndeterminate(selection: .constant(selection),
-                                              label: "Test",
+            _ = OUDSCheckboxItemIndeterminate(label: "Test",
+                                              selection: .constant(selection),
                                               isError: true,
                                               isReadOnly: true)
         }

--- a/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemIndeterminateCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Checkbox/OUDSCheckboxItemIndeterminateCrashTests.swift
@@ -29,7 +29,7 @@ struct OUDSCheckboxItemIndeterminateCrashTests {
     func checkboxItemIndeterminateCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
             let selection = OUDSCheckboxIndicatorState.indeterminate
-            _ = OUDSCheckboxItemIndeterminate(label: "Test",
+            _ = OUDSCheckboxItemIndeterminate("Test",
                                               selection: .constant(selection),
                                               isError: true,
                                               isReadOnly: true)

--- a/OUDS/Core/Components/Tests/Controls/Radio/OUDSRadioItemCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Radio/OUDSRadioItemCrashTests.swift
@@ -28,7 +28,7 @@ struct OUDSRadioItemCrashTests {
     @Test
     func radioItemCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
-            _ = OUDSRadioItem(label: "Test",,
+            _ = OUDSRadioItem("Test",
                               isOn: .constant(false),
                               isError: true,
                               isReadOnly: true)

--- a/OUDS/Core/Components/Tests/Controls/Radio/OUDSRadioItemCrashTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/Radio/OUDSRadioItemCrashTests.swift
@@ -28,8 +28,8 @@ struct OUDSRadioItemCrashTests {
     @Test
     func radioItemCrashesWhenReadOnlyAndError() async {
         await #expect(processExitsWith: .failure) {
-            _ = OUDSRadioItem(isOn: .constant(false),
-                              label: "Test",
+            _ = OUDSRadioItem(label: "Test",,
+                              isOn: .constant(false),
                               isError: true,
                               isReadOnly: true)
         }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/GettingStarted.md
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/GettingStarted.md
@@ -13,7 +13,7 @@ How to add the package as dependency, import libraries and use theme and compone
 
 If you want to add the iOS library of *Orange Unified Design System*, you need to add our _Swift Package_ into your project.
 To do that, add a new _package dependency_ to your _Xcode_ project by refering to it by `github.com/Orange-OpenSource/ouds-ios`.
-You are free to choose wether or not you want a branch or a specific tag, pick the solution you want.
+You are free to choose whether or not you want a branch or a specific tag, pick the solution you want.
 
 You can [refer to the wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki/50-%E2%80%90-About-versions,-releases-and-builds) for more details about versions, releases and tags. You can find release tags (e.g. *1.0.0*) and release candidates tags (e.g. *1.0.0-rc3*).
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial (solution).swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial (solution).swift
@@ -91,7 +91,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial (solution).swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial (solution).swift
@@ -91,7 +91,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-3.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
                             radios: genderRadioValues(),
                             placement: .horizontal(false))
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
         }
     }
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-3.swift
@@ -25,7 +25,7 @@ struct ContentView: View {
                             radios: genderRadioValues(),
                             placement: .horizontal(false))
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
         }
     }
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-4.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
         }
     }
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-4.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
         }
     }
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-5.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-5.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
         }.preferredColorScheme(switchToDarkMode ? .dark : .light)

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-5.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-5.swift
@@ -28,7 +28,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
         }.preferredColorScheme(switchToDarkMode ? .dark : .light)

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-6.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-6.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-6.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-6.swift
@@ -30,7 +30,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-7.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-7.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-7.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-3-7.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-1.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-1.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-1.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-1.swift
@@ -37,7 +37,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-2.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-2.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-2.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-2.swift
@@ -40,7 +40,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-3.swift
@@ -51,7 +51,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-3.swift
@@ -51,7 +51,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSSwitchItem("Switch to dark mode", isOn: $switchToDarkMode)
 

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-4.swift
@@ -52,7 +52,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
 
             OUDSColoredSurface(color: theme.colorModes.onStatusInfoEmphasized) {
                 VStack(alignment: .center, spacing: theme.spaces.fixedXsmall) {

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-4-4.swift
@@ -52,7 +52,7 @@ struct ContentView: View {
 
             OUDSHorizontalDivider(color: .brandPrimary)
 
-            OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+            OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
 
             OUDSColoredSurface(color: theme.colorModes.onStatusInfoEmphasized) {
                 VStack(alignment: .center, spacing: theme.spaces.fixedXsmall) {

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-1.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-1.swift
@@ -79,7 +79,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                 }
             }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-1.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-1.swift
@@ -79,7 +79,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                 }
             }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-2.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-2.swift
@@ -64,7 +64,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-2.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-2.swift
@@ -64,7 +64,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-3.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-3.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-3.swift
@@ -65,7 +65,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-4.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-4.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-4.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-5.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-5.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-5.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-5.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-6.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-6.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-6.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-6.swift
@@ -66,7 +66,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-7.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-7.swift
@@ -69,7 +69,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(isOn: $termsAccepted, label: "I accept the terms of use")
+                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-7.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial/swift-samples/tutorial-5-7.swift
@@ -69,7 +69,7 @@ struct ContentView: View {
 
                         OUDSHorizontalDivider(color: .brandPrimary)
 
-                        OUDSCheckboxItem(label: "I accept the terms of use", isOn: $termsAccepted)
+                        OUDSCheckboxItem("I accept the terms of use", isOn: $termsAccepted)
                     }
                     .padding(.horizontal, theme.spaces.fixedSmall)
                 }

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorModeSemanticToken.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorModeSemanticToken.swift
@@ -66,7 +66,7 @@ public final class MultipleColorModeSemanticToken: NSObject, Sendable {
     /// Initializes a new color mode color multiple semantic token with the same value for light and dark modes
     /// - Parameters:
     ///    - name: A unique name for the token
-    ///    - value: The `ColorModeSemanticToken` to apply wether the device is in *light* and *dark* mode
+    ///    - value: The `ColorModeSemanticToken` to apply whether the device is in *light* and *dark* mode
     public init(_ name: String, _ value: ColorModeSemanticToken) {
         self.name = name
         light = value

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorSemanticToken.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleColorSemanticToken.swift
@@ -71,7 +71,7 @@ public final class MultipleColorSemanticToken: NSObject, Sendable {
     public let dark: ColorSemanticToken
 
     /// Initializes a new color multiple semantic token with the same value for light and dark modes
-    /// - Parameter value: The `ColorSemanticToken` to apply wether the device is in *light* and *dark* mode
+    /// - Parameter value: The `ColorSemanticToken` to apply whether the device is in *light* and *dark* mode
     public init(_ value: ColorSemanticToken) {
         light = value
         dark = value

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawToken.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Multiples/MultipleElevationCompositeRawToken.swift
@@ -75,7 +75,7 @@ public final class MultipleElevationCompositeRawToken: NSObject, Sendable {
     public let dark: ElevationCompositeRawToken
 
     /// Initializes a new elevation composite raw token with the same value for light and dark modes
-    /// - Parameter value: The `ElevationCompositeRawToken` to apply wether the device is in *light* and *dark* mode
+    /// - Parameter value: The `ElevationCompositeRawToken` to apply whether the device is in *light* and *dark* mode
     public init(_ value: ElevationCompositeRawToken) {
         light = value
         dark = value

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/FontMultipleSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/FontMultipleSemanticTokens.swift
@@ -22,7 +22,7 @@
 /// ``MultipleFontLineHeightSemanticToken`` for *line heights* and ``MultipleFontSizeSemanticToken`` for *font sizes*.
 ///
 /// In fact these ``MultipleFontLetterSpacingSemanticToken``, ``MultipleFontLineHeightSemanticToken`` and  ``MultipleFontSizeSemanticToken`` classes will help users
-/// (i.e. developers) to handle one semantic token for font things depending to size class (wether it could be compact / mobile or regular / tablet).
+/// (i.e. developers) to handle one semantic token for font things depending to size class (whether it could be compact / mobile or regular / tablet).
 /// Because *Figma* is not able to manage pair of values for one token, and its produced JSON does not reflect this mecanism, the *tokenator* cannot provide
 /// such ``MultipleFontLetterSpacingSemanticToken``, ``MultipleFontLineHeightSemanticToken`` and ``MultipleFontSizeSemanticToken`` tokens.
 /// Thus the "real" letter spacing, line height and font size tokens are declared in ``FontSemanticTokens`` protocol and defined inside `OUDSTheme` (to be overridable then by subthemes).

--- a/OUDS/Foundations/Sources/OUDSWCAG21Ratio.swift
+++ b/OUDS/Foundations/Sources/OUDSWCAG21Ratio.swift
@@ -27,7 +27,7 @@ public typealias WCAG21Requirements = (textual: Bool, nonTextual: Bool)
 /// The WCAG specifications, for AA level, defines a contrast ratio of 4.5:1 for textual elements (i.e. texts), and 3:1 for non-textual elements (i.e. link's chevron).
 /// However it is higly recommended for mobile devices to reach AAA level because of the screen sizes and luminosity issues, i.e. 7:1 for textual
 /// and 4.5:1 for non-textual elements.
-/// This utility helps to define wether a set of contrast ratio matches AA and AAA or not.
+/// This utility helps to define whether a set of contrast ratio matches AA and AAA or not.
 /// See for example [the following guidelines](https://system.design.orange.com/0c1af118d/p/2531b9-accessibility-compliance)
 ///
 /// - Since: 0.15.0

--- a/OUDS/Foundations/Tests/OUDSWCAG21RatiosTests.swift
+++ b/OUDS/Foundations/Tests/OUDSWCAG21RatiosTests.swift
@@ -22,7 +22,7 @@ import Testing
 /// Struct to test `OUDSWCAG21Ratio`.
 /// Use cases picked from issue [#647](https://github.com/Orange-OpenSource/ouds-ios/issues/647)
 /// based on Orange Theme v0.14.0 and tokens lib v0.11.0
-/// The aim is to be sure the utils are able to computed the suitable ratios and define wether or not WCAG 2.1 are respected.
+/// The aim is to be sure the utils are able to computed the suitable ratios and define whether or not WCAG 2.1 are respected.
 struct OUDSWCAG21RatioTests {
 
     // See https://github.com/Orange-OpenSource/ouds-ios/issues/667


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1314

### Description

<!-- Describe your changes in detail -->
Deprecate old signatures and add newer ones

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve developer experienc eand be consistant between API

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->
- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
