### PR TITLE
[#1317] Add an helper on view to apply grid margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+– helper to apply grid margin (Orange-OpenSource/ouds-ios#1317)
 - `inline alert` component (Orange-OpenSource/ouds-ios#1307)
 - `alert message` component (Orange-OpenSource/ouds-ios#1159)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-– helper to apply grid margin (Orange-OpenSource/ouds-ios#1317)
+- Helper to apply grid margin on views (Orange-OpenSource/ouds-ios#1317)
 - `inline alert` component (Orange-OpenSource/ouds-ios#1307)
 - `alert message` component (Orange-OpenSource/ouds-ios#1159)
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,8 +1,43 @@
 # Migration Guide
 
+- [v1.2.0 → v1.3.0](#v120--v130)
 - [v1.1.0 → v1.2.0](#v110--v120)
 - [v1.0.0 → v1.1.0](#v100--v110)
 - [Support](#support)
+
+## v1.2.0 → v1.3.0
+
+### Overview
+
+The design team confirms that any logic related to grids, gutters and spacings are related to the horizontal size class.
+Thus existence of `oudsVerticalSizeClass`, used nowhere, is a non-sense; this property has been removed.
+
+### Before You Begin
+
+#### Prerequisites
+
+- Use version 1.x
+
+### Breaking Changes
+
+#### 1. Removal of `oudsVerticalSizeClass`
+
+**Impact**: Low
+
+**Before (v1.x)**:
+```swift
+@Environment(\.oudsVerticalSizeClass) var sizeClass // Or any other name for property
+```
+
+**After (v1.3.0)**:
+```swift
+// Property removed
+```
+
+**Required Action**:
+- Remove us of `oudsVerticalSizeClass` environment object
+
+**Reason for Change**: Not used, not relevant, must not be considered even if design side
 
 ## v1.1.0 → v1.2.0
 

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/Internal/CheckboxIndicator.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/Internal/CheckboxIndicator.swift
@@ -56,6 +56,7 @@ struct CheckboxIndicator: View {
     private func tickImage(name: String) -> some View {
         Image(decorative: name, bundle: theme.resourcesBundle)
             .resizable()
+            .renderingMode(.template)
             .scaledToFit()
             .accessibilityHidden(true)
             .oudsForegroundColor(appliedColor)

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
@@ -94,7 +94,7 @@ import SwiftUI
 ///
 /// - Since: 0.17.0
 @available(iOS 15, macOS 13, visionOS 1, *)
-public struct OUDSChipPicker<Tag>: View where Tag: Hashable {
+public struct OUDSChipPicker<Tag: Hashable>: View {
 
     /// The title of the picker
     let title: String?
@@ -132,7 +132,7 @@ public struct OUDSChipPicker<Tag>: View where Tag: Hashable {
     ///    - title: The title of the picker, can be nil
     ///    - selection: The current selected value
     ///    - chips: The raw data to wrap in ``OUDSFilterChip`` for display
-    ///    - itemsSpacing: The custom spacing to apply between utems, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
+    ///    - itemsSpacing: The custom spacing to apply between items, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
     public init(title: String? = nil, selection: Binding<Tag?>, chips: [OUDSChipPickerData<Tag>], itemsSpacing: SpaceSemanticToken? = nil) {
         if let title, title.isEmpty {
             OL.warning("The title of the OUDSChipPicker is empty, prefer nil instead")
@@ -150,7 +150,7 @@ public struct OUDSChipPicker<Tag>: View where Tag: Hashable {
     ///    - title: The title of the picker, can be nil
     ///    - selection: The current selected value
     ///    - chips: The raw data to wrap in ``OUDSFilterChip`` for display
-    ///    - itemsSpacing: The custom spacing to apply between utems, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
+    ///    - itemsSpacing: The custom spacing to apply between items, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
     public init(title: String? = nil, selection: Binding<Tag>, chips: [OUDSChipPickerData<Tag>], itemsSpacing: SpaceSemanticToken? = nil) {
         if let title, title.isEmpty {
             OL.warning("The title of the OUDSChipPicker is empty, prefer nil instead")
@@ -168,7 +168,7 @@ public struct OUDSChipPicker<Tag>: View where Tag: Hashable {
     ///    - title: The title of the picker, can be nil
     ///    - selections: Current selected values
     ///    - chips: The raw data to wrap in ``OUDSFilterChip`` for display
-    ///    - itemsSpacing: The custom spacing to apply between utems, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
+    ///    - itemsSpacing: The custom spacing to apply between items, default set to *nl*. If *nil* token *theme.spaces.fixedNone* will be used.
     public init(title: String? = nil, selections: Binding<[Tag]>, chips: [OUDSChipPickerData<Tag>], itemsSpacing: SpaceSemanticToken? = nil) {
         if let title, title.isEmpty {
             OL.warning("The title of the OUDSChipPicker is empty, prefer nil instead")

--- a/OUDS/Core/Components/Sources/_/Extensions/View+Grids.swift
+++ b/OUDS/Core/Components/Sources/_/Extensions/View+Grids.swift
@@ -14,21 +14,17 @@
 import OUDSThemesContract
 import SwiftUI
 
-// MARK: - View extensions for grid
-
 extension View {
 
     /// Adds a margin amount to specific edges of this view.
+    /// Indicate the edges to margin by naming either a single value from `Edge/Set`,
+    /// or by specifying an `OptionSet`.
     ///
-    /// ```
-    ///   // Indicate the edges to magin by naming either a single value from ``Edge/Set``, or by
-    ///   // specifying an <doc://com.apple.documentation/documentation/Swift/OptionSet>
-    ///
+    /// ```swift
     ///   MyView().oudsGridMargin(.horizontal)
-    ///  ```
+    /// ```
     ///
-    /// - Parameter edges: The set of edges to add margin for this view. The default is `Edge/Set/all`.
-    ///
+    /// - Parameter edges: The set of edges to add margin for this view (default is  `.all`).
     /// - Returns: A view that's margin are added by the specified amount on the specified edges.
     public func oudsGridMargin(_ edges: Edge.Set = .all) -> some View {
         modifier(GridMarginModifier(edges: edges))

--- a/OUDS/Core/Components/Sources/_/Extensions/view+Grid.swift
+++ b/OUDS/Core/Components/Sources/_/Extensions/view+Grid.swift
@@ -27,7 +27,7 @@ extension View {
     ///   MyView().oudsGridMargin(.horizontal)
     ///  ```
     ///
-    /// - Parameter edges: The set of edges to add margin for this view. The default is ``Edge/Set/all``.
+    /// - Parameter edges: The set of edges to add margin for this view. The default is `Edge/Set/all`.
     ///
     /// - Returns: A view that's margin are added by the specified amount on the specified edges.
     public func oudsGridMargin(_ edges: Edge.Set = .all) -> some View {

--- a/OUDS/Core/Components/Sources/_/Extensions/view+Grid.swift
+++ b/OUDS/Core/Components/Sources/_/Extensions/view+Grid.swift
@@ -1,0 +1,36 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+// MARK: - View extensions for grid
+
+extension View {
+
+    /// Adds a margin amount to specific edges of this view.
+    ///
+    /// ```
+    ///   // Indicate the edges to magin by naming either a single value from ``Edge/Set``, or by
+    ///   // specifying an <doc://com.apple.documentation/documentation/Swift/OptionSet>
+    ///
+    ///   MyView().oudsGridMargin(.horizontal)
+    ///  ```
+    ///
+    /// - Parameter edges: The set of edges to add margin for this view. The default is ``Edge/Set/all``.
+    ///
+    /// - Returns: A view that's margin are added by the specified amount on the specified edges.
+    public func oudsGridMargin(_ edges: Edge.Set = .all) -> some View {
+        modifier(GridMarginModifier(edges: edges))
+    }
+}

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/GridModifier/GridMarginModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/GridModifier/GridMarginModifier.swift
@@ -1,0 +1,32 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSThemesContract
+import SwiftUI
+
+/// Adds a margin amount to specific edges of this view.
+///
+/// The equal margin is applied horizontally and verticaly based only on the horizontal size class.
+/// It is based on the margin token from the theme in environement.
+///
+struct GridMarginModifier: ViewModifier {
+
+    let edges: Edge.Set
+
+    @Environment(\.theme) private var theme
+    @Environment(\.oudsHorizontalSizeClass) private var oudsHorizontalSizeClass
+
+    func body(content: Content) -> some View {
+        content.padding(edges, theme.gridMargin(for: oudsHorizontalSizeClass))
+    }
+}

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/GridModifier/GridMarginModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/GridModifier/GridMarginModifier.swift
@@ -14,11 +14,7 @@
 import OUDSThemesContract
 import SwiftUI
 
-/// Adds a margin amount to specific edges of this view.
-///
-/// The equal margin is applied horizontally and verticaly based only on the horizontal size class.
-/// It is based on the margin token from the theme in environement.
-///
+/// `ViewModifier` to use to define pading to given `edges` using the OUDS current horizontal size class
 struct GridMarginModifier: ViewModifier {
 
     let edges: Edge.Set

--- a/OUDS/Core/ThemesContract/Sources/OUDSTheme/Helpers/OUDSTheme+GridSemanticTokensHelper.swift
+++ b/OUDS/Core/ThemesContract/Sources/OUDSTheme/Helpers/OUDSTheme+GridSemanticTokensHelper.swift
@@ -26,7 +26,6 @@ extension OUDSTheme {
     ///
     ///         @Environment(\.theme) var theme
     ///         @Environment(\.oudsHorizontalSizeClass) var sizeClass
-    ///         // Or also @Environment(\.oudsVerticalSizeClass) var sizeClass
     ///
     ///         func someFunc() -> GridRawToken {
     ///             theme.gridMinWidth(for: sizeClass)
@@ -56,7 +55,6 @@ extension OUDSTheme {
     ///
     ///         @Environment(\.theme) var theme
     ///         @Environment(\.oudsHorizontalSizeClass) var sizeClass
-    ///         // Or also @Environment(\.oudsVerticalSizeClass) var sizeClass
     ///
     ///         func someFunc() -> GridRawToken {
     ///             theme.gridMaxWidth(for: sizeClass)
@@ -86,7 +84,6 @@ extension OUDSTheme {
     ///
     ///         @Environment(\.theme) var theme
     ///         @Environment(\.oudsHorizontalSizeClass) var sizeClass
-    ///         // Or also @Environment(\.oudsVerticalSizeClass) var sizeClass
     ///
     ///         func someFunc() -> GridRawToken {
     ///             theme.gridMargin(for: sizeClass)
@@ -116,7 +113,6 @@ extension OUDSTheme {
     ///
     ///         @Environment(\.theme) var theme
     ///         @Environment(\.oudsHorizontalSizeClass) var sizeClass
-    ///         // Or also @Environment(\.oudsVerticalSizeClass) var sizeClass
     ///
     ///         func someFunc() -> GridRawToken {
     ///             theme.gridColumnGap(for: sizeClass)

--- a/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
+++ b/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
@@ -19,14 +19,16 @@ import SwiftUI
 import UIKit
 #endif
 
+// MARK: - Environment Values
+
 extension EnvironmentValues {
 
-    // The `OUDSTheme` instance exposed as en environment values across the library.
-    // Because at the level of the package we don't have any existing theme, this instance is optional
+    /// The `OUDSTheme` instance exposed as en environment values across the library.
+    /// Because at the level of the package we don't have any existing theme, this instance is optional
     @Entry public var _theme: OUDSTheme?
 
     // swiftlint:disable force_unwrapping
-    /// The `OUDSTheme` applied to the application
+    /// The `OUDSTheme` applied to the application, must be defined otherwise **crash will occur**.
     public var theme: OUDSTheme {
         _theme!
     }

--- a/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
+++ b/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
@@ -19,26 +19,11 @@ import SwiftUI
 import UIKit
 #endif
 
-// MARK: - Environment values
-
-private struct ThemeEnvironmentKey: EnvironmentKey {
-
-    /// ``OUDSTheme`` is kind of abstract, no instance can be done because of providers to define at theme levels
-    static let defaultValue: OUDSTheme? = nil
-}
-
 extension EnvironmentValues {
 
-    /// The `OUDSTheme` instance exposed as en environment values across the library.
-    /// Because at the level of the package we don't have any existing theme, this instance is optional
-    public var _theme: OUDSTheme? {
-        get {
-            self[ThemeEnvironmentKey.self]
-        }
-        set {
-            self[ThemeEnvironmentKey.self] = newValue
-        }
-    }
+    // The `OUDSTheme` instance exposed as en environment values across the library.
+    // Because at the level of the package we don't have any existing theme, this instance is optional
+    @Entry public var _theme: OUDSTheme?
 
     // swiftlint:disable force_unwrapping
     /// The `OUDSTheme` applied to the application
@@ -69,7 +54,7 @@ extension EnvironmentValues {
 /// ```
 ///
 /// - Since: 0.8.0
-public struct OUDSThemeableView<Content>: View where Content: View {
+public struct OUDSThemeableView<Content: View>: View {
 
     private let theme: OUDSTheme
     private let content: () -> Content
@@ -98,7 +83,6 @@ public struct OUDSThemeableView<Content>: View where Content: View {
 private struct UserInterfaceSizeClassModifier: ViewModifier {
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     /// According to Apple guidelines, this value of 390 is the limit defining extract compact size classes if lower and compact if higher or equal
     private static let extraCompactMaxWidth = 390.0
@@ -115,22 +99,9 @@ private struct UserInterfaceSizeClassModifier: ViewModifier {
         #endif
     }
 
-    private var verticalUserInterfaceSizeClass: OUDSUserInterfaceSizeClass {
-        #if os(iOS)
-        if UIScreen.main.bounds.width < Self.extraCompactMaxWidth {
-            .extraCompact
-        } else {
-            verticalSizeClass == .compact ? .compact : .regular
-        }
-        #else
-        verticalSizeClass == .compact ? .compact : .regular
-        #endif
-    }
-
     func body(content: Content) -> some View {
         content
             .environment(\.oudsHorizontalSizeClass, horizontalUserInterfaceSizeClass)
-            .environment(\.oudsVerticalSizeClass, verticalUserInterfaceSizeClass)
     }
 }
 #endif

--- a/OUDS/Foundations/Sources/OUDSUserInterfaceSizeClass.swift
+++ b/OUDS/Foundations/Sources/OUDSUserInterfaceSizeClass.swift
@@ -19,19 +19,9 @@ import UIKit
 
 // MARK: - Environment values
 
-private struct HorizontalSizeClassEnvironmentKey: EnvironmentKey {
-
-    static let defaultValue = OUDSUserInterfaceSizeClass.regular
-}
-
-private struct VerticalSizeClassEnvironmentKey: EnvironmentKey {
-
-    static let defaultValue = OUDSUserInterfaceSizeClass.regular
-}
-
 extension EnvironmentValues {
 
-    /// The `OUDSUserInterfaceSizeClass` instance exposed as en environment values across the library for the horizontal viewport.
+    /// The `oudsHorizontalSizeClass` instance exposed as en environment values across the library for the horizontal viewport.
     ///
     /// You receive a ``OUDSUserInterfaceSizeClass`` value when you read this environment value.
     /// The value tells you about the amount of horizontal space available to the view that reads it.
@@ -39,31 +29,7 @@ extension EnvironmentValues {
     ///
     ///     @Environment(\.oudsHorizontalSizeClass) private var horizontalSizeClass
     ///
-    public var oudsHorizontalSizeClass: OUDSUserInterfaceSizeClass {
-        get {
-            self[HorizontalSizeClassEnvironmentKey.self]
-        }
-        set {
-            self[HorizontalSizeClassEnvironmentKey.self] = newValue
-        }
-    }
-
-    /// The `OUDSUserInterfaceSizeClass` instance exposed as en environment values across the library for the vertical viewport.
-    ///
-    /// You receive a ``OUDSUserInterfaceSizeClass`` value when you read this environment value.
-    /// The value tells you about the amount of vertical space available to the view that reads it.
-    /// You can read this size class like any other of the ``EnvironmentValues``, by creating a property with the `Environment` property wrapper:
-    ///
-    ///     @Environment(\.oudsVerticalSizeClass) private var verticalSizeClass
-    ///
-    public var oudsVerticalSizeClass: OUDSUserInterfaceSizeClass {
-        get {
-            self[VerticalSizeClassEnvironmentKey.self]
-        }
-        set {
-            self[VerticalSizeClassEnvironmentKey.self] = newValue
-        }
-    }
+    @Entry public var oudsHorizontalSizeClass: OUDSUserInterfaceSizeClass = .regular
 }
 
 /// Enumerates the size classes defined by the design system.
@@ -76,7 +42,6 @@ extension EnvironmentValues {
 /// To use it:
 /// ```swift
 ///     @Environment(\.oudsHorizontalSizeClass) var horizontalSizeClass
-///     @Environment(\.oudsVerticalSizeClass) var verticalSizeClass
 /// ```
 ///
 /// - Since: 0.8.0


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1317

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
