### PR TITLE
[#1482] Update `Link` to center next indicator on multiline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update `Link` to center next indicator on multiline (Orange-OpenSource/ouds-ios#1482)
+- Update `link` component to center git stathe indicator on multiline (Orange-OpenSource/ouds-ios#1482)
 - URL redirection for documentation (Orange-OpenSource/ouds-ios#1481)
 - Move from Xcode 26.3 to Xcode 26.4, and Swift 6.2 to Swift 6.3 (Orange-OpenSource/ouds-ios#1356)
 - **BREAKING**: Update of tokens (tokens librairies v2.5.0) (Orange-OpenSource/ouds-ios#1473)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update `Link` to center next indicator on multiline (Orange-OpenSource/ouds-ios#1482)
 - URL redirection for documentation (Orange-OpenSource/ouds-ios#1481)
 - Move from Xcode 26.3 to Xcode 26.4, and Swift 6.2 to Swift 6.3 (Orange-OpenSource/ouds-ios#1356)
 - **BREAKING**: Update of tokens (tokens librairies v2.5.0) (Orange-OpenSource/ouds-ios#1473)

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -57,9 +57,9 @@ struct LinkButtonStyle: ButtonStyle {
         .padding(.vertical, theme.link.spacePaddingBlock)
         .frame(minWidth: minWidth, minHeight: minHeight)
         #if !os(watchOS) && !os(tvOS)
-        .onHover { isHover in
-            self.isHover = isHover
-        }
+            .onHover { isHover in
+                self.isHover = isHover
+            }
         #endif
     }
 

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -57,9 +57,9 @@ struct LinkButtonStyle: ButtonStyle {
         .padding(.vertical, theme.link.spacePaddingBlock)
         .frame(minWidth: minWidth, minHeight: minHeight)
         #if !os(watchOS) && !os(tvOS)
-            .onHover { isHover in
-                self.isHover = isHover
-            }
+        .onHover { isHover in
+            self.isHover = isHover
+        }
         #endif
     }
 
@@ -85,7 +85,7 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
     let indicator: OUDSLink.Indicator
 
     func makeBody(configuration: Configuration) -> some View {
-        HStack(alignment: alignment, spacing: spacing) {
+        HStack(alignment: .center, spacing: spacing) {
             if indicator == .back {
                 configuration.icon
                     .modifier(LinkSizeIconModifier(size: size))
@@ -106,10 +106,6 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
 
     private var spacing: Double {
         size == .small ? theme.link.spaceColumnGapChevronSmall : theme.link.spaceColumnGapChevronDefault
-    }
-
-    private var alignment: VerticalAlignment {
-        indicator == .back ? .center : .bottom
     }
 }
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1482

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [ ] Design review has been done
- NA Accessibility review has been done
- NA Q/A team has tested the evolution
- NA Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
