### PR TITLE
[#1434] Overlay items of tab bar component are still displayed even if tab bar hidden for disabled Liquid Glass apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Overlay items of `tab bar` component still displayed even if hidden for disabled Liquid Glass (Orange-OpenSource/ouds-ios#1434)
 - Selected tab indicator in `tab bar` component if Liquid Glass not applied (Orange-OpenSource/ouds-ios#1428)
 
 ## [1.4.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.3.0...1.4.0) - 2026-04-15

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
@@ -41,6 +41,7 @@ struct SelectedTabIndicator: View {
     /// Horizontal scale factor used to animate the indicator expanding from its center.
     /// Starts at 0 (invisible) and is animated to 1 (full width) whenever a tab becomes selected.
     @State private var indicatorScaleX: CGFloat = 0
+    @State private var isTabBarHidden: Bool = false
 
     /// To disable animation if device in low power mode
     @EnvironmentObject private var lowPowerModeObserver: OUDSLowPowerModeObserver
@@ -51,6 +52,8 @@ struct SelectedTabIndicator: View {
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
 
+    // MARK: - Body
+
     var body: some View {
         GeometryReader { geometry in
             let tabWidth = geometry.size.width / CGFloat(count)
@@ -58,7 +61,9 @@ struct SelectedTabIndicator: View {
             let indicatorPosition = (geometry.size.height - tabBarHeight + safeAreaBottom) + (theme.bar.sizeHeightActiveIndicatorCustom / 2)
             let xOffset = tabWidth * CGFloat(selected) + (tabWidth - indicatorWidth) / 2
 
-            if reduceMotion || lowPowerModeObserver.isLowPowerModeEnabled {
+            // Do not render the indicator when the native tab bar is hidden
+            // (e.g. when the user applies `.toolbar(.hidden, for: .tabBar)`).
+            if !isTabBarHidden, reduceMotion || lowPowerModeObserver.isLowPowerModeEnabled {
                 // No animation: display a full-tab-width indicator, instantly repositioned on selection change.
                 RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
                     .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
@@ -69,7 +74,7 @@ struct SelectedTabIndicator: View {
                     .onChange(of: geometry.size) { _ in
                         updateTabBarHeight()
                     }
-            } else {
+            } else if !isTabBarHidden {
                 RoundedRectangle(cornerRadius: theme.bar.borderRadiusActiveIndicatorCustomTop)
                     .fill(theme.bar.colorActiveIndicatorCustomSelectedEnabled.color(for: colorScheme))
                     .frame(width: indicatorWidth, height: theme.bar.sizeHeightActiveIndicatorCustom)
@@ -104,11 +109,16 @@ struct SelectedTabIndicator: View {
                 updateTabBarHeight()
             }
         }
+        // React to `.toolbar(.hidden, for: .tabBar)` being applied or removed at any time.
+        .onReceive(NotificationCenter.default.publisher(for: TabBarVisibilityObserver.visibilityDidChange)) { _ in
+            updateTabBarHeight()
+        }
     }
 
     // MARK: Tab bar heights
 
-    /// Get the tab bar height depending to the state of the device and updates the same area stored dimension
+    /// Get the tab bar height depending to the state of the device and updates the same area stored dimension.
+    /// Also updates `isTabBarHidden` to reflect whether `.toolbar(.hidden, for: .tabBar)` has been applied.
     private func updateTabBarHeight() {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return }
@@ -116,9 +126,11 @@ struct SelectedTabIndicator: View {
         safeAreaBottom = window.safeAreaInsets.bottom
 
         if let detectedTabBar = findTabBar() {
+            isTabBarHidden = detectedTabBar.isHidden
             tabBarHeight = detectedTabBar.frame.height
         } else {
             // If not possible to compute tab bar height, get recommended / precomputed value as fallback
+            isTabBarHidden = false
             let heights = iPhoneInUse.tabBarHeights
             tabBarHeight = Self.isInLandscapeViewport() ? heights.landscape : heights.portrait
         }

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/SelectedTabIndicator.swift
@@ -19,8 +19,6 @@ import OUDSTokensRaw
 import OUDSTokensSemantic
 import SwiftUI
 
-// MARK: - Selected Tab Indicator
-
 /// An indicator to display at the top of the selected tab for iOS lower than 26 (i.e. no Liquid Glass)
 struct SelectedTabIndicator: View {
 

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
@@ -32,22 +32,16 @@ struct TabBarTopDivider: View {
 
     var body: some View {
         GeometryReader { geometry in
-            // The condition is placed OUTSIDE the Rectangle but INSIDE the GeometryReader
-            // so that the geometry proxy is always available. The guard is re-evaluated
-            // on every state change because GeometryReader itself re-renders when @State changes.
-            // `tabBarHeight > 0` prevents a misplaced render on the first layout pass
-            // (before `updateTabBarHeight()` has run). The GeometryReader size does not change
-            // between passes so we need the state-driven condition here rather than relying
-            // on geometry changes to trigger re-evaluation.
+            // Keep the GeometryReader always present so its proxy stays available for
+            // measuring and positioning the divider on every update.
             //
-            // NOTE: the condition must live outside the GeometryReader closure at the `body`
-            // level so SwiftUI identity-diffs it on every @State update. If placed inside the
-            // GeometryReader, SwiftUI may skip re-running the closure when geometry.size is
-            // unchanged even though @State values have changed.
+            // The visibility guard intentionally stays inside the GeometryReader and is
+            // applied with `.opacity` on the Rectangle rather than conditionally removing
+            // the view. This lets the position calculation continue to use the current
+            // geometry and state values on each pass.
             //
-            // We keep the GeometryReader always present (so its size is always measured) and
-            // use `.opacity` to hide/show the Rectangle — this guarantees the closure is
-            // re-evaluated and the position calculation always uses fresh state values.
+            // `tabBarHeight > 0` prevents a misplaced render during the first layout pass,
+            // before `updateTabBarHeight()` has populated the measured tab bar height.
             let dividerPosition = geometry.size.height - tabBarHeight + safeAreaBottom
             Rectangle()
                 .fill(theme.colors.borderMinimal.color(for: colorScheme))

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
@@ -59,17 +59,17 @@ struct TabBarTopDivider: View {
         }
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
-                updateTabBarHeight()
+                updateTabBarStatus()
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
             DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
-                updateTabBarHeight()
+                updateTabBarStatus()
             }
         }
         // React to `.toolbar(.hidden, for: .tabBar)` being applied or removed at any time.
         .onReceive(NotificationCenter.default.publisher(for: TabBarVisibilityObserver.visibilityDidChange)) { _ in
-            updateTabBarHeight()
+            updateTabBarStatus()
         }
     }
 
@@ -77,7 +77,7 @@ struct TabBarTopDivider: View {
 
     /// Get the tab bar height depending to the state of the device and updates the same area stored dimension.
     /// Also updates `isTabBarHidden` to reflect whether `.toolbar(.hidden, for: .tabBar)` has been applied.
-    private func updateTabBarHeight() {
+    private func updateTabBarStatus() {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return }
 
@@ -85,12 +85,10 @@ struct TabBarTopDivider: View {
 
         if let detectedTabBar = findTabBar() {
             // UITabBar found: read actual height and visibility.
-            print("🟥 findTabBar OK — isHidden=\(detectedTabBar.isHidden) frame.height=\(detectedTabBar.frame.height)")
             isTabBarHidden = detectedTabBar.isHidden
             tabBarHeight = detectedTabBar.frame.height
         } else {
             // UITabBar not yet in the hierarchy (timing issue on first appear).
-            print("🟥 findTabBar FAILED — using fallback")
             // Use hardcoded fallback so `tabBarHeight > 0` unlocks the render guard,
             // but do NOT touch `isTabBarHidden` — KVO via TabBarVisibilityObserver is
             // the sole source of truth for visibility; we just don't know it yet here.
@@ -100,11 +98,8 @@ struct TabBarTopDivider: View {
             // the UIKit hierarchy has settled.
             DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
                 if let retryTabBar = findTabBar() {
-                    print("🟥 retry OK — isHidden=\(retryTabBar.isHidden) frame.height=\(retryTabBar.frame.height)")
                     isTabBarHidden = retryTabBar.isHidden
                     tabBarHeight = retryTabBar.frame.height
-                } else {
-                    print("🟥 retry FAILED too")
                 }
             }
         }

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarTopDivider.swift
@@ -24,6 +24,7 @@ struct TabBarTopDivider: View {
 
     @State private var tabBarHeight: CGFloat = 0
     @State private var safeAreaBottom: CGFloat = 0
+    @State private var isTabBarHidden: Bool = false
 
     @Environment(\.iPhoneInUse) private var iPhoneInUse
     @Environment(\.theme) private var theme
@@ -31,14 +32,30 @@ struct TabBarTopDivider: View {
 
     var body: some View {
         GeometryReader { geometry in
+            // The condition is placed OUTSIDE the Rectangle but INSIDE the GeometryReader
+            // so that the geometry proxy is always available. The guard is re-evaluated
+            // on every state change because GeometryReader itself re-renders when @State changes.
+            // `tabBarHeight > 0` prevents a misplaced render on the first layout pass
+            // (before `updateTabBarHeight()` has run). The GeometryReader size does not change
+            // between passes so we need the state-driven condition here rather than relying
+            // on geometry changes to trigger re-evaluation.
+            //
+            // NOTE: the condition must live outside the GeometryReader closure at the `body`
+            // level so SwiftUI identity-diffs it on every @State update. If placed inside the
+            // GeometryReader, SwiftUI may skip re-running the closure when geometry.size is
+            // unchanged even though @State values have changed.
+            //
+            // We keep the GeometryReader always present (so its size is always measured) and
+            // use `.opacity` to hide/show the Rectangle — this guarantees the closure is
+            // re-evaluated and the position calculation always uses fresh state values.
             let dividerPosition = geometry.size.height - tabBarHeight + safeAreaBottom
-
             Rectangle()
                 .fill(theme.colors.borderMinimal.color(for: colorScheme))
                 .frame(height: 1)
                 .position(
                     x: geometry.size.width / 2,
                     y: dividerPosition)
+                .opacity(tabBarHeight > 0 && !isTabBarHidden ? 1 : 0)
         }
         .onAppear {
             DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
@@ -50,11 +67,16 @@ struct TabBarTopDivider: View {
                 updateTabBarHeight()
             }
         }
+        // React to `.toolbar(.hidden, for: .tabBar)` being applied or removed at any time.
+        .onReceive(NotificationCenter.default.publisher(for: TabBarVisibilityObserver.visibilityDidChange)) { _ in
+            updateTabBarHeight()
+        }
     }
 
     // MARK: Tab bar heights
 
-    /// Get the tab bar height depending to the state of the device and updates the same area stored dimension
+    /// Get the tab bar height depending to the state of the device and updates the same area stored dimension.
+    /// Also updates `isTabBarHidden` to reflect whether `.toolbar(.hidden, for: .tabBar)` has been applied.
     private func updateTabBarHeight() {
         guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
               let window = windowScene.windows.first else { return }
@@ -62,11 +84,29 @@ struct TabBarTopDivider: View {
         safeAreaBottom = window.safeAreaInsets.bottom
 
         if let detectedTabBar = findTabBar() {
+            // UITabBar found: read actual height and visibility.
+            print("🟥 findTabBar OK — isHidden=\(detectedTabBar.isHidden) frame.height=\(detectedTabBar.frame.height)")
+            isTabBarHidden = detectedTabBar.isHidden
             tabBarHeight = detectedTabBar.frame.height
         } else {
-            // If not possible to compute tab bar height, get recommended / precomputed value as fallback
+            // UITabBar not yet in the hierarchy (timing issue on first appear).
+            print("🟥 findTabBar FAILED — using fallback")
+            // Use hardcoded fallback so `tabBarHeight > 0` unlocks the render guard,
+            // but do NOT touch `isTabBarHidden` — KVO via TabBarVisibilityObserver is
+            // the sole source of truth for visibility; we just don't know it yet here.
             let heights = iPhoneInUse.tabBarHeights
             tabBarHeight = Self.isInLandscapeViewport() ? heights.landscape : heights.portrait
+            // Schedule a retry so we can replace the fallback with the real value once
+            // the UIKit hierarchy has settled.
+            DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
+                if let retryTabBar = findTabBar() {
+                    print("🟥 retry OK — isHidden=\(retryTabBar.isHidden) frame.height=\(retryTabBar.frame.height)")
+                    isTabBarHidden = retryTabBar.isHidden
+                    tabBarHeight = retryTabBar.frame.height
+                } else {
+                    print("🟥 retry FAILED too")
+                }
+            }
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarVisibilityObserver.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarVisibilityObserver.swift
@@ -1,0 +1,60 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+import SwiftUI
+
+#if os(iOS)
+
+/// A KVO-based observer that watches `UITabBar.isHidden` and broadcasts a custom notification
+/// whenever the property changes. This allows OUDS overlay views (`SelectedTabIndicator`,
+/// `TabBarTopDivider`) to react when `.toolbar(.hidden, for: .tabBar)` is applied or removed.
+///
+/// Because `UITabBar.isHidden` is a `@MainActor`-isolated property in Swift 6, KVO is performed
+/// through a raw string key path (`"hidden"`) rather than a typed Swift key path (`\.isHidden`),
+/// which avoids a compiler error when the observation closure is a `@Sendable` context.
+final class TabBarVisibilityObserver: NSObject, @unchecked Sendable {
+
+    /// Posted on the default `NotificationCenter` whenever the observed `UITabBar.isHidden` changes.
+    static let visibilityDidChange = Notification.Name("ouds.tabBarVisibilityDidChange")
+
+    private weak var tabBar: UITabBar?
+
+    init(tabBar: UITabBar) {
+        self.tabBar = tabBar
+        super.init()
+        // Use raw string KVO key ("hidden") to avoid "cannot form key path to main actor-isolated
+        // property" error raised by Swift 6 when using the typed key path `\.isHidden`.
+        tabBar.addObserver(self, forKeyPath: "hidden", options: [.new], context: nil)
+    }
+
+    deinit {
+        tabBar?.removeObserver(self, forKeyPath: "hidden")
+    }
+
+    // swiftlint:disable block_based_kvo
+    // swiftlint:disable discouraged_optional_collection
+    override func observeValue(forKeyPath keyPath: String?,
+                               of object: Any?,
+                               change: [NSKeyValueChangeKey: Any]?,
+                               context: UnsafeMutableRawPointer?)
+    {
+        guard keyPath == "hidden" else { return }
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: TabBarVisibilityObserver.visibilityDidChange, object: nil)
+        }
+    }
+    // swiftlint:enable block_based_kvo
+    // swiftlint:enable discouraged_optional_collection
+}
+#endif

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarVisibilityObserver.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarVisibilityObserver.swift
@@ -49,9 +49,9 @@ final class TabBarVisibilityObserver: NSObject, @unchecked Sendable {
                                change: [NSKeyValueChangeKey: Any]?,
                                context: UnsafeMutableRawPointer?)
     {
-        guard keyPath == "hidden" else { return }
+        guard keyPath == "hidden", let observedTabBar = object as? UITabBar else { return }
         DispatchQueue.main.async {
-            NotificationCenter.default.post(name: TabBarVisibilityObserver.visibilityDidChange, object: nil)
+            NotificationCenter.default.post(name: TabBarVisibilityObserver.visibilityDidChange, object: observedTabBar)
         }
     }
     // swiftlint:enable block_based_kvo

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -204,6 +204,12 @@ public struct OUDSTabBar<Content: View>: View {
     /// Track orientation changes to trigger view refresh
     @State private var isLandscape: Bool
 
+    #if os(iOS)
+    /// KVO observer that watches the native `UITabBar.isHidden` property and broadcasts
+    /// `TabBarVisibilityObserver.visibilityDidChange` so overlay views can react.
+    @State private var tabBarVisibilityObserver: TabBarVisibilityObserver?
+    #endif
+
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Initializers
@@ -355,6 +361,20 @@ public struct OUDSTabBar<Content: View>: View {
         }
         .onAppear {
             isLandscape = Self.isInLandscapeViewport()
+            // Attach KVO observer on the live UITabBar so the overlay views
+            // (SelectedTabIndicator, TabBarTopDivider) are notified whenever
+            // `.toolbar(.hidden, for: .tabBar)` is applied or removed.
+            // The UIKit hierarchy may not be fully settled on the first onAppear,
+            // so retry after a short delay if findTabBar() returns nil.
+            if let tabBar = findTabBar() {
+                tabBarVisibilityObserver = TabBarVisibilityObserver(tabBar: tabBar)
+            } else {
+                DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
+                    if let tabBar = findTabBar() {
+                        tabBarVisibilityObserver = TabBarVisibilityObserver(tabBar: tabBar)
+                    }
+                }
+            }
         }
         .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
             // Delay to ensure the orientation change is complete


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1434 

### Description

<!-- Describe your changes in detail -->
Use the hidden state of the tab bar to be sure the selected tab indicator and the divider are hidden if tab bar hidden

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Hide items if bar hidden

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
