### PR TITLE
[#1409] For `PIN code input` component add label on each digit and do not move focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Vocalization for `PIN code input` component (Orange-OpenSource/ouds-ios#1409)
 - Vocalization for content of `password input` component (Orange-OpenSource/ouds-ios#1406)
 - Accessibility label for `alert` components for `warning` and `negative` statuses (Orange-OpenSource/ouds-ios#1407)
 - Accessibility hint for double-tap to unselect action for `filter chip` component (Orange-OpenSource/ouds-ios#1277)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Vocalization for `PIN code input` component (Orange-OpenSource/ouds-ios#1409)
+- Vocalization and management of focus for `PIN code input` component (Orange-OpenSource/ouds-ios#1409)
 - Vocalization for content of `password input` component (Orange-OpenSource/ouds-ios#1406)
 - Accessibility label for `alert` components for `warning` and `negative` statuses (Orange-OpenSource/ouds-ios#1407)
 - Accessibility hint for double-tap to unselect action for `filter chip` component (Orange-OpenSource/ouds-ios#1277)

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
@@ -32,8 +32,11 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
 
     @Binding var text: String
     @Binding var displayText: String
+
     let font: UIFont
     let index: Int
+    let a11yLabel: String
+    let a11yValue: String
     let onBackspace: () -> Void
     let onTextInserted: (String) -> Void
 
@@ -51,6 +54,12 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         textField.onBackspace = onBackspace
         textField.fieldIndex = index
         textField.font = font
+
+        // VoiceOver reads UIKit accessibility properties directly on the hosted UIView.
+        // SwiftUI's .accessibilityLabel / .accessibilityValue modifiers have no effect on
+        // UIViewRepresentable, so the values must be set here on the UITextField itself.
+        textField.accessibilityLabel = a11yLabel
+        textField.accessibilityValue = a11yValue
 
         // Set low priorities to allow the SwiftUI frame modifier to control the size
         textField.setContentHuggingPriority(.defaultLow, for: .vertical)
@@ -75,6 +84,11 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         if uiView.text != displayText {
             uiView.text = displayText
         }
+
+        // Keep accessibility properties in sync on every SwiftUI re-render (e.g. when the digit
+        // changes and the value string switches between "Empty" and the actual digit)
+        uiView.accessibilityLabel = a11yLabel
+        uiView.accessibilityValue = a11yValue
     }
 
     /// Creates the coordinator that acts as the `UITextFieldDelegate`.

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -38,10 +38,10 @@ struct PinCodeInputContainer: View {
     /// The digits written one by one by the user before being exposed through `value`
     @State private var digits: [String]
 
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    @Environment(\.verticalSizeClass) private var verticalSizeClass
-    @Environment(\.colorScheme) private var colorScheme
     @Environment(\.theme) private var theme
+    @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     // MARK: - Black magic
 
@@ -108,9 +108,15 @@ struct PinCodeInputContainer: View {
                     .contentShape(Rectangle())
                     .foregroundColor(foregroundColor)
                     .modifier(PinCodeInputBorderModifier(isOutlined: isOutlined, isError: isError, isFocused: focusedIndex == index))
-                    .accessibilityValue(accessibilityValue(for: index))
+                // NOTE: no SwiftUI .accessibilityLabel here — it is silently ignored on UIViewRepresentable.
+                // The label and value are set directly on the UITextField inside BackspaceDetectingTextField.
             }
         }
+        // .contain keeps each digit field individually reachable by VoiceOver swipe gestures inside the group.
+        // VoiceOver first announces the group label (groupAccessibilityLabel), then the user can swipe
+        // into the container to reach and vocalize each individual digit field.
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(groupAccessibilityLabel)
         .onAppear {
             // Focus on the first empty field if:
             // - autofocus is enabled (empty value case)
@@ -171,6 +177,24 @@ struct PinCodeInputContainer: View {
         }
     }
 
+    /// Returns the accessibility label for a digit field at the given index.
+    /// e.g. "Digit 1", "Chiffre 2", "الرقم 3" (localized).
+    /// This is forwarded directly to the UITextField — SwiftUI accessibility modifiers
+    /// are silently ignored on UIViewRepresentable.
+    ///
+    /// - Parameter index: The 0-based index of the digit field
+    /// - Returns: The localized positional label
+    private func accessibilityLabel(for index: Int) -> String {
+        "core_pinCodeInput_digitLabel_a11y" <- (index + 1)
+    }
+
+    /// Returns the accessibility label for the group container of all digit fields.
+    /// e.g. "Enter the 6-digit code" (localized, driven by the component's `length`).
+    /// - Returns: String
+    private var groupAccessibilityLabel: String {
+        "core_pinCodeInput_groupLabel_a11y" <- length.rawValue
+    }
+
     // MARK: - Digits fields
 
     /// Returns the string to display for a digit field:
@@ -204,6 +228,8 @@ struct PinCodeInputContainer: View {
             displayText: .constant(displayText(for: index)),
             font: uiFont,
             index: index,
+            a11yLabel: accessibilityLabel(for: index),
+            a11yValue: accessibilityValue(for: index),
             onBackspace: {
                 handleBackspace(at: index)
             },

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -168,6 +168,18 @@ struct PinCodeInputContainer: View {
         }
     }
 
+    /// Returns `true` when VoiceOver (or any assistive technology that relies on explicit focus
+    /// control) is currently running.
+    /// When `true`, automatic focus advancement to the next field is suppressed so that the user
+    /// can navigate fields at their own pace via VoiceOver swipe gestures.
+    private var isVoiceOverRunning: Bool {
+        #if canImport(UIKit)
+        UIAccessibility.isVoiceOverRunning
+        #else
+        false
+        #endif
+    }
+
     private func accessibilityValue(for index: Int) -> String {
         let value = digits[index]
         if value.isEmpty {
@@ -287,9 +299,13 @@ struct PinCodeInputContainer: View {
                 focusedIndex = nil
             } else {
                 value = ""
-                // Focus the field right after the last filled one, if any
-                let nextIndex = index + toDistribute.count
-                focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
+                // Move focus to the next empty field only when VoiceOver is not running.
+                // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
+                // would interrupt their navigation.
+                if !isVoiceOverRunning {
+                    let nextIndex = index + toDistribute.count
+                    focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
+                }
             }
             return
         }
@@ -311,7 +327,12 @@ struct PinCodeInputContainer: View {
                 value = joined
                 focusedIndex = nil
             } else if index < length.rawValue - 1 {
-                focusedIndex = index + 1
+                // Move focus to the next field only when VoiceOver is not running.
+                // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
+                // would interrupt their navigation.
+                if !isVoiceOverRunning {
+                    focusedIndex = index + 1
+                }
                 value = ""
             } else {
                 value = ""
@@ -374,8 +395,13 @@ struct PinCodeInputContainer: View {
             focusedIndex = nil
         } else {
             value = ""
-            let nextIndex = index + toDistribute.count
-            focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
+            // Move focus to the next empty field only when VoiceOver is not running.
+            // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
+            // would interrupt their navigation.
+            if !isVoiceOverRunning {
+                let nextIndex = index + toDistribute.count
+                focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
+            }
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
@@ -80,6 +80,10 @@ import SwiftUI
 ///
 /// The component gets only numeric values, not letters or symbols, only numbers.
 ///
+/// If Voice Over is enabled, the autofocus is not used, otherwise focus will be moved to the next field.
+///
+/// Component and its digits fields are vocalized with iternal wording.
+///
 /// When using the error status, provide a clear, concise error message explaining what went wrong and, when possible, how to fix it
 /// (for example: *“The code you entered is invalid. Try again.”*).
 ///

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
@@ -80,9 +80,10 @@ import SwiftUI
 ///
 /// The component gets only numeric values, not letters or symbols, only numbers.
 ///
-/// If Voice Over is enabled, the autofocus is not used, otherwise focus will be moved to the next field.
+/// Depending on the component configuration, autofocus can still be used when the component appears, and focus is moved to the next field as digits are entered.
+/// For example if Voice Over is enavled, the autoficus is disabled.
 ///
-/// Component and its digits fields are vocalized with iternal wording.
+/// The component and its digit fields are vocalized with internal wording.
 ///
 /// When using the error status, provide a clear, concise error message explaining what went wrong and, when possible, how to fix it
 /// (for example: *“The code you entered is invalid. Try again.”*).

--- a/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
@@ -694,6 +694,30 @@
         }
       }
     },
+    "core_pinCodeInput_groupLabel_a11y" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "أدخل رمزًا مكونًا من %lld رقمًا"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the code with %lld digits"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Entrez le code à %lld chiffres"
+          }
+        }
+      }
+    },
     "core_radio_hint_selected_a11y" : {
       "comment" : "Component - Radio",
       "extractionState" : "manual",


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1409 

### Description

<!-- Describe your changes in detail -->
- Disable autofocus if Voice Over
- Voice Over label for component and fields

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve a11Y of component

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
