### PR TITLE
[#1351] Update `selected tab indicator` animation for `tab bar` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `alert message` component with new label colors (Orange-OpenSource/ouds-ios#1342)
 - Selected tab animation for `tab bar component` (iOS 18 and older) (Orange-OpenSource/ouds-ios#1351)
+- `alert message` component with new label colors (Orange-OpenSource/ouds-ios#1342)
 - Rename in `bullet list` component API "unordered icon" to "unordered asset" (Orange-OpenSource/ouds-ios#1326)
 - AGENTS.md file to focus only on users (Orange-OpenSource/ouds-ios#1341)
 - Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - `alert message` component with new label colors (Orange-OpenSource/ouds-ios#1342)
+- Selected tab animation for `tab bar component` (iOS 18 and older) (Orange-OpenSource/ouds-ios#1351)
 - Rename in `bullet list` component API "unordered icon" to "unordered asset" (Orange-OpenSource/ouds-ios#1326)
 - AGENTS.md file to focus only on users (Orange-OpenSource/ouds-ios#1341)
 - Signatures of control-item-based components (Orange-OpenSource/ouds-ios#1314)

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
@@ -38,6 +38,11 @@ struct SelectedTabIndicator: View {
     /// Starts at 0 (invisible) and is animated to 1 (full width) whenever a tab becomes selected.
     @State private var indicatorScaleX: CGFloat = 0
 
+    /// To disable animation if device in low power mode
+    @EnvironmentObject private var lowPowerModeObserver: OUDSLowPowerModeObserver
+    /// To disable animation if user asked for it in device settings
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @Environment(\.iPhoneInUse) private var iPhoneInUse
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
@@ -49,25 +54,38 @@ struct SelectedTabIndicator: View {
             let indicatorPosition = (geometry.size.height - tabBarHeight + safeAreaBottom) + (theme.bar.sizeHeightActiveIndicatorCustom / 2)
             let xOffset = tabWidth * CGFloat(selected) + (tabWidth - indicatorWidth) / 2
 
-            RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
-                .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
-                .frame(width: indicatorWidth, height: theme.bar.sizeHeightActiveIndicatorCustom)
-                .scaleEffect(x: indicatorScaleX, y: 1, anchor: .center)
-                .position(
-                    x: xOffset + indicatorWidth / 2,
-                    y: indicatorPosition)
-                .onChange(of: selected) { _ in
-                    // Instantly collapse the indicator to zero width (no animation, so no slide
-                    // from the old tab to the new one), then animate the line expanding outward
-                    // from the center of the new tab.
-                    indicatorScaleX = 0
-                    withAnimation(.easeInOut(duration: kTabBarAnimationDuration)) {
-                        indicatorScaleX = 1
+            if reduceMotion || lowPowerModeObserver.isLowPowerModeEnabled {
+                // No animation: display a full-tab-width indicator, instantly repositioned on selection change.
+                RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
+                    .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
+                    .frame(width: indicatorWidth, height: theme.bar.sizeHeightActiveIndicatorCustom)
+                    .position(
+                        x: tabWidth * CGFloat(selected) + tabWidth / 2,
+                        y: indicatorPosition)
+                    .onChange(of: geometry.size) { _ in
+                        updateTabBarHeight()
                     }
-                }
-                .onChange(of: geometry.size) { _ in
-                    updateTabBarHeight()
-                }
+            } else {
+                RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
+                    .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
+                    .frame(width: indicatorWidth, height: theme.bar.sizeHeightActiveIndicatorCustom)
+                    .scaleEffect(x: indicatorScaleX, y: 1, anchor: .center)
+                    .position(
+                        x: xOffset + indicatorWidth / 2,
+                        y: indicatorPosition)
+                    .onChange(of: selected) { _ in
+                        // Instantly collapse the indicator to zero width (no animation, so no slide
+                        // from the old tab to the new one), then animate the line expanding outward
+                        // from the center of the new tab.
+                        indicatorScaleX = 0
+                        withAnimation(.easeInOut(duration: kTabBarAnimationDuration)) {
+                            indicatorScaleX = 1
+                        }
+                    }
+                    .onChange(of: geometry.size) { _ in
+                        updateTabBarHeight()
+                    }
+            }
         }
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + kAsyncDelay) {

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
@@ -34,6 +34,9 @@ struct SelectedTabIndicator: View {
 
     @State private var tabBarHeight: CGFloat = 0
     @State private var safeAreaBottom: CGFloat = 0
+    /// Horizontal scale factor used to animate the indicator expanding from its center.
+    /// Starts at 0 (invisible) and is animated to 1 (full width) whenever a tab becomes selected.
+    @State private var indicatorScaleX: CGFloat = 0
 
     @Environment(\.iPhoneInUse) private var iPhoneInUse
     @Environment(\.theme) private var theme
@@ -49,10 +52,19 @@ struct SelectedTabIndicator: View {
             RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
                 .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
                 .frame(width: indicatorWidth, height: theme.bar.sizeHeightActiveIndicatorCustom)
+                .scaleEffect(x: indicatorScaleX, y: 1, anchor: .center)
                 .position(
                     x: xOffset + indicatorWidth / 2,
                     y: indicatorPosition)
-                .animation(.easeInOut(duration: kTabBarAnimationDuration), value: selected)
+                .onChange(of: selected) { _ in
+                    // Instantly collapse the indicator to zero width (no animation, so no slide
+                    // from the old tab to the new one), then animate the line expanding outward
+                    // from the center of the new tab.
+                    indicatorScaleX = 0
+                    withAnimation(.easeInOut(duration: kTabBarAnimationDuration)) {
+                        indicatorScaleX = 1
+                    }
+                }
                 .onChange(of: geometry.size) { _ in
                     updateTabBarHeight()
                 }
@@ -60,6 +72,9 @@ struct SelectedTabIndicator: View {
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + kAsyncDelay) {
                 updateTabBarHeight()
+                withAnimation(.easeInOut(duration: kTabBarAnimationDuration)) {
+                    indicatorScaleX = 1
+                }
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
@@ -21,7 +21,7 @@ import SwiftUI
 
 // MARK: - Constants
 
-let kTabBarAnimationDuration: CGFloat = 0.3
+let kTabBarAnimationDuration: CGFloat = 0.2
 let kAsyncDelay: CGFloat = 0.1
 
 // MARK: - Selected Tab Indicator


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1351

### Description

<!-- Describe your changes in detail -->
Change animation to have something cooler

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Fill the need of NDE project

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [x] Design review has been done
- (NA) Accessibility review has been done
- (NA)Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
