### PR TITLE
[#1440] Update of `bullet list` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `bullet list` component can use rich text if bold or not (Orange-OpenSource/ouds-ios#1440)
 - `tag` component with label medium moderate typography for text for small size (Orange-OpenSource/ouds-ios#1449)
 - `filter chip` and `suggestion chip` components with label medium moderate typography for text (Orange-OpenSource/ouds-ios#1441)
 - `input tag` component with label medium moderate typography for text (Orange-OpenSource/ouds-ios#1450)

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/BulletTextModifier.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/BulletTextModifier.swift
@@ -31,15 +31,9 @@ struct BulletListLabel: View {
     // MARK: - Body
 
     var body: some View {
-        if isBold {
-            Text(label.rawValue)
-                .modifier(BulletTextModifier(textStyle: textStyle, isBold: isBold))
-                .frame(maxWidth: maxWidth.dimension(for: horizontalSizeClass ?? .regular), alignment: .leading)
-        } else {
-            textView(for: label)
-                .modifier(BulletTextModifier(textStyle: textStyle, isBold: isBold))
-                .frame(maxWidth: maxWidth.dimension(for: horizontalSizeClass ?? .regular), alignment: .leading)
-        }
+        textView(for: label)
+            .modifier(BulletTextModifier(textStyle: textStyle, isBold: isBold))
+            .frame(maxWidth: maxWidth.dimension(for: horizontalSizeClass ?? .regular), alignment: .leading)
     }
 
     private var maxWidth: MultipleSizeSemanticToken {

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/OUDSBulletList.swift
@@ -116,12 +116,13 @@ import SwiftUI
 ///        }
 /// ```
 ///
-/// ## Rich text
+/// ## Rich text recommendations
 ///
-/// Rich text can be applied only if `isBold` flag is set to *false*.
+/// Rich text can be applied for bullet list whatever the `isBold` flag is.
 ///
 /// Strong text can be used sparingly within alert messages to highlight key information.
 /// Underlined text must not be used for emphasis, as it is commonly associated with links.
+/// Underlined links must be bold.
 /// If a hyperlink is needed within the content, the underlined style should be used.
 /// Italic should be used with care, some brands do not allow it like Orange brand.
 /// No other text styles should be used.
@@ -152,7 +153,7 @@ import SwiftUI
 ///
 /// ![A bullet list component in light and dark modes with Wireframe theme](component_bullet_list_Wireframe)
 ///
-/// - Version: 1.0.0 (Figma component design version)
+/// - Version: 1.1.0 (Figma component design version)
 /// - Since: 1.2.0
 @available(iOS 15, macOS 13, visionOS 1, watchOS 11, tvOS 16, *)
 public struct OUDSBulletList: View {

--- a/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
+++ b/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
@@ -46,8 +46,8 @@
 
     // MARK: - Components versions - Content display
 
-    /// Version of the Figma specifications for the component bullet list (1.0.0)
-    public static let componentBulletListVersion = "1.0.0" // NOTE: #1473 - v1.1.0 not implemented yet
+    /// Version of the Figma specifications for the component bullet list (1.1.0)
+    public static let componentBulletListVersion = "1.1.0"
 
     // MARK: - Components versions - Control
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1440 

### Description

<!-- Describe your changes in detail -->
Remove limitation of rich text for isBold flag

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [x] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
