### PR TITLE
[#1557] Manage edge case for tab bar with OS version, Liquid Glass configuration and Xcode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `tab bar` layout is broken for iOS 27 (Orange-OpenSource/ouds-ios#1557)
 - Label and description of `alert message` component not vocalized together (Orange-OpenSource/ouds-ios#1552)
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.0.0...2.1.0) - 2026-06-02

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarViewModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/TabBarViewModifier.swift
@@ -39,6 +39,7 @@ struct TabBarViewModifier: ViewModifier {
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.verticalSizeClass) private var verticalSizeClass
+    @Environment(\.forceOUDSLegacyTabBar) private var forceOUDSLegacyTabBar
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Init
@@ -149,7 +150,7 @@ struct TabBarViewModifier: ViewModifier {
          It could mean in dark mode the text is not readable at all.
          Thus apply the unselector color only for cases where everything works, i.e. not Liquid Glass
          */
-        if isLiquidGlassDisabled { // No Liquid Glass (i.e. iOS 26 with disabled option, and iOS < 26)
+        if forceOUDSLegacyTabBar || isLiquidGlassDisabled { // No Liquid Glass (i.e. iOS 26 with disabled option, and iOS < 26)
             let unselectedUIColor = themeToApply.bar.colorContentUnselectedEnabled.color(for: colorSchemeToApply).uiColor
             tabBarItemAppearance.normal.iconColor = unselectedUIColor
             tabBarItemAppearance.normal.titleTextAttributes = [
@@ -164,7 +165,7 @@ struct TabBarViewModifier: ViewModifier {
 
         // MARK: Tab bar selected item
 
-        if isLiquidGlassDisabled {
+        if forceOUDSLegacyTabBar || isLiquidGlassDisabled {
             let selectedUIColor = themeToApply.bar.colorContentSelectedEnabled.color(for: colorSchemeToApply).uiColor
             tabBarItemAppearance.selected.iconColor = selectedUIColor
             tabBarItemAppearance.selected.titleTextAttributes = [

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSLegacyTabBarModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSLegacyTabBarModifier.swift
@@ -38,7 +38,7 @@ public struct OUDSLegacyTabBarModifier: ViewModifier {
     /// Instanciates the `OUDSLegacyTabBarModifier` and displays error messages in the standard output
     public init() {
         OL.error("You should not force the legacy layout of the tab bar; please embrace Liquid Glass!")
-        OL.error("You should not use this View Modifier with Xcode 27 and UIDesignRequiresCompatibility set to YES")
+        OL.error("You should not use this OUDSLegacyTabBarModifier with Xcode 27 or with Xcode 26 without UIDesignRequiresCompatibility or set to NO")
     }
 
     /// Defines environement variable to precise the legacy tab bar must be forced

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSLegacyTabBarModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSLegacyTabBarModifier.swift
@@ -1,0 +1,56 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import OUDSFoundations
+import SwiftUI
+
+/// `ViewModifier` to manage an edge case about Liquid Glass configuration of Apple OS and Xcode versions.
+///
+/// If an app is compiled with Xcode 27 for iOS 27, Liquid Glass is forced by the system and considered as enabled by OUDS.
+/// If an app is compiled with Xcode 26 for iOS 26, the *UIDesignRequiresCompatibility* flag is read and OUDS considers wether or not Liquid Glass is enabled.
+/// If an app is compiled with Xcode 26 for iOS 18 and lower, Liquid Glass is considered as unavailable, disabled.
+///
+/// The edge case is when the OS version is 27, the flag *UIDesignRequiresCompatibility* stils exists but the app is compiled with Xcode 26.
+/// This case is extreme: the system does not force Liquid Glass, the flag is here, and OUDS cannot only rely on the OS version.
+/// Thus, this ``OUDSLegacyTabBarModifier``  will define an environment value sayin, any legacy layout things (appearances, selector, divider) must be displayed.
+///
+/// **You must use this `ViewModifier` with care, and oly if you are using Xcode 26 and  _UIDesignRequiresCompatibility_ to YES **.
+/// Prefer build with Xcode 27 without the *UIDesignRequiresCompatibility*  flag.
+///
+/// ```swift
+///   OUDSTabBar(selectedTab: ..., count: ...) { ... )
+///     .modifier(OUDSLegacyTabBarModifier())
+/// ```
+///
+/// - Since: 2.2.0
+public struct OUDSLegacyTabBarModifier: ViewModifier {
+
+    /// Instanciates the `OUDSLegacyTabBarModifier` and displays error messages in the standard output
+    public init() {
+        OL.error("You should not force the legacy layout of the tab bar; please embrace Liquid Glass!")
+        OL.error("You should not use this View Modifier with Xcode 27 and UIDesignRequiresCompatibility set to YES")
+    }
+
+    /// Defines environement variable to precise the legacy tab bar must be forced
+    public func body(content: Content) -> some View {
+        content
+            .environment(\.forceOUDSLegacyTabBar, true)
+    }
+}
+
+extension EnvironmentValues {
+
+    /// A flag indicating the OUDS tab bar must hev the legacy layout.
+    /// Very experimental.
+    @Entry public var forceOUDSLegacyTabBar: Bool = false
+}

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -216,6 +216,7 @@ public struct OUDSTabBar<Content: View>: View {
     @State private var isTabBarHidden: Bool = false
     #endif
 
+    @Environment(\.forceOUDSLegacyTabBar) private var forceOUDSLegacyTabBar
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Initializers
@@ -358,6 +359,7 @@ public struct OUDSTabBar<Content: View>: View {
     /// Determines if the selected tab indicator should be shown, i.e. if iOS lower than 26 in portrait mode.
     private var shouldShowTabIndicator: Bool {
         #if canImport(UIKit) && !os(watchOS)
+        if forceOUDSLegacyTabBar { return true }
         guard isLiquidGlassDisabled else { return false }
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         return !isLandscape
@@ -369,6 +371,7 @@ public struct OUDSTabBar<Content: View>: View {
     /// - Returns Bool: true if iOS lower than 26.0 for iPhone or iOS lower than 18.0 for iPad, false otherwise
     private var hasLegacyLayout: Bool {
         #if canImport(UIKit) && !os(watchOS)
+        if forceOUDSLegacyTabBar { return true }
         // iOS < 26
         if isLiquidGlassDisabled {
             // iPhone

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -33,6 +33,8 @@ import SwiftUI
 /// the native API is used instead.
 ///
 /// Because Liquid Glass is available since iOS 26, the tab bar will be liquified / glassified since this OS version, not before.
+/// However if an app is built with Xcode 26 and the flag *UIDesignRequiresCompatibility* set to *YES*, then Loquid Glass won't be applied but the alternative layout.
+/// Nevertheless with Xcode 27 and for iOS 27, Liquid Glass will be always applied, whatever the value of the flag is.
 ///
 /// If you use SF Symbols for images, if they exist their *fill* variant will be automatically used in the tab bar (native behaviour).
 ///

--- a/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
+++ b/OUDS/Core/ThemesContract/Sources/OUDSTheme/Views/OUDSThemeableView.swift
@@ -38,7 +38,8 @@ extension EnvironmentValues {
     /// The environment entry default is *false*.
     /// When using `OUDSThemeableView` (the recommended integration path), this value may be overridden to *true*
     /// on iOS versions earlier than 26 or when the app enables *UIDesignRequiresCompatibility* in the
-    /// *main Bundle* `Info.plist`.
+    /// *main Bundle* `Info.plist` if Xcode 26.
+    /// For Xcode 27, will be always `false` as Apple forces Liquid Glass.
     @Entry public var isLiquidGlassDisabled: Bool = false
 }
 
@@ -69,9 +70,11 @@ public struct OUDSThemeableView<Content: View>: View {
     private let content: () -> Content
 
     private static var isLiquidGlassDisabled: Bool {
-        if #available(iOS 26.0, *) {
+        if #available(iOS 27.0, *) { // Liquid Glass mandatory for iOS 27 (so Xcode 27)
+            false
+        } else if #available(iOS 26.0, *) { // Liquid Glass optional for iOS 26 (with Xcode 26)
             (Bundle.main.object(forInfoDictionaryKey: "UIDesignRequiresCompatibility") as? Bool) ?? false
-        } else {
+        } else { // Liquid Glass unavailable for iOS 18 and lower
             true
         }
     }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1557 

### Description

<!-- Describe your changes in detail -->
Liquid Glass rules have been applied for iOS 27: Liquid Glass will be forced on this OS if compiled with Xcode 27.
But users can still compile app on iOS 27 with Xcode 26: in that case Liquid Glass can be disabled.
So we are stuck:
- we can consider with iOS 27 Liquid Glass is not disabled, and this is true with Xcode 27
- we can consider with iOS 27 Liquid Glass is disable with Xcode 26 and PLIST updated

But in our code side even if we can red the PLIST and the OS version, we cannot guess which versions of Xcode was user:
- Xcode 27, so Liquid Glass forced?
- Xcode 26, so Liquid Glass maybe disabled?

The only inputs we have is the PLIST, the OS versions and that's all but not enough.

This, add a dedicated ViewModifier for users, to use while they compile with Xcode 26, to force in their case the legacy layout for iOS 27.
Otherwise, Liquid Glass and legacy layout are not well applied like below:

<img height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 16 23 15" src="https://github.com/user-attachments/assets/cde12de1-c393-470e-8b49-4e8b0caa8d34" />

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let users with Xcode 26 have a clean layout for tab bar on iOS 27 like below:

<img height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-09 at 16 24 18" src="https://github.com/user-attachments/assets/4db94c50-a72f-4ec3-826f-4bb4636402d3" />

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
