### PR TITLE
[#1528] Add flag for `text area` component to block height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Flag to limit the height of the `text area` component (Orange-OpenSource/ouds-ios#1528)
 - `View modifier` for fonts using only token (Orange-OpenSource/ouds-ios#1534)
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.0.0...2.1.0) - 2026-06-02

--- a/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaContainer.swift
@@ -30,6 +30,7 @@ struct TextAreaContainer: View {
     let excessCount: Int
     let status: OUDSTextArea.Status
     let isOutlined: Bool
+    let constrainedMaxHeight: Bool
     let accessibilityHint: String?
 
     @State private var hover: Bool = false
@@ -55,7 +56,8 @@ struct TextAreaContainer: View {
 
                     TextAreaInputText(placeholder: placeholder ?? "",
                                       text: text,
-                                      status: status)
+                                      status: status,
+                                      constrainedMaxHeight: constrainedMaxHeight)
                         .focused($focused)
                         .allowsHitTesting(status != .readOnly && status != .disabled)
                         .onTapGesture {

--- a/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaInputText.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaInputText.swift
@@ -25,6 +25,7 @@ struct TextAreaInputText: View {
     let placeholder: String
     let text: Binding<String>
     let status: OUDSTextArea.Status
+    let constrainedMaxHeight: Bool
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
@@ -54,7 +55,7 @@ struct TextAreaInputText: View {
                 .background(Color.clear)
                 .padding(EdgeInsets(top: -8, leading: -5, bottom: -8, trailing: 0))
                 .frame(minHeight: theme.textArea.sizeMinHeightInput)
-                .frame(maxHeight: theme.textArea.sizeMaxHeightInput)
+                .frame(maxHeight: constrainedMaxHeight ? theme.textArea.sizeMinHeightInput : theme.textArea.sizeMaxHeightInput)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/TextArea/OUDSTextArea.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextArea/OUDSTextArea.swift
@@ -100,6 +100,22 @@ import SwiftUI
 ///     OUDSTextArea(label: "Comments", text: $text, isOutlined: true)
 /// ```
 ///
+/// ## Fixed height
+///
+/// By **default**, the text area grows vertically as the user types, up to a maximum height defined by the
+/// design system (token `sizeMaxHeightInput`). Once that height is reached, the content becomes scrollable.
+///
+/// When `constrainedMaxHeight` is set to `true`, the maximum height is capped to the **minimum** height
+/// (token `sizeMinHeightInput`), keeping the component at a fixed, compact size at all times.
+/// The content is immediately scrollable from the first overflow line.
+///
+/// This is useful in dense layouts — forms, filter panels, chat composers — where vertical space is at a premium.
+///
+/// ```swift
+///     // Height is fixed to the minimum (no vertical growth)
+///     OUDSTextArea(label: "Comments", text: $text, constrainedMaxHeight: true)
+/// ```
+///
 /// ## Rich text
 ///
 /// Rich text can be used for error and helper texts.
@@ -146,6 +162,9 @@ import SwiftUI
 ///
 ///     // Outlined style
 ///     OUDSTextArea(label: "Comments", text: $text, isOutlined: true)
+///
+///     // Fixed height — no vertical growth
+///     OUDSTextArea(label: "Comments", text: $text, constrainedMaxHeight: true)
 /// ```
 ///
 /// ## Design documentation
@@ -185,6 +204,7 @@ public struct OUDSTextArea: View {
     let status: Self.Status
     let isOutlined: Bool
     let constrainedMaxWidth: Bool
+    let constrainedMaxHeight: Bool
 
     @Environment(\.theme) private var theme
 
@@ -336,6 +356,9 @@ public struct OUDSTextArea: View {
     ///    - constrainedMaxWidth: When `true`, the width is constrained to a maximum value defined by the design system.
     ///      When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
     ///      modifier. Defaults to `false`.
+    ///    - constrainedMaxHeight: When `true`, the maximum height is capped to the minimum height token (`sizeMinHeightInput`),
+    ///      keeping the component at a fixed compact size. The content becomes immediately scrollable on overflow.
+    ///      When `false` (default), the component grows up to `sizeMaxHeightInput` before scrolling.
     ///    - status: The current status of the text area, by default to set *enabled*
     public init(label: String,
                 text: Binding<String>,
@@ -344,6 +367,7 @@ public struct OUDSTextArea: View {
                 helperLink: Self.Helperlink? = nil,
                 isOutlined: Bool = false,
                 constrainedMaxWidth: Bool = false,
+                constrainedMaxHeight: Bool = false,
                 status: Self.Status = .enabled)
     {
         self.label = label
@@ -354,6 +378,7 @@ public struct OUDSTextArea: View {
         self.isOutlined = isOutlined
         self.status = status
         self.constrainedMaxWidth = constrainedMaxWidth
+        self.constrainedMaxHeight = constrainedMaxHeight
     }
 
     // swiftlint:disable function_default_parameter_at_end
@@ -373,6 +398,7 @@ public struct OUDSTextArea: View {
     ///    - helperLink: An optional helper link, by default is *nil*
     ///    - isOutlined: When `true`, the text area uses a full-perimeter border, defaults to `false`
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - constrainedMaxHeight: When `true`, the height is fixed to the minimum token value, defaults to `false`
     ///    - status: The current status of the text area, default set to *enabled*
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -383,6 +409,7 @@ public struct OUDSTextArea: View {
                 helperLink: Self.Helperlink? = nil,
                 isOutlined: Bool = false,
                 constrainedMaxWidth: Bool = false,
+                constrainedMaxHeight: Bool = false,
                 status: Self.Status = .enabled)
     {
         self.init(label: key.resolved(tableName: tableName, bundle: bundle),
@@ -392,6 +419,7 @@ public struct OUDSTextArea: View {
                   helperLink: helperLink,
                   isOutlined: isOutlined,
                   constrainedMaxWidth: constrainedMaxWidth,
+                  constrainedMaxHeight: constrainedMaxHeight,
                   status: status)
     }
 
@@ -442,6 +470,7 @@ public struct OUDSTextArea: View {
                                   excessCount: excessCount,
                                   status: status,
                                   isOutlined: isOutlined,
+                                  constrainedMaxHeight: constrainedMaxHeight,
                                   accessibilityHint: helperText?.accessibilityDescription(remainingCount: remainingCount))
 
                 TextAreaHelperErrorTextContainer(helperText: helperText,

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -262,10 +262,16 @@ OUDSTextArea(label: "Label", text: $text, helperText: .plain("Max 500 chars."))
 OUDSTextArea(label: "Label", text: $text, helperText: .charactersMaxCount(500))
 OUDSTextArea(label: "Label", text: $text,
              helperLink: .init(text: "Learn more") { openUrl(url) })
+// Fixed height — no vertical growth, scroll from first overflow line
+OUDSTextArea(label: "Label", text: $text, constrainedMaxHeight: true)
 // Error status → see §6 Common patterns
 ```
 
-> Min visible lines: 3 (`OUDSTextArea.minLines`). Max before scrolling: 10 (`OUDSTextArea.maxLines`).
+> Height is controlled by two component tokens on `theme.textArea`:
+> - `sizeMinHeightInput` (72 pt by default) — minimum height, always applied
+> - `sizeMaxHeightInput` (240 pt by default) — maximum height before scroll (used when `constrainedMaxHeight: false`, the default)
+>
+> When `constrainedMaxHeight: true`, `maxHeight` is capped to `sizeMinHeightInput`, keeping the component at a fixed compact size.
 
 ---
 


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1528 

### Description

<!-- Describe your changes in detail -->
Add flag, default set to flag, to limit the height of the text area and avoid autoresize

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve DX

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
