### PR TITLE
[#1342] Change colors of texts and bullets for `alert message` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `alert message` component with new label colors (Orange-OpenSource/ouds-ios#1342)
 - Rename in `bullet list` component API "unordered icon" to "unordered asset" (Orange-OpenSource/ouds-ios#1326)
 - AGENTS.md file to focus only on users (Orange-OpenSource/ouds-ios#1341)
 - Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
@@ -19,6 +19,7 @@ struct AlertMessageBulletListItem: View {
     // MARK: - Properties
 
     let text: String
+    let status: OUDSAlertStatus
 
     @Environment(\.theme) private var theme
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
@@ -38,10 +39,12 @@ struct AlertMessageBulletListItem: View {
 
             Text(text)
                 .labelDefaultMedium(theme)
-                .oudsForegroundColor(theme.colors.contentMuted)
+                .oudsForegroundColor(foregroundColor)
                 .frame(maxWidth: theme.sizes.maxWidthTypeLabelMedium.dimension(for: horizontalSizeClass ?? .regular), alignment: .leading)
         }
     }
+
+    // MARK: - Helpers
 
     private var iconSize: CGFloat {
         let rawSize = theme.sizes.iconWithLabelMediumSizeSmall
@@ -56,5 +59,22 @@ struct AlertMessageBulletListItem: View {
     private var maxHeight: CGFloat {
         let rawSize = theme.fonts.lineHeightBodyMedium.lineHeight(for: verticalSizeClass ?? .regular)
         return rawSize * dynamicTypeSize.percentageRate / 100
+    }
+
+    private var foregroundColor: MultipleColorSemanticToken {
+        switch status {
+        case .neutral:
+            theme.colors.contentDefault
+        case .accent:
+            theme.colors.contentOnStatusAccentMuted
+        case .positive:
+            theme.colors.contentOnStatusPositiveMuted
+        case .negative:
+            theme.colors.contentOnStatusNegativeMuted
+        case .warning:
+            theme.colors.contentOnStatusWarningMuted
+        case .info:
+            theme.colors.contentOnStatusInfoMuted
+        }
     }
 }

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
@@ -31,7 +31,7 @@ struct AlertMessageBulletListItem: View {
     var body: some View {
         HStack(alignment: .top, spacing: theme.bulletList.spaceColumnGapBodyMedium) {
             HStack(alignment: .center) {
-                OUDSIcon(assetName: "ic_bullet_list_level0", color: theme.colors.contentMuted)
+                OUDSIcon(assetName: "ic_bullet_list_level0", color: foregroundColor)
                     .frame(width: iconSize, height: iconSize)
             }
             .frame(width: width, alignment: .trailing)

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
@@ -19,6 +19,7 @@ struct AlertMessageContent: View {
     // MARK: - Properties
 
     let text: String
+    let status: OUDSAlertStatus
     let description: String?
     let bulletList: [String]
     let link: OUDSAlertMessage.Link?
@@ -32,20 +33,20 @@ struct AlertMessageContent: View {
             VStack(alignment: .leading, spacing: theme.alert.spaceRowGap) {
                 Text(text)
                     .labelModerateLarge(theme)
-                    .oudsForegroundColor(theme.colors.contentDefault)
+                    .oudsForegroundColor(foregroundColor)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if let description, !description.isEmpty {
                     Text(description)
                         .labelDefaultMedium(theme)
-                        .oudsForegroundColor(theme.colors.contentMuted)
+                        .oudsForegroundColor(foregroundColor)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
 
                 if !bulletList.isEmpty {
                     VStack(alignment: .leading, spacing: theme.alert.spaceRowGapBullet) {
                         ForEach(Array(bulletList.enumerated()), id: \.offset) { _, text in
-                            AlertMessageBulletListItem(text: text)
+                            AlertMessageBulletListItem(text: text, status: status)
                         }
                     }
                 }
@@ -58,5 +59,24 @@ struct AlertMessageContent: View {
         }
         .padding(.vertical, theme.alert.spacePaddingBlock)
         .fixedSize(horizontal: false, vertical: true)
+    }
+
+    // MARK: - Helpers
+
+    private var foregroundColor: MultipleColorSemanticToken {
+        switch status {
+        case .neutral:
+            theme.colors.contentDefault
+        case .accent:
+            theme.colors.contentOnStatusAccentMuted
+        case .positive:
+            theme.colors.contentOnStatusPositiveMuted
+        case .negative:
+            theme.colors.contentOnStatusNegativeMuted
+        case .warning:
+            theme.colors.contentOnStatusWarningMuted
+        case .info:
+            theme.colors.contentOnStatusInfoMuted
+        }
     }
 }

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
@@ -65,7 +65,7 @@ import SwiftUI
 ///
 /// ![An alert message component in light and dark modes with Wireframe theme](component_alertMessage_Wireframe)
 ///
-/// - Version: 1.0.0 (Figma component design version)
+/// - Version: 1.1.0 (Figma component design version)
 /// - Since: 1.3.0
 @available(iOS 15, macOS 13, visionOS 1, tvOS 16, *)
 public struct OUDSAlertMessage: View {
@@ -162,7 +162,7 @@ public struct OUDSAlertMessage: View {
         HStack(alignment: .top, spacing: theme.alert.spaceColumnGap) {
             AlertLeadingIcon(status: status)
                 .padding(.top, theme.alert.spacePaddingBlock)
-            AlertMessageContent(text: text, description: description, bulletList: bulletList, link: link)
+            AlertMessageContent(text: text, status: status, description: description, bulletList: bulletList, link: link)
             AlertMessageAction(link: link, onClose: onClose)
         }
         .padding(.leading, theme.alert.spacePaddingInline)

--- a/OUDS/Core/Components/Sources/_/Extensions/View+Grids.swift
+++ b/OUDS/Core/Components/Sources/_/Extensions/View+Grids.swift
@@ -11,7 +11,6 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
-import OUDSThemesContract
 import SwiftUI
 
 extension View {

--- a/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
+++ b/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
@@ -76,8 +76,8 @@ public enum OUDSVersions {
 
     // MARK: - Components versions - Dialog
 
-    /// Version of the Figma specifications for the component alert (alert message)  (1.0.0)
-    public static let componentAlertMessageVersion = "1.0.0"
+    /// Version of the Figma specifications for the component alert (alert message)  (1.1.0)
+    public static let componentAlertMessageVersion = "1.1.0" // WARNING: Manually updated as tokenator not updated yet
     /// Version of the Figma specifications for the component alert (inline alert) (1.0.0)
     public static let componentInlineAlertVersion = "1.0.0"
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1342

### Description

<!-- Describe your changes in detail -->
Change colors of all texts but links in `alert message` component

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Apply new design update for the component (v1.1.0)

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [ ] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
