### PR TITLE
[#1373] Refactor `tab bar` component init with deprecation of older one for a new one with Binding

### DIFF
--- a/.opencode/skills/ouds-framework-usage/SKILL.md
+++ b/.opencode/skills/ouds-framework-usage/SKILL.md
@@ -370,14 +370,18 @@ OUDSLink(text: "Text", icon: Image("ic"), size: .default) {}
 Docs: https://ios.unified-design-system.orange.com/documentation/oudscomponents/oudstabbar
 
 ```swift
-// iOS 15–25: pass selected tab index and total count
-OUDSTabBar(selected: 0, count: 3) {
+// iOS 15–25: declare a @State for the selected tab, then pass it as a Binding.
+// The binding is updated when the user taps a tab, and changing it programmatically
+// switches the displayed tab.
+@State private var selectedTab = 0
+
+OUDSTabBar(selectedTab: $selectedTab, count: 3) {
     SomeView().tabItem { Label("Tab 1", image: "ic_1") }.tag(0)
     OtherView().tabItem { Label("Tab 2", image: "ic_2") }.tag(1)
     LastView().tabItem { Label("Tab 3", image: "ic_3") }.tag(2)
 }
 
-// iOS 26+: no need for selected/count
+// iOS 26+: no need for selectedTab/count
 OUDSTabBar {
     SomeView().tabItem { Label("Tab 1", image: "ic_1") }
     OtherView().tabItem { Label("Tab 2", image: "ic_2") }
@@ -386,6 +390,7 @@ OUDSTabBar {
 ```
 
 > Tab bar images must be 26×26 pt. Colors are managed automatically by `OUDSTabBar`.
+> `OUDSTabBar(selected:count:content:)` (plain `Int`) is deprecated — use `OUDSTabBar(selectedTab:count:content:)` (`Binding<Int>`) instead.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `tab bar` component initialization (Orange-OpenSource/ouds-ios#1373)
 - Optimization of public API (frozen structs and enums, inlinable properties) (Orange-OpenSource/ouds-ios#1382)
 - Improve documentation (Orange-OpenSource/ouds-ios#1286)
 - Update illustrations in documentation for `alert message` component (Orange-OpenSource/ouds-ios#1359)

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,7 +12,7 @@
 
 Some public `View` extension methods prefixed with `ouds` have been renamed to remove the prefix, aligning with the naming style of typography helpers.
 The old methods are deprecated and will be removed in a future major version.
-The tab bar component has a new initialiser with a binding for selected tab making the older one deprecated.
+The tab bar component has a new initializer with a binding for the selected tab, deprecating the older one.
 
 ### Before You Begin
 
@@ -120,7 +120,7 @@ The new initializer uses a `Binding<Int>` so the selected tab is always in sync 
 
 ### Compatibility
 
-- **Backward Compatibility**: No
+- **Backward Compatibility**: Yes
 - **v1.4.0 Support**:  Until release of next minor version
 
 ## v1.2.0 → v1.3.0

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,7 @@
 
 Some public `View` extension methods prefixed with `ouds` have been renamed to remove the prefix, aligning with the naming style of typography helpers.
 The old methods are deprecated and will be removed in a future major version.
+The tab bar component has a new initialiser with a binding for selected tab making the older one deprecated.
 
 ### Before You Begin
 
@@ -77,6 +78,45 @@ SomeView()
 - Replace deprecated `ouds`-prefixed calls with their unprefixed counterparts
 
 **Reason for Change**: User feedback indicated the `ouds` prefix on methods was redundant and verbose given that parameter types are strongly typed OUDS tokens which prevent any ambiguity with native SwiftUI overloads.
+
+#### Deprecated `OUDSTabBar` initializer
+
+The `OUDSTabBar(selected:count:content:)` initializer that accepted a plain `Int` for the initially selected tab is now deprecated.
+A new `OUDSTabBar(selectedTab:count:content:)` initializer replaces it, accepting a `Binding<Int>` that is updated whenever the user taps a tab — keeping the parent view in sync with the tab bar selection without any extra code.
+
+**Impact**: Low
+
+**Before (v1.3.x)**:
+```swift
+// The initial tab is fixed at 0; user interactions are not propagated back.
+OUDSTabBar(selected: 0, count: 3) {
+    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
+    OtherView().tabItem { Label("Search", image: "ic_search") }.tag(1)
+    LastView().tabItem { Label("Profile", image: "ic_profile") }.tag(2)
+}
+```
+
+**After (v1.4.0)**:
+```swift
+// Declare a @State to hold the selected tab index.
+@State private var selectedTab = 0
+
+// Pass it as a Binding: the tab bar updates selectedTab when the user taps a tab,
+// and programmatically changing selectedTab switches the displayed tab.
+OUDSTabBar(selectedTab: $selectedTab, count: 3) {
+    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
+    OtherView().tabItem { Label("Search", image: "ic_search") }.tag(1)
+    LastView().tabItem { Label("Profile", image: "ic_profile") }.tag(2)
+}
+```
+
+**Required Action**:
+- Replace `OUDSTabBar(selected:count:content:)` calls with `OUDSTabBar(selectedTab:count:content:)`
+- Declare a `@State private var selectedTab: Int` (or use an existing state/binding) and pass it as `$selectedTab`
+- Remove any manual workaround you may have used to track or drive tab selection from outside the component
+
+**Reason for Change**: The original initializer only accepted a one-time initial value (`Int`) with no way to observe or control the selected tab from outside the component.
+The new initializer uses a `Binding<Int>` so the selected tab is always in sync with the parent view: user taps update the binding, and external state changes switch the visible tab.
 
 ### Compatibility
 

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -63,8 +63,8 @@ import SwiftUI
 ///
 /// ## Accessibility considerations
 ///
-/// - If your tabs embeded in the `OUDSTabBar` do not contain texts but only images, add an accessibility label introducing the journey for this tab
-/// - If your tabs embeded in the `OUDSTabBar` display a badge (empty or with text), vocalize it in your tab to let users know what it is (unread messages, new things, etc)
+/// - If your tabs embedded in the `OUDSTabBar` do not contain texts but only images, add an accessibility label introducing the journey for this tab
+/// - If your tabs embedded in the `OUDSTabBar` display a badge (empty or with text), vocalize it in your tab to let users know what it is (unread messages, new things, etc)
 /// by using accessibiltiy value
 ///
 /// ```swift
@@ -123,6 +123,7 @@ import SwiftUI
 ///                     Image(decorative: "image_2")
 ///                         .renderingMode(.template) // Mandatory to apply color on selected item
 ///                 }
+///              }
 ///             .tag(1) // Must be used for the selectedTab binding
 ///         LastView()
 ///             .tabItem {
@@ -222,7 +223,7 @@ public struct OUDSTabBar<Content: View>: View {
     ///                 Label("Label 1", image: "some-image")
     ///              }
     ///              .tag(0)
-    ///         OtherViewView()
+    ///         OtherView()
     ///             .tabItem {
     ///                 Label("Label 2", image: "some-image")
     ///              }
@@ -231,18 +232,19 @@ public struct OUDSTabBar<Content: View>: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - selectedTab: A binding to the 0-based index of the currently selected tab, associated to a *tag* on a *tab bar item*. Updated when the user selects a tab.
+    ///    - selectedTab: A binding to the 0-based index of the currently selected tab, associated to a *tag* on a *tab bar item*.
+    ///    Updated when the user selects a tab. Must be positive and lower than `count`.
     ///    - count: The current number of tabs hosted in the tab bar, must be a positive non-null integer
     ///    - content: The list of items to add in the tab bar
     public init(selectedTab: Binding<Int>,
-                count: Int,
+                count: UInt8,
                 @ViewBuilder content: @escaping () -> Content)
     {
         if selectedTab.wrappedValue < 0 || selectedTab.wrappedValue >= count {
             OL.warning("The selected tab binding for the OUDSTabBar does not match the count of tabs")
         }
         _selectedTab = selectedTab
-        tabCount = count
+        tabCount = Int(count)
         self.content = content
         _isLandscape = State(initialValue: Self.isInLandscapeViewport())
     }
@@ -266,7 +268,7 @@ public struct OUDSTabBar<Content: View>: View {
     ///                 Label("Label 1", image: "some-image")
     ///              }
     ///              .tag(0)
-    ///         OtherViewView()
+    ///         OtherView()
     ///             .tabItem {
     ///                 Label("Label 2", image: "some-image")
     ///              }
@@ -303,7 +305,7 @@ public struct OUDSTabBar<Content: View>: View {
     ///             .tabItem {
     ///                 Label("Label 1", image: "some-image")
     ///              }
-    ///         OtherViewView()
+    ///         OtherView()
     ///             .tabItem {
     ///                 Label("Label 2", image: "some-image")
     ///              }

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -86,9 +86,10 @@ import SwiftUI
 /// ## Selection of tabs
 ///
 /// For iOS lower than 26, a selected tab indicator can be displayed in the `OUDSTabBar` if the `count` parameter is defined (to the number of tabs in the component)
-/// and if the `selected` parameter is equal to a given tag associated to a tab item.
+/// and if the `selectedTab` binding value is equal to a given tag associated to a tab item.
 /// Otherwise the indicator won't appear; these parameters are mandatory to compute the location of the indicator.
 /// This rule is only applied if selected tab indicator must be displayed.
+/// When the user taps a tab, the `selectedTab` binding is updated automatically, keeping the parent view in sync.
 ///
 /// ## Technical considerations
 ///
@@ -101,9 +102,11 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Use the OUDS tab bar to wrap tab bar items and associated views
-///     // Item tagged 0 will be selected first, 3 tabs are embeded.
+///     // Item tagged 0 will be selected first, 3 tabs are embedded.
 ///     // Image with size of 26 x 26
-///     OUDSTabBar(selected: 0, count: 3) {
+///     @State private var selectedTab = 0
+///
+///     OUDSTabBar(selectedTab: $selectedTab, count: 3) {
 ///
 ///         // Add the views with the SwiftUI tab item and labels
 ///         // No need to define colors, everything is done inside OUDSTabBar
@@ -111,7 +114,7 @@ import SwiftUI
 ///             .tabItem {
 ///                 Label("Label 1", image: "image_1")
 ///             }
-///             .tag(0) // Must match the selected parameter
+///             .tag(0) // Must match the selectedTab binding value
 ///         OtherView()
 ///             .tabItem {
 ///                 Label {
@@ -120,12 +123,12 @@ import SwiftUI
 ///                     Image(decorative: "image_2")
 ///                         .renderingMode(.template) // Mandatory to apply color on selected item
 ///                 }
-///             .tag(1) // Must be used for the selected parameter
+///             .tag(1) // Must be used for the selectedTab binding
 ///         LastView()
 ///             .tabItem {
 ///                 Label("Label 3", image: "image_3")
 ///             }
-///             .tag(2) // Must be used for the selected parameter
+///             .tag(2) // Must be used for the selectedTab binding
 ///     }
 /// ```
 ///
@@ -189,8 +192,10 @@ public struct OUDSTabBar<Content: View>: View {
     /// The current number of tabs in the `OUDSTabBar` to compute the selected tab indicator for iOS without Liquid Glass
     private let tabCount: Int
 
-    /// State to keep the selected tab reference and refresh the view
-    @State private var selectedTab: Int
+    /// Binding to the currently selected tab index.
+    /// When the user selects a tab, this binding is updated so the parent view can react.
+    /// When the parent changes this binding, the displayed selected tab updates accordingly.
+    @Binding private var selectedTab: Int
 
     /// Contains the tab bar items
     @ViewBuilder private let content: () -> Content
@@ -200,12 +205,61 @@ public struct OUDSTabBar<Content: View>: View {
 
     // MARK: Initializers
 
-    /// NOTE: No use of #if os(iOS) to let OUDS maintainers macOS computers compute the documentation
-    /// Defines the tab bar component with given tab bar items.
+    // NOTE: No use of #if os(iOS) to let OUDS maintainers macOS computers compute the documentation
+    /// Defines the tab bar component with given tab bar items and a two-way binding to the selected tab index.
     /// Number of tabs and selected tab are needed to compute the selected tab indicator for iOS lower than 26.
-    /// If you target iOS 26+ or other platform, prefer instead `OUDSTabBar(content:)`
+    /// If you target iOS 26+ or other platform, prefer instead `OUDSTabBar(content:)`.
+    ///
+    /// The `selectedTab` binding is updated whenever the user taps a tab item, allowing the parent
+    /// view to observe or drive tab selection programmatically.
     ///
     /// ```swift
+    ///     @State private var selectedTab = 0
+    ///
+    ///     OUDSTabBar(selectedTab: $selectedTab, count: 2) {
+    ///         SomeView()
+    ///             .tabItem {
+    ///                 Label("Label 1", image: "some-image")
+    ///              }
+    ///              .tag(0)
+    ///         OtherViewView()
+    ///             .tabItem {
+    ///                 Label("Label 2", image: "some-image")
+    ///              }
+    ///              .tag(1)
+    ///     }
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - selectedTab: A binding to the 0-based index of the currently selected tab, associated to a *tag* on a *tab bar item*. Updated when the user selects a tab.
+    ///    - count: The current number of tabs hosted in the tab bar, must be a positive non-null integer
+    ///    - content: The list of items to add in the tab bar
+    public init(selectedTab: Binding<Int>,
+                count: Int,
+                @ViewBuilder content: @escaping () -> Content)
+    {
+        if selectedTab.wrappedValue < 0 || selectedTab.wrappedValue >= count {
+            OL.warning("The selected tab binding for the OUDSTabBar does not match the count of tabs")
+        }
+        _selectedTab = selectedTab
+        tabCount = count
+        self.content = content
+        _isLandscape = State(initialValue: Self.isInLandscapeViewport())
+    }
+
+    // NOTE: No use of #if os(iOS) to let OUDS maintainers macOS computers compute the documentation
+    /// Defines the tab bar component with given tab bar items.
+    /// Number of tabs and selected tab are needed to compute the selected tab indicator for iOS lower than 26.
+    /// If you target iOS 26+ or other platform, prefer instead `OUDSTabBar(content:)`.
+    ///
+    /// - Warning: Deprecated. Use ``init(selectedTab:count:content:)`` instead.
+    ///   This initializer uses a read-only `Int` for the initial selected tab; tab selection changes
+    ///   made by the user are not propagated back to the caller.
+    ///   Migrate to `init(selectedTab:count:content:)` which accepts a `Binding<Int>` for
+    ///   full two-way synchronisation.
+    ///
+    /// ```swift
+    ///     // Deprecated — use init(selectedTab:count:content:) instead
     ///     OUDSTabBar(selected: 0, count: 2) {
     ///         SomeView()
     ///             .tabItem {
@@ -224,19 +278,24 @@ public struct OUDSTabBar<Content: View>: View {
     ///    - selected: The identifier of the first selected tab, i.e. its rank starting from 0, associated to a *tag*  on a *tab bar item*
     ///    - count: The current number of tabs hosted in the tab bar, must be positive non null integer
     ///    - content: The list of items to add in the tab bar
+    @available(*, deprecated, renamed: "init(selectedTab:count:content:)",
+               message: "Pass a Binding<Int> using init(selectedTab:count:content:) so that tab selection is reflected back to the caller.")
     public init(selected: Int,
                 count: Int,
                 @ViewBuilder content: @escaping () -> Content)
     {
-        selectedTab = selected
+        if selected < 0 || selected >= count {
+            OL.warning("The selected tab index for the OUDSTabBar does not match the count of tabs")
+        }
+        _selectedTab = .constant(selected)
         tabCount = count
         self.content = content
         _isLandscape = State(initialValue: Self.isInLandscapeViewport())
     }
 
-    /// NOTE: No use of #if os(iOS) to let OUDS maintainers macOS computers compute the documentation
+    // NOTE: No use of #if os(iOS) to let OUDS maintainers macOS computers compute the documentation
     /// Defines the tab bar component with given tab bar items.
-    /// If you target iOS lower than 26, prefer instead `OUDSTabBar(selected:count:content:)`
+    /// If you target iOS lower than 26, prefer instead `OUDSTabBar(selectedTab:count:content:)`
     ///
     /// ```swift
     ///     OUDSTabBar {
@@ -254,7 +313,7 @@ public struct OUDSTabBar<Content: View>: View {
     /// - Parameter content: The views to add in the tab bar
     @available(iOS 26, *)
     public init(@ViewBuilder content: @escaping () -> Content) {
-        selectedTab = 0
+        _selectedTab = .constant(0)
         tabCount = 0
         self.content = content
         _isLandscape = State(initialValue: false)

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -85,8 +85,11 @@ The ``OUDSTabBar`` provides a native SwiftUI `TabView` with use of OUDS effects 
 The ``OUDSTabBar`` lets users define their own hierarchy of views associated to tab items.
 
 ```swift        
-// Use the OUDS tab bar to wrap tab bar items and associated views
-OUDSTabBar(selected: 0, count: 3) {
+// Use the OUDS tab bar to wrap tab bar items and associated views.
+// Declare a @State to hold the selected tab index, then pass it as a binding.
+@State private var selectedTab = 0
+
+OUDSTabBar(selectedTab: $selectedTab, count: 3) {
         
     // Add the views with the SwiftUI tab item and labels
     // No need to define colors, everything is done inside OUDSTabBar

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial_onboarding/Resources/swift-samples/tutorial-onboarding (solution).swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial_onboarding/Resources/swift-samples/tutorial-onboarding (solution).swift
@@ -248,12 +248,18 @@ struct ContentView: View {
 
     private let theme = OrangeTheme()
 
+    // Tracks the currently selected tab; updated automatically when the user taps a tab item.
+    // Can also be set programmatically to switch tabs from outside the component.
+    @State private var selectedTab = 0
+
     var body: some View {
         OUDSThemeableView(theme: theme) {
-            // Initializer for iOS 18- compatibility
-            // Images are available in project assets
-            // Tags allow to make the binding and display the selected tab indicator for iOS 18-
-            OUDSTabBar(selected: 0, count: 3) {
+            // Initializer for iOS 18- compatibility.
+            // Images are available in project assets.
+            // Tags identify each tab and must match the values used by the selectedTab binding.
+            // The binding keeps the parent in sync: user taps update selectedTab, and
+            // changing selectedTab programmatically switches the displayed tab.
+            OUDSTabBar(selectedTab: $selectedTab, count: 3) {
                 HomeScreen().tabItem {
                     Label("Home", image: "Home")
                 }

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial_onboarding/Resources/swift-samples/tutorial-onboarding-3-8.swift
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Tutorial_onboarding/Resources/swift-samples/tutorial-onboarding-3-8.swift
@@ -17,10 +17,11 @@ import SwiftUI
 struct ContentView: View {
 
     private let theme = OrangeTheme()
+    @State private var selectedTab = 0
 
     var body: some View {
         OUDSThemeableView(theme: theme) {
-            OUDSTabBar(selected: 0, count: 3) {
+            OUDSTabBar(selectedTab: $selectedTab, count: 3) {
                 HomeScreen().tabItem {
                     Label("Home", image: "Home")
                 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1373

### Description

<!-- Describe your changes in detail -->
Add new init with a binding, deprecated the older one

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let user know why tab is selected an change it by code

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
