### PR TITLE
[#1398] Add badge on toolbar item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: `OUDSBulletList.UnorderedAsset.free` case
 - **BREAKING**: `OUDSCheckboxItem(isOn:)`, `OUDSRadioItem(isOn:)`, `OUDSCheckboxItemIndeterminate(selection:)` inits
 - **BREAKING**: `OUDSTabBar(selected:count)` init
+### Added
+
+- `badge` on `toolbar` item (Orange-OpenSource/ouds-ios#1398)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `badge` on `toolbar` components items (Orange-OpenSource/ouds-ios#1398)
+- **BREAKING**: `badge` on `toolbar` components items with icons (Orange-OpenSource/ouds-ios#1398)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/1.4.0...develop)
 
+### Added
+
+- `badge` on `toolbar` components items (Orange-OpenSource/ouds-ios#1398)
+
 ### Changed
 
 - Move from Xcode 26.3 to Xcode 26.4, and Swift 6.2 to Swift 6.3 (Orange-OpenSource/ouds-ios#1356)
 - **BREAKING**: Update of tokens (tokens librairies v2.5.0) (Orange-OpenSource/ouds-ios#1473)
 - **BREAKING**: Update of tokens (tokens librairies v2.4.0) (Orange-OpenSource/ouds-ios#1437)
+
+### Fixed
+
+- Overlay items of `tab bar` component still displayed even if hidden for disabled Liquid Glass (Orange-OpenSource/ouds-ios#1434)
+- Selected tab indicator in `tab bar` component if Liquid Glass not applied (Orange-OpenSource/ouds-ios#1428)
 
 ### Removed
 
@@ -19,14 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: `OUDSBulletList.UnorderedAsset.free` case
 - **BREAKING**: `OUDSCheckboxItem(isOn:)`, `OUDSRadioItem(isOn:)`, `OUDSCheckboxItemIndeterminate(selection:)` inits
 - **BREAKING**: `OUDSTabBar(selected:count)` init
-### Added
-
-- `badge` on `toolbar` item (Orange-OpenSource/ouds-ios#1398)
-
-### Fixed
-
-- Overlay items of `tab bar` component still displayed even if hidden for disabled Liquid Glass (Orange-OpenSource/ouds-ios#1434)
-- Selected tab indicator in `tab bar` component if Liquid Glass not applied (Orange-OpenSource/ouds-ios#1428)
 
 ## [1.4.0](https://github.com/Orange-OpenSource/ouds-ios/compare/1.3.0...1.4.0) - 2026-04-15
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,6 +12,7 @@
 ### Overview
 
 Tokens librairies have been updated, with some raw, semantic and components tokens removed or renamed.
+API for `action type` of `toolbar item` has been enriched.
 
 ### Before You Begin
 
@@ -99,7 +100,6 @@ For bar component tokens
 | `sizeWidthActiveIndicatorCustomTop`             | `sizeWidthCurrentIndicatorCustomTop`            |
 | `sizeWidthActiveIndicatorCustomBottom`          | `sizeWidthCurrentIndicatorCustomBottom`         |
 | `sizeWidthActiveIndicatorCustomBottom`          | `sizeWidthCurrentIndicatorCustomBottom`         |
-
     
 **Required Action**:
 - Use the new names as explained above
@@ -135,6 +135,18 @@ The tokens provider for charts colors, previously named `charts`, is now named `
 - Rename any use of `theme.charts` to `theme.colorsCharts`
 
 **Reason for Change**: Bring more clarity in naming
+
+### Refactor of API for `action type` of `toolbar item`
+
+The `OUDSToolBarItem.ActionType` enum has been updated for the `icon` case.
+A new parameter named `badgeType` appeared.
+
+**Impact**: Low
+
+**Required Action**: 
+- If you make pattern matching on this case, add a new slot for this parameter.
+
+**Reason for Change**: Manage badge for items with icons in toolbars
 
 ### Compatibility
 

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -311,7 +311,7 @@ public struct OUDSBadge: View {
     }
 
     private init(layout: BadgeLayout, accessibilityLabel: String) {
-        if accessibilityLabel.isEmpty {
+        if accessibilityLabel.isEmpty, case .empty = layout.type {
             OL.warning("The OUDSBadge should not have an empty accessibility label, think about your disabled users!")
         }
         self.layout = layout

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomModifier.swift
@@ -88,6 +88,7 @@ struct ToolBarBottomModifier: ViewModifier {
     private func itemsView(_ items: [OUDSToolBarItem]) -> some View {
         ForEach(items) { item in
             item
+                .environment(\.toolbarItemLocation, .toolbarBottom)
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -48,20 +48,37 @@ struct ToolBarItemActionButton: View {
             .modifier(ToolBarActionItemModifier(style: style))
             .accessibilityHint(Text(accessibilityHint ?? ""))
 
-        case let .icon(asset, accessibilityLabel, accessibilityHint, action):
-            Button {
-                action?()
-            } label: {
-                asset
-                    .renderingMode(.template)
-                    .resizable()
-                    .frame(width: 26, height: 26)
-                // NOTE: Cannot define size of 44x44 for button because with Liquid Glass height is constrained and button will be flattened
+        case let .icon(asset, accessibilityLabel, accessibilityHint, badgeType, action):
+            ZStack(alignment: .topTrailing) {
+                Button {
+                    action?()
+                } label: {
+                    asset
+                        .renderingMode(.template)
+                        .resizable()
+                        .frame(width: 26, height: 26)
+                    // NOTE: Cannot define size of 44x44 for button because with Liquid Glass height is constrained and button will be flattened
+                }
+                .disabled(action == nil)
+                .modifier(ToolBarActionItemModifier(style: style))
+                .accessibilityLabel(Text(accessibilityLabel))
+                .accessibilityHint(Text(accessibilityHint ?? ""))
+
+                if let badgeType {
+                    badge(from: badgeType)
+                }
             }
-            .disabled(action == nil)
-            .modifier(ToolBarActionItemModifier(style: style))
-            .accessibilityLabel(Text(accessibilityLabel))
-            .accessibilityHint(Text(accessibilityHint ?? ""))
+        }
+    }
+
+    @ViewBuilder
+    func badge(from type: OUDSToolBarItem.BadgeType) -> some View {
+        switch type {
+        case .standard:
+            OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
+        case let .number(count):
+            OUDSBadge(count: count, accessibilityLabel: "", status: .negative, size: .medium)
+                .offset(x: 3, y: -3)
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -91,7 +91,7 @@ private struct ToolBarItemBadgeModifier: ViewModifier {
                 case .standard:
                     OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
                 case let .number(count):
-                    OUDSBadge(count: count, accessibilityLabel: "", status: .negative, size: .medium)
+                    OUDSBadge(count: count, accessibilityLabel: String(count), status: .negative, size: .medium)
                         .offset(x: 3, y: -3)
                 case .none:
                     EmptyView()

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -17,7 +17,7 @@ import OUDSThemesContract
 import OUDSTokensSemantic
 import SwiftUI
 
-// MARK: - Toolbar Item Action Button
+// MARK: - ToolBar Item Action Button
 
 struct ToolBarItemActionButton: View {
 
@@ -67,7 +67,9 @@ struct ToolBarItemActionButton: View {
     }
 }
 
-struct ToolBarItemBadgeModifier: ViewModifier {
+// MARK: - ToolBar Item Badge Modifier
+
+private struct ToolBarItemBadgeModifier: ViewModifier {
 
     let type: OUDSToolBarItem.BadgeType?
 

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -69,11 +69,10 @@ struct ToolBarItemActionButton: View {
 
 // MARK: - ToolBar Item Badge Modifier
 
-/// Depending to the OS version and the toolbar associated to the item, adds a badge to the item/
-/// For iOS 26 / Liquid Glass, system badge must be used for top toolbar, otherwise badge won't be readable.
-/// However with this case and for bottom toolbar, the system does not display system badge, thus an OUDS badge should be used
-/// as workaround.
-/// For iOS until 18, use OUDS badge in all cases.
+/// Depending on the OS version and the toolbar associated with the item, adds a badge to the item.
+/// For iOS 26 / Liquid Glass, the system badge must be used for the top toolbar; otherwise, the badge will not be readable.
+/// However, for the bottom toolbar, the system does not display the badge, so an OUDS badge is used as a workaround.
+/// For iOS versions up to 18, use the OUDS badge in all cases.
 private struct ToolBarItemBadgeModifier: ViewModifier {
 
     let type: OUDSToolBarItem.BadgeType?

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -69,33 +69,55 @@ struct ToolBarItemActionButton: View {
 
 // MARK: - ToolBar Item Badge Modifier
 
+/// Depending to the OS version and the toolbar associated to the item, adds a badge to the item/
+/// For iOS 26 / Liquid Glass, system badge must be used for top toolbar, otherwise badge won't be readable.
+/// However with this case and for bottom toolbar, the system does not display system badge, thus an OUDS badge should be used
+/// as workaround.
+/// For iOS until 18, use OUDS badge in all cases.
 private struct ToolBarItemBadgeModifier: ViewModifier {
 
     let type: OUDSToolBarItem.BadgeType?
+    @Environment(\.toolbarItemLocation) private var location
+    @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     func body(content: Content) -> some View {
-        if #available(iOS 26, *) {
+        if isLiquidGlassDisabled {
+            oudsBadgeLayout(content)
+        } else {
+            switch location {
+            case .toolbarTop:
+                systemBadgeLayout(content)
+            case .toolbarBottom:
+                oudsBadgeLayout(content)
+            }
+        }
+    }
+
+    /// Adds a system badge to the item
+    @ViewBuilder private func systemBadgeLayout(_ content: Content) -> some View {
+        switch type {
+        case .standard:
+            content.badge("")
+        case let .number(count):
+            let text = count > OUDSBadge.maxCount ? "+\(OUDSBadge.maxCount)" : "\(count)"
+            content.badge(Text(text))
+        case .none:
+            content
+        }
+    }
+
+    /// Adds an OUDS badge to the item
+    @ViewBuilder private func oudsBadgeLayout(_ content: Content) -> some View {
+        ZStack(alignment: .topTrailing) {
+            content
             switch type {
             case .standard:
-                content.badge("")
+                OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
             case let .number(count):
-                let text = count > OUDSBadge.maxCount ? "+\(OUDSBadge.maxCount)" : "\(count)"
-                content.badge(Text(text))
+                OUDSBadge(count: count, accessibilityLabel: String(count), status: .negative, size: .medium)
+                    .offset(x: 3, y: -3)
             case .none:
-                content
-            }
-        } else {
-            ZStack(alignment: .topTrailing) {
-                content
-                switch type {
-                case .standard:
-                    OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
-                case let .number(count):
-                    OUDSBadge(count: count, accessibilityLabel: String(count), status: .negative, size: .medium)
-                        .offset(x: 3, y: -3)
-                case .none:
-                    EmptyView()
-                }
+                EmptyView()
             }
         }
     }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -49,36 +49,52 @@ struct ToolBarItemActionButton: View {
             .accessibilityHint(Text(accessibilityHint ?? ""))
 
         case let .icon(asset, accessibilityLabel, accessibilityHint, badgeType, action):
-            ZStack(alignment: .topTrailing) {
-                Button {
-                    action?()
-                } label: {
-                    asset
-                        .renderingMode(.template)
-                        .resizable()
-                        .frame(width: 26, height: 26)
-                    // NOTE: Cannot define size of 44x44 for button because with Liquid Glass height is constrained and button will be flattened
-                }
-                .disabled(action == nil)
-                .modifier(ToolBarActionItemModifier(style: style))
-                .accessibilityLabel(Text(accessibilityLabel))
-                .accessibilityHint(Text(accessibilityHint ?? ""))
-
-                if let badgeType {
-                    badge(from: badgeType)
-                }
+            Button {
+                action?()
+            } label: {
+                asset
+                    .renderingMode(.template)
+                    .resizable()
+                    .frame(width: 26, height: 26)
+                // NOTE: Cannot define size of 44x44 for button because with Liquid Glass height is constrained and button will be flattened
             }
+            .disabled(action == nil)
+            .modifier(ToolBarActionItemModifier(style: style))
+            .accessibilityLabel(Text(accessibilityLabel))
+            .accessibilityHint(Text(accessibilityHint ?? ""))
+            .modifier(ToolBarItemBadgeModifier(type: badgeType))
         }
     }
+}
 
-    @ViewBuilder
-    func badge(from type: OUDSToolBarItem.BadgeType) -> some View {
-        switch type {
-        case .standard:
-            OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
-        case let .number(count):
-            OUDSBadge(count: count, accessibilityLabel: "", status: .negative, size: .medium)
-                .offset(x: 3, y: -3)
+struct ToolBarItemBadgeModifier: ViewModifier {
+
+    let type: OUDSToolBarItem.BadgeType?
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26, *) {
+            switch type {
+            case .standard:
+                content.badge("")
+            case let .number(count):
+                let text = count > OUDSBadge.maxCount ? "+\(OUDSBadge.maxCount)" : "\(count)"
+                content.badge(Text(text))
+            case .none:
+                content
+            }
+        } else {
+            ZStack(alignment: .topTrailing) {
+                content
+                switch type {
+                case .standard:
+                    OUDSBadge(accessibilityLabel: "", status: .negative, size: .small)
+                case let .number(count):
+                    OUDSBadge(count: count, accessibilityLabel: "", status: .negative, size: .medium)
+                        .offset(x: 3, y: -3)
+                case .none:
+                    EmptyView()
+                }
+            }
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -82,6 +82,7 @@ struct ToolBarTopModifier: ViewModifier {
     private func itemsView(_ items: [OUDSToolBarItem]) -> some View {
         ForEach(items) { item in
             item
+                .environment(\.toolbarItemLocation, .toolbarTop)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarBottom.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarBottom.swift
@@ -34,6 +34,14 @@ import SwiftUI
 /// - If you use both an  ``OUDSTabBar`` with the `toolBarBottom`, the toolbar will be **behind** the tabbar for iOS 26+, so not usable, **not recommended**
 /// - Avoid use of both `toolBarBottom` and ``OUDSTabBar`` in the same page
 ///
+/// ## Badges uses
+///
+/// Because the system does not render system badge for items in bottom toolbar, the ``OUDSBadge`` is used for iOS 26 with Liquid Glass and bottom toolbars.
+/// However the glassified effect of Liquid Glass does not make sometimes the badge readable, that is the reason why you should use badge for bottom toolbars with lots of care
+/// and prefer *prominent* or *tinted* styles for the item with the badge instead of *default*.
+///
+/// For iOS until 18 and without Liquid Glass ``OUDSBadge`` is always used.
+///
 /// ## Code samples
 ///
 /// Define leading and trailing items for the bottom toolbar

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -19,19 +19,40 @@ import SwiftUI
 
 // MARK: - OUDS ToolBar Item
 
-/// A strongly typed toolbar item container used inside:
-/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
-/// - `toolBarBottom(leadingItems:trailingItems:)`
-///
-/// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
-///
-/// ```swift
-///     // A toolbar item with only the close icon
-///     OUDSToolBarItem(navigation: .close)
-///
-///     // A toolbar item with the back icon and and a text, for iOS < 26
-///     OUDSToolBarItem(navigation: .back(label: "Back"))
-///
+// A strongly typed toolbar item container used inside:
+// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
+// - `toolBarBottom(leadingItems:trailingItems:)`
+//
+// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
+//
+// ```swift
+//     // A toolbar item with only the close icon
+//     OUDSToolBarItem(navigation: .close)
+//
+//     // A toolbar item with the back icon and and a text, for iOS < 26
+//     OUDSToolBarItem(navigation: .back(label: "Back"))
+//
+//     // A toolbar item with the labal
+//     OUDSToolBarItem(action: "Label") {
+//        // do something
+//     }
+//
+//     // A toolbar item with the labal
+//     OUDSToolBarItem(action: .label("Label")) {
+//        // do something
+//     }
+//
+//     // A toolbar item with the icon
+//     OUDSToolBarItem(action:
+//     .icon(asset: Image("ic_heart"), accessibilityLabel: "New messages available")) {
+//        // do something
+//     }
+//
+//     // A toolbar item with the icon with badge count
+//     OUDSToolBarItem(action: .icon(asset: Image("ic_heart"), accessibilityLabel: "9 new messages", badge: .number(count: 9))) {
+//        // do something
+//     }
+
 ///     // A toolbar item with some View inside
 ///     OUDSToolBarItem {
 ///         // Menu, ...
@@ -82,8 +103,21 @@ public struct OUDSToolBarItem: View, Identifiable {
         ///     - asset: The asset displayed in the icon
         ///     - accessibilityLabel: The accessibility label discribes the action
         ///     - accessibilityHint: Communicates to the user what happens after performing the action, default set to *nil*
+        ///     - badge: The optional badge type, by default *nil* means no badge.
         ///     - action: The action to do when clicked. If *nil* (default) the button is disabled
-        case icon(asset: Image, accessibilityLabel: String, accessibilityHint: String? = nil, action: (() -> Void)? = nil)
+        case icon(asset: Image, accessibilityLabel: String, accessibilityHint: String? = nil, badgeType: BadgeType? = nil, action: (() -> Void)? = nil)
+    }
+
+    /// Defines the badge type can be added on `ActionType.icon` for item of toolbars.
+    ///
+    /// - Since: 1.5.0
+    public enum BadgeType {
+        /// The basic badge without any information
+        case standard
+
+        /// Tha badge with a count
+        /// - Parameters count:The number displayed in the badge.
+        case number(count: UInt8)
     }
 
     /// Defines the built-in navigation type available for the toolbars. Those items must be used only on top leading position of `.toolBar`

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -50,8 +50,8 @@ import SwiftUI
 ///
 ///     // A toolbar item with the icon and badge count
 ///     OUDSToolBarItem(action: .icon(asset: Image("mail"),
-///                     accessibilityLabel: "9 new messages",
-///                     badge: .number(count: 9))) {
+///                                   accessibilityLabel: "9 new messages",
+///                                   badgeType: .number(count: 9))) {
 ///        // do something
 ///     }
 ///
@@ -122,7 +122,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         /// The basic badge without any information
         case standard
 
-        /// Tha badge with a count
+        /// The badge with a count
         ///
         /// - Parameter count:The number displayed in the badge.
         case number(count: UInt8)

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -314,4 +314,18 @@ public enum OUDSToolBarItemsBuilder {
         components.flatMap(\.self)
     }
 }
+
+// MARK: - OUDS Tool Bar Item Position
+
+enum ToolBarItemLocation {
+    case toolbarTop
+    case toolbarBottom
+}
+
+extension EnvironmentValues {
+
+    /// A flag to know if ``OUDSToolBarItem`` will be placed in ``OUDSToolBarBottom`` or ``OUDSToolBarTop``
+    @Entry var toolbarItemLocation: ToolBarItemLocation = .toolbarTop
+}
+
 #endif

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -19,40 +19,42 @@ import SwiftUI
 
 // MARK: - OUDS ToolBar Item
 
-// A strongly typed toolbar item container used inside:
-// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
-// - `toolBarBottom(leadingItems:trailingItems:)`
-//
-// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
-//
-// ```swift
-//     // A toolbar item with only the close icon
-//     OUDSToolBarItem(navigation: .close)
-//
-//     // A toolbar item with the back icon and and a text, for iOS < 26
-//     OUDSToolBarItem(navigation: .back(label: "Back"))
-//
-//     // A toolbar item with the labal
-//     OUDSToolBarItem(action: "Label") {
-//        // do something
-//     }
-//
-//     // A toolbar item with the labal
-//     OUDSToolBarItem(action: .label("Label")) {
-//        // do something
-//     }
-//
-//     // A toolbar item with the icon
-//     OUDSToolBarItem(action:
-//     .icon(asset: Image("ic_heart"), accessibilityLabel: "New messages available")) {
-//        // do something
-//     }
-//
-//     // A toolbar item with the icon with badge count
-//     OUDSToolBarItem(action: .icon(asset: Image("ic_heart"), accessibilityLabel: "9 new messages", badge: .number(count: 9))) {
-//        // do something
-//     }
-
+/// A strongly typed toolbar item container used inside:
+/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
+/// - `toolBarBottom(leadingItems:trailingItems:)`
+///
+/// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
+///
+/// ```swift
+///     // A toolbar item with only the close icon
+///     OUDSToolBarItem(navigation: .close)
+///
+///     // A toolbar item with the back icon and and a text, for iOS < 26
+///     OUDSToolBarItem(navigation: .back(label: "Back"))
+///
+///     // A toolbar item with the label
+///     OUDSToolBarItem(action: "Label") {
+///        // do something
+///     }
+///
+///     // A toolbar item with the label
+///     OUDSToolBarItem(action: .label("Label")) {
+///        // do something
+///     }
+///
+///     // A toolbar item with the icon
+///     OUDSToolBarItem(action: .icon(asset: Image("mail"),
+///                     accessibilityLabel: "New messages available")) {
+///        // do something
+///     }
+///
+///     // A toolbar item with the icon and badge count
+///     OUDSToolBarItem(action: .icon(asset: Image("mail"),
+///                     accessibilityLabel: "9 new messages",
+///                     badge: .number(count: 9))) {
+///        // do something
+///     }
+///
 ///     // A toolbar item with some View inside
 ///     OUDSToolBarItem {
 ///         // Menu, ...
@@ -87,6 +89,7 @@ public struct OUDSToolBarItem: View, Identifiable {
     ///
     /// - Since: 1.4.0
     @frozen public enum ActionType {
+
         /// Create an action wth label only that could be emphasized.
         /// **For iOS > 26, label is always emphasized.**
         ///
@@ -103,7 +106,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         ///     - asset: The asset displayed in the icon
         ///     - accessibilityLabel: The accessibility label discribes the action
         ///     - accessibilityHint: Communicates to the user what happens after performing the action, default set to *nil*
-        ///     - badge: The optional badge type, by default *nil* means no badge.
+        ///     - badgeType: The optional badge type, by default *nil* means no badge.
         ///     - action: The action to do when clicked. If *nil* (default) the button is disabled
         case icon(asset: Image, accessibilityLabel: String, accessibilityHint: String? = nil, badgeType: BadgeType? = nil, action: (() -> Void)? = nil)
     }
@@ -111,16 +114,17 @@ public struct OUDSToolBarItem: View, Identifiable {
     /// Defines the badge type can be added on `ActionType.icon` for item of toolbars.
     ///
     /// **By default, the `OUDSBadge` is used, but for iOS > 26, the system one is used, so its color, size and position
-    /// and can not be changed.**
+    /// can not be changed.**
     ///
-    /// - Since: 1.5.0
-    public enum BadgeType {
-        ///
+    /// - Since: 2.0.0
+    @frozen public enum BadgeType {
+
         /// The basic badge without any information
         case standard
 
         /// Tha badge with a count
-        /// - Parameters count:The number displayed in the badge.
+        ///
+        /// - Parameter count:The number displayed in the badge.
         case number(count: UInt8)
     }
 
@@ -196,7 +200,11 @@ public struct OUDSToolBarItem: View, Identifiable {
     /// Creates a toobar item with action type.
     ///
     /// ```swift
+    ///     // A toolbar item with an "Edit" label and an associated action
     ///     OUDSToolBarItem(action: .label("Edit") { /* Action */ })
+    ///
+    ///     // A toolbar item with an image and a badge
+    ///     OUDSToolBarItem(action: .icon(asset: Image("mail"), accessibilityLabel: "5 new emails", badgeType: .number(count: 5)))
     /// ```
     ///
     /// - Parameter type: The action type describing the layout and assoicated action.
@@ -234,12 +242,12 @@ public struct OUDSToolBarItem: View, Identifiable {
     /// Use this initializer to provide any SwiftUI view, such as a `Menu`, custom button, or complex layout.
     ///
     /// ```swift
-    /// OUDSToolBarItem {
-    ///     Menu("Options") {
-    ///         Button("Option 1") { }
-    ///         Button("Option 2") { }
+    ///     OUDSToolBarItem {
+    ///         Menu("Options") {
+    ///             Button("Option 1") { }
+    ///             Button("Option 2") { }
+    ///         }
     ///     }
-    /// }
     /// ```
     ///
     /// - Parameter content: A view builder that returns the custom view to display.

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -110,8 +110,12 @@ public struct OUDSToolBarItem: View, Identifiable {
 
     /// Defines the badge type can be added on `ActionType.icon` for item of toolbars.
     ///
+    /// **By default, the `OUDSBadge` is used, but for iOS > 26, the system one is used, so its color, size and position
+    /// and can not be changed.**
+    ///
     /// - Since: 1.5.0
     public enum BadgeType {
+        ///
         /// The basic badge without any information
         case standard
 

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -57,6 +57,11 @@ import SwiftUI
 /// - The component is available on iOS, iPadOS, and visionOS
 /// - The component is not available for watchOS, tvOS and macOS
 ///
+/// ## Badges uses
+///
+/// For iOS 26 with Liquid Glass, the systme badge is used because the ``OUDSBadge`` does not provide a suitable rendering with the glassified effect applied on the top toolbar.
+/// For iOS until 18 and without Liquid Glass ``OUDSBadge`` is always used.
+///
 /// ## Code sample
 ///
 /// ```swift

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -59,7 +59,7 @@ import SwiftUI
 ///
 /// ## Badges uses
 ///
-/// For iOS 26 with Liquid Glass, the systme badge is used because the ``OUDSBadge`` does not provide a suitable rendering with the glassified effect applied on the top toolbar.
+/// For iOS 26 with Liquid Glass, the system badge is used because the ``OUDSBadge`` does not provide a suitable rendering with the glassified effect applied on the top toolbar.
 /// For iOS until 18 and without Liquid Glass ``OUDSBadge`` is always used.
 ///
 /// ## Code sample

--- a/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
@@ -4,6 +4,78 @@
     "" : {
       "shouldTranslate" : false
     },
+    "core_alertMessage_close_a11y" : {
+      "comment" : "Component - Alert Message",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "إغلاق رسالة التنبيه"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close alert message"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fermer le message d'alerte"
+          }
+        }
+      }
+    },
+    "core_alertMessage_negative_a11y" : {
+      "comment" : "Component - Alerts",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خطأ"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Error"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Erreur"
+          }
+        }
+      }
+    },
+    "core_alertMessage_warning_a11y" : {
+      "comment" : "Component - Alerts",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تحذير"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Warning"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avertissement"
+          }
+        }
+      }
+    },
     "core_bulletList_a11y_level" : {
       "comment" : "Component - Bullet List - VoiceOver: nesting level of an item (e.g. \"level 1\")",
       "extractionState" : "manual",
@@ -108,78 +180,6 @@
                 }
               }
             }
-          }
-        }
-      }
-    },
-    "core_alertMessage_close_a11y" : {
-      "comment" : "Component - Alert Message",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "إغلاق رسالة التنبيه"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Close alert message"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fermer le message d'alerte"
-          }
-        }
-      }
-    },
-    "core_alertMessage_negative_a11y" : {
-      "comment" : "Component - Alerts",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "خطأ"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
-          }
-        }
-      }
-    },
-    "core_alertMessage_warning_a11y" : {
-      "comment" : "Component - Alerts",
-      "extractionState" : "manual",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "تحذير"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Warning"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Avertissement"
           }
         }
       }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1398

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- [ ] Accessibility review has been done
- [ ] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
