### PR TITLE
[#1326] Update Bullet list API to rename unordered icon to asset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename in `bullet list` component API "unordered icon" to "unordered asset" (Orange-OpenSource/ouds-ios#1326)
 - AGENTS.md file to focus only on users (Orange-OpenSource/ouds-ios#1341)
-- Update Bullet list API to rename unordered icon to asset (Orange-OpenSource/ouds-ios#1326)
 - Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - AGENTS.md file to focus only on users (Orange-OpenSource/ouds-ios#1341)
+- Update Bullet list API to rename unordered icon to asset (Orange-OpenSource/ouds-ios#1326)
 - Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)
 
 ### Fixed

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -16,7 +16,7 @@ Thus existence of `oudsVerticalSizeClass`, used nowhere, is a non-sense; this pr
 
 #### Prerequisites
 
-- Use version 1.x
+- Use version 1.2 or older
 
 ### Breaking Changes
 
@@ -38,6 +38,30 @@ Thus existence of `oudsVerticalSizeClass`, used nowhere, is a non-sense; this pr
 - Remove us of `oudsVerticalSizeClass` environment object
 
 **Reason for Change**: Not used, not relevant, must not be considered even if design side
+
+#### 2. Rename of OUDSBulletList.UnorderedIcon` to `OUDSBulletList.UnorderedAsset`
+
+**Impact**: Low
+
+**Before (v1.x)**:
+```swift
+var someIconForBulletList: OUDSBulletList.UnorderedIcon {
+    .free(someImage)
+}
+```
+
+**After (v1.3.0)**:
+```swift
+var someIconForBulletList: OUDSBulletList.UnorderedAsset {
+    .icon(someImage)
+}
+```
+
+**Required Action**:
+- Rename any use of `OUDSBulletList.UnorderedIcon` to `OUDSBulletList.UnorderedAsset`
+- Case `.free` must be replaced by `.icon`
+
+**Reason for Change**: "asset" word has a better meaning than "icon", and is aligned with Android OUDS library API
 
 ## v1.1.0 → v1.2.0
 

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
@@ -37,8 +37,8 @@ struct Bullet: View {
     var body: some View {
         HStack(alignment: .center) {
             switch type {
-            case let .unordered(icon, isBranded):
-                UnorderedBullet(icon: icon, isBranded: isBranded, level: level, textStyle: textStyle)
+            case let .unordered(asset, isBranded):
+                UnorderedBullet(asset: asset, isBranded: isBranded, level: level, textStyle: textStyle)
             case .ordered:
                 OrderedBullet(level: level, textStyle: textStyle, isBold: isBold, index: index)
             case .bare:
@@ -84,7 +84,7 @@ struct UnorderedBullet: View {
 
     // MARK: Properties
 
-    let icon: OUDSBulletList.UnorderedIcon
+    let asset: OUDSBulletList.UnorderedAsset
     let isBranded: Bool
     let level: OUDSBulletList.NestedLevel
     let textStyle: OUDSBulletList.TextStyle
@@ -95,19 +95,21 @@ struct UnorderedBullet: View {
     // MARK: Body
 
     var body: some View {
-        ScaledIcon(icon: asset.renderingMode(.template), size: assetSize)
+        ScaledIcon(icon: image.renderingMode(.template), size: assetSize)
             .oudsForegroundColor(color)
     }
 
     // MARK: Private helpers
 
-    private var asset: Image {
-        switch icon {
+    private var image: Image {
+        switch asset {
         case .bullet:
             Image(decorative: bulletAssetName, bundle: theme.resourcesBundle)
         case .tick:
             Image(decorative: "ic_bullet_list_tick", bundle: theme.resourcesBundle)
         case let .free(image, _):
+            image
+        case let .icon(image, _):
             image
         }
     }

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
@@ -69,8 +69,8 @@ import SwiftUI
 ///        // 1.1. Item of Unordered list with bullet as tick, a text style
 ///        // body medium and text bold
 ///        OUDSBulletList(type: .unordered(asset: .tick),
-///                    textStyle: .bodyMedium,
-///                    isBold: true)  {
+///                       textStyle: .bodyMedium,
+///                       isBold: true)  {
 ///            OUDSBulletList.Item("Label 1")
 ///            OUDSBulletList.Item("Label 2")
 ///            OUDSBulletList.Item("Label 3")
@@ -200,6 +200,10 @@ public struct OUDSBulletList: View {
     // swiftlint:enable discouraged_optional_boolean
 
     // MARK: - Unordered Icon
+
+    /// Old name of `OUDSBulletList.UnorderedAsset`
+    @available(*, deprecated, message: "Use instead OUDSBulletList.UnorderedAsset")
+    public typealias UnorderedIcon = UnorderedAsset
 
     /// The type of asset in the unordered list
     /// - Since: 1.2.0

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
@@ -68,7 +68,7 @@ import SwiftUI
 ///
 ///        // 1.1. Item of Unordered list with bullet as tick, a text style
 ///        // body medium and text bold
-///        OUDSBulletList(type: .unordered(icon: .tick),
+///        OUDSBulletList(type: .unordered(asset: .tick),
 ///                    textStyle: .bodyMedium,
 ///                    isBold: true)  {
 ///            OUDSBulletList.Item("Label 1")
@@ -105,10 +105,10 @@ import SwiftUI
 ///        }
 ///
 ///        // Same Bullet list but items in third level with free icon as bullet
-///        let freeIcon = Image(decorative: "ic_heart")
+///        let icon = Image(decorative: "ic_heart")
 ///        OUDSBulletList(type: .ordered) {
 ///            OUDSBulletList.Item("Label 1") {
-///                OUDSBulletList.Item("Label 1.1", subListType: .unordered(icon: .free(freeIcon))) {
+///                OUDSBulletList.Item("Label 1.1", subListType: .unordered(asset: .icon(icon))) {
 ///                    OUDSBulletList.Item("Label 1.1.1")
 ///                    OUDSBulletList.Item("Label 1.1.2")
 ///                }
@@ -201,9 +201,9 @@ public struct OUDSBulletList: View {
 
     // MARK: - Unordered Icon
 
-    /// The type of icon in the unordered list
+    /// The type of asset in the unordered list
     /// - Since: 1.2.0
-    public enum UnorderedIcon {
+    public enum UnorderedAsset {
         /// A bullet for unordered bullet list
         case bullet
 
@@ -215,7 +215,15 @@ public struct OUDSBulletList: View {
         ///  - Parameters:
         ///     - image: The asset image as bullet
         ///     - accessibilityLabel: An optional label for accessibility description if asset is not decorative.
+        @available(*, deprecated, message: "Use instead .icon(:accessibilityLabel:)")
         case free(_ image: Image, accessibilityLabel: String? = nil)
+
+        /// A free icon as bullet
+        ///
+        ///  - Parameters:
+        ///     - image: The asset image as bullet
+        ///     - accessibilityLabel: An optional label for accessibility description if asset is not decorative.
+        case icon(_ image: Image, accessibilityLabel: String? = nil)
     }
 
     // MARK: - Type
@@ -227,9 +235,9 @@ public struct OUDSBulletList: View {
         /// List items are typically marked with bullets, but it is also possible to use a tick or any Solaris icon.
         ///
         ///  - Parameters:
-        ///     - icon: The type of icon the unordered item should be used, Bullet as default and branded
+        ///     - asset: The type of icon the unordered item should be used, Bullet as default and branded
         ///     - isBranded: Flag used to display icon tinted with brand color. false by default
-        case unordered(icon: UnorderedIcon = .bullet, isBranded: Bool = true)
+        case unordered(asset: UnorderedAsset = .bullet, isBranded: Bool = true)
 
         /// Collects related items with numeric order or sequence. Numbering starts at 1 with the first list item and increases
         /// by increments of 1 for each successive ordered list item.
@@ -274,11 +282,11 @@ public struct OUDSBulletList: View {
     ///
     /// - Parameters:
     ///    - type: The visual type of the list (e.g., `ordered`, `unordered` or `bare`).
-    ///     See `OUDSBulletList.Type`, default `.unordered(icon: .bullet, isBranded: false)`
+    ///     See `OUDSBulletList.Type`, default `.unordered(asset: .bullet, isBranded: false)`
     ///    - textStyle: The typography style for the list items. See `OUDSBulletList.TextStyle`, defaults `.bodyLarge`
     ///    - isBold: Whether the list item text should be bold. This can be overridden for sub-lists. Defaults to `true`
     ///    - items: Defines the list items
-    public init(type: Self.`Type` = .unordered(icon: .bullet, isBranded: false),
+    public init(type: Self.`Type` = .unordered(asset: .bullet, isBranded: false),
                 textStyle: Self.TextStyle = .bodyLarge,
                 isBold: Bool = true,
                 @OUDSBulletListItemBuilder items: () -> [OUDSBulletList.Item])

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/ContentDisplay.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/ContentDisplay.md
@@ -40,7 +40,7 @@ OUDSBulletList(type: .bare) {
 
 // Item of Unordered list with bullet as tick, a text style
 // body medium and text bold
-OUDSBulletList(type: .unordered(icon: .tick),
+OUDSBulletList(type: .unordered(asset: .tick),
               textStyle: .bodyMedium,
               isBold: true)  {
     OUDSBulletList.Item("Label 1")


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1326

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
