### PR TITLE
[#1511] In library update alert message inline alert button checkbox item radio button item switch item suggestion chip filter chip link tag and text input to allow the use of fixed images

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Load skills on demand for detailed guidance:
 - **`ouds-ios-vocabulary`** — glossary of OUDS-specific terms (tokenator, token types, theme, …)
 - **`ouds-ios-framework-usage`** — full usage reference: imports, themes, tokens, view modifiers, all components with code examples
 - **`ouds-ios-figma-to-swift`** — how to derive a Swift token name from a Figma token path (raw, semantic and component tokens)
+- **`ouds-ios-migration`** — step-by-step migration guide from v1.0.0 to v2.3.0 (current); covers all breaking changes, removed APIs and deprecated symbols
 
 ## Key files
 
@@ -35,6 +36,7 @@ Load skills on demand for detailed guidance:
 - Always load the **`ouds-ios-vocabulary`** skill before discussing tokens or themes.
 - Always load the **`ouds-ios-framework-usage`** skill before writing or reviewing code that uses OUDS components or tokens.
 - Always load the **`ouds-ios-figma-to-swift`** skill when asked to find or map a Figma token name to its Swift equivalent.
+- Always load the **`ouds-ios-migration`** skill when the user wants to migrate OUDS code or when deprecated OUDS API usages are detected.
 - Before committing: format → build → fix errors → run tests → lint (see `.github/copilot-instructions.md` §3).
 - Use `#available` for iOS 26 SDK APIs (min deployment is iOS 15).
 - Use `#if os(…)` for platform-specific code.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `badge` umbrella component managing the three variants (Orange-OpenSource/ouds-ios#1439)
+## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...develop)
+
+### Added
+
+- Use of original image for components (Orange-OpenSource/ouds-ios#1511)
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.0.0...2.1.0) - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Use of original image possible for components with icons (Orange-OpenSource/ouds-ios#1511)
 - View modifier to fill colors on `Shape`
 - Helper to register local fonts configurations for custom themes
-## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...develop)
-
-### Added
-
-- Use of original image possible for components with icons (Orange-OpenSource/ouds-ios#1511)
 
 ## [2.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...2.2.0) - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Migration skill for AI agents
 - Use of original image possible for components with icons (Orange-OpenSource/ouds-ios#1511)
 - View modifier to fill colors on `Shape`
 - Helper to register local fonts configurations for custom themes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Use of original image for components (Orange-OpenSource/ouds-ios#1511)
+- Use of original image possible for components with icons (Orange-OpenSource/ouds-ios#1511)
 
 ## [2.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...2.2.0) - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - View modifier to fill colors on `Shape`
 - Helper to register local fonts configurations for custom themes
+## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...develop)
+
+### Added
+
+- Use of original image for components (Orange-OpenSource/ouds-ios#1511)
 
 ## [2.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...2.2.0) - 2026-06-18
 
@@ -36,11 +41,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 
 - `badge` umbrella component managing the three variants (Orange-OpenSource/ouds-ios#1439)
-## [Unreleased](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...develop)
-
-### Added
-
-- Use of original image for components (Orange-OpenSource/ouds-ios#1511)
 
 ## [2.1.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.0.0...2.1.0) - 2026-06-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - View modifier to fill colors on `Shape`
 - Helper to register local fonts configurations for custom themes
 
+### Deprecated
+
+- Components with several configuration parameters for images (Orange-OpenSource/ouds-ios#1511)
+
 ## [2.2.0](https://github.com/Orange-OpenSource/ouds-ios/compare/2.1.0...2.2.0) - 2026-06-18
 
 ### Added

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -298,6 +298,98 @@ OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: 
 
 **Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSSwitchItem` with the same pattern applied to `OUDSButton`, `OUDSCheckboxItem`, `OUDSRadioItem` and other components.
 
+### Deprecated OUDSFilterChip and OUDSSuggestionChip initialisers with `icon: Image` parameter
+
+Initialisers of `OUDSFilterChip` and `OUDSSuggestionChip` that accepted a bare `Image` together with a separate `renderingMode` parameter are deprecated.
+Use the new initialisers that accept an `OUDSImage` value instead.
+
+**Impact**: Low
+
+**Note**: Unlike other components, chips do **not** support `flipIcon` — `OUDSImage.flipped` is not used here.
+The `accessibilityLabel` parameter remains on the chip itself; do not set it on `OUDSImage`.
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
+OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") {}
+OUDSSuggestionChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
+
+OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
+OUDSFilterChip(icon: Image("ic_heart"), text: "Heart", selected: true) {}
+OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+```
+
+**Required Action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+3. Remove the now-unused `renderingMode` parameter from the chip call site
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns the chip components with the same pattern applied to all other OUDS components.
+
+### OUDSChipPickerData.Layout — new static factories for OUDSImage
+
+The `@frozen` enum `OUDSChipPickerData.Layout` has been enriched with two static factory methods accepting `OUDSImage`.
+The existing cases `.icon(icon:accessibilityLabel:renderingMode:)` and `.textAndIcon(text:icon:renderingMode:)` remain available for backward compatibility.
+
+**Impact**: Low — additive change, no breaking change.
+
+**Before (v2.2.0)**:
+```swift
+OUDSChipPickerData(tag: .x,
+                   layout: .icon(icon: Image("ic_heart"), accessibilityLabel: "Heart"))
+OUDSChipPickerData(tag: .y,
+                   layout: .icon(icon: Image("ic_brand"), accessibilityLabel: "Brand",
+                                 renderingMode: .original))
+OUDSChipPickerData(tag: .z,
+                   layout: .textAndIcon("Label", icon: Image("ic_heart")))
+OUDSChipPickerData(tag: .w,
+                   layout: .textAndIcon("Brand", icon: Image("ic_brand"),
+                                        renderingMode: .original))
+```
+
+**After (v2.3.0)** — preferred new form using static factories:
+```swift
+OUDSChipPickerData(tag: .x,
+                   layout: .icon(OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart"))
+OUDSChipPickerData(tag: .y,
+                   layout: .icon(OUDSImage(asset: Image("ic_brand"), renderingMode: .original),
+                                 accessibilityLabel: "Brand"))
+OUDSChipPickerData(tag: .z,
+                   layout: .textAndIcon("Label", image: OUDSImage(asset: Image("ic_heart"))))
+OUDSChipPickerData(tag: .w,
+                   layout: .textAndIcon("Brand",
+                                        image: OUDSImage(asset: Image("ic_brand"),
+                                                         renderingMode: .original)))
+```
+
+**Required Action**:
+- Migrate to the new static factory form to avoid passing `renderingMode` separately
+- The old case-based form continues to compile and remains valid
+
+**Reason for Change**: `@frozen` is preserved for ABI stability. Static factories provide a cleaner API aligned with `OUDSImage` without requiring a breaking enum change.
+
 ### Compatibility
 
 - **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -432,6 +432,50 @@ OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand")
 
 **Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSTag.Status` with the same pattern applied to all other OUDS components.
 
+### Deprecated OUDSLink initialisers with `icon: Image` parameter
+
+The two `OUDSLink` initialisers that accepted a bare `Image` together with a separate `renderingMode` parameter are deprecated.
+Use the new overloads that accept an `OUDSImage?` value instead.
+
+> The navigation initialisers (`init(text:indicator:size:action:)` and `init(_:tableName:bundle:indicator:size:action:)`) are **unchanged**.
+> `OUDSLink` does not support `flipIcon` for custom icons — only navigation indicators are automatically flipped for RTL.
+
+**Impact**: Low
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSLink(text: "Learn more", icon: Image("ic_heart"), size: .default) {}
+OUDSLink(text: "Brand", icon: Image("ic_brand"), renderingMode: .original, size: .default) {}
+OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
+         icon: Image("ic_heart"), size: .default) {}
+OUDSLink(LocalizedStringKey("brand"), bundle: Bundle.module,
+         icon: Image("ic_brand"), renderingMode: .original, size: .default) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
+         icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+OUDSLink(LocalizedStringKey("brand"), bundle: Bundle.module,
+         icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+```
+
+**Required Action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+3. Remove the now-unused `renderingMode` parameter from the call site
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSLink` with the same pattern applied to all other OUDS components.
+
 ### Compatibility
 
 - **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -129,14 +129,14 @@ OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn:
 **After (v2.3.0)**:
 ```swift
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+                 image: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+                 image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-                                 flipped: layoutDirection == .rightToLeft))
+                 image: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                  flipped: layoutDirection == .rightToLeft))
 OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+                 image: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
 ```
 
 #### OUDSCheckboxItemIndeterminate
@@ -152,13 +152,13 @@ OUDSCheckboxItemIndeterminate("Label", selection: $state,
 **After (v2.3.0)**:
 ```swift
 OUDSCheckboxItemIndeterminate("Label", selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+                               image: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
 OUDSCheckboxItemIndeterminate("Label", selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+                               image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 
 // New in v2.3.0: LocalizedStringKey variant now available
 OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module, selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+                               image: OUDSImage(asset: Image(decorative: "ic_heart")))
 ```
 
 #### OUDSCheckboxPickerData
@@ -173,13 +173,13 @@ OUDSCheckboxPickerData(tag: "b", label: "Option B",
 **After (v2.3.0)**:
 ```swift
 OUDSCheckboxPickerData(tag: "a", label: "Option A",
-                       icon: OUDSImage(asset: Image(systemName: "flame")))
+                       image: OUDSImage(asset: Image(systemName: "flame")))
 OUDSCheckboxPickerData(tag: "b", label: "Option B",
-                       icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+                       image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 ```
 
 **Required Action**:
-1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+1. Replace every `icon: Image(…)` parameter with `image: OUDSImage(asset: Image(…))`
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
@@ -216,14 +216,14 @@ OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $
 **After (v2.3.0)**:
 ```swift
 OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+              image: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
 OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+              image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
-                              flipped: layoutDirection == .rightToLeft))
+              image: OUDSImage(asset: Image(systemName: "chevron.right"),
+                               flipped: layoutDirection == .rightToLeft))
 OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+              image: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
 ```
 
 #### OUDSRadioPickerData
@@ -238,13 +238,13 @@ OUDSRadioPickerData(tag: "b", label: "Option B",
 **After (v2.3.0)**:
 ```swift
 OUDSRadioPickerData(tag: "a", label: "Option A",
-                    icon: OUDSImage(asset: Image(systemName: "flame")))
+                    image: OUDSImage(asset: Image(systemName: "flame")))
 OUDSRadioPickerData(tag: "b", label: "Option B",
-                    icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+                    image: OUDSImage(asset: Image(decorative: "il_brand")))
 ```
 
 **Required Action**:
-1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+1. Replace every `icon: Image(…)` parameter with `image: OUDSImage(asset: Image(…))`
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
@@ -280,18 +280,18 @@ OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: 
 **After (v2.3.0)**:
 ```swift
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+               image: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+               image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-                               flipped: layoutDirection == .rightToLeft))
+               image: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                flipped: layoutDirection == .rightToLeft))
 OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "ic_wifi"), renderingMode: .original))
+               image: OUDSImage(asset: Image(decorative: "ic_wifi"), renderingMode: .original))
 ```
 
 **Required Action**:
-1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+1. Replace every `icon: Image(…)` parameter with `image: OUDSImage(asset: Image(…))`
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
@@ -312,8 +312,15 @@ The `accessibilityLabel` parameter remains on the chip itself; do not set it on 
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` (FilterChip) / `icon: OUDSImage(asset: Image(…))` (SuggestionChip — see note) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+> **Note on parameter label differences between the two chip components:**
+>
+> `OUDSFilterChip` active initialisers all use `image: OUDSImage` as the parameter label.
+>
+> `OUDSSuggestionChip` active initialisers use `image: OUDSImage` only for the `LocalizedStringKey text` variant.
+> The three other active initialisers (`text: String`, `accessibilityLabel: String`, `accessibilityLabel: LocalizedStringKey`) keep `icon: OUDSImage` as the parameter label — this is intentional and does not cause ambiguity since the `OUDSImage` type differs from the deprecated `Image` type.
 
 **Before (v2.2.0)**:
 ```swift
@@ -330,23 +337,27 @@ OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original)
 
 **After (v2.3.0)**:
 ```swift
+// OUDSSuggestionChip — icon: OUDSImage (parameter label unchanged for these 3 variants)
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+// OUDSFilterChip — image: OUDSImage (parameter label renamed from icon: to image:)
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 ```
 
 **Required Action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+1. Replace `icon: Image(…)` with `OUDSImage(asset: Image(…))`
 2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 3. Remove the now-unused `renderingMode` parameter from the chip call site
+4. For `OUDSFilterChip`: rename the parameter label from `icon:` to `image:`
+5. For `OUDSSuggestionChip`: keep `icon:` as the parameter label (except the `LocalizedStringKey text` variant which uses `image:`)
 
-**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns the chip components with the same pattern applied to all other OUDS components.
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns the chip components with the same pattern applied to all other OUDS components. `OUDSFilterChip` additionally renames `icon:` to `image:` to resolve a potential init ambiguity; `OUDSSuggestionChip` retains `icon:` on most variants because the `OUDSImage` / `Image` type distinction already prevents ambiguity.
 
 ### OUDSChipPickerData.Layout — new static factories for OUDSImage
 
@@ -461,16 +472,16 @@ OUDSLink(LocalizedStringKey("brand"), bundle: Bundle.module,
 
 **After (v2.3.0)**:
 ```swift
-OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
-OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+OUDSLink(text: "Learn more", image: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+OUDSLink(text: "Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
 OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
-         icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+         image: OUDSImage(asset: Image("ic_heart")), size: .default) {}
 OUDSLink(LocalizedStringKey("brand"), bundle: Bundle.module,
-         icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+         image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
 ```
 
 **Required Action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+1. Replace `icon: Image(…)` with `image: OUDSImage(asset: Image(…))`
 2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 3. Remove the now-unused `renderingMode` parameter from the call site
 
@@ -488,7 +499,7 @@ Both `OUDSTextInput` and its nested `TrailingAction` struct have been updated to
 
 | Old parameter | New location |
 |---|---|
-| `leadingIcon: Image(…)` | `leadingIcon: OUDSImage(asset: Image(…))` |
+| `leadingIcon: Image(…)` | `leadingImage: OUDSImage(asset: Image(…))` |
 | `flipLeadingIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
 | `leadingIconRenderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
@@ -501,9 +512,9 @@ OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), flipLeading
 
 **After (v2.3.0)**:
 ```swift
-OUDSTextInput(label: "Email", text: $text, leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
-OUDSTextInput(label: "Brand", text: $text, leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
-OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic"), flipped: true))
+OUDSTextInput(label: "Email", text: $text, leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
+OUDSTextInput(label: "Brand", text: $text, leadingImage: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+OUDSTextInput(label: "Label", text: $text, leadingImage: OUDSImage(asset: Image("ic"), flipped: true))
 ```
 
 #### OUDSTextInput.TrailingAction
@@ -529,13 +540,93 @@ OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), rendering
 ```
 
 **Required Action**:
-1. Replace `leadingIcon: Image(…)` with `leadingIcon: OUDSImage(asset: Image(…))`
+1. Replace `leadingIcon: Image(…)` with `leadingImage: OUDSImage(asset: Image(…))`
 2. Move `flipLeadingIcon:` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `leadingIconRenderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(icon: OUDSImage(asset: Image(…)), …)`
 5. Move `flipIcon:` and `renderingMode:` inside the `OUDSImage` construction
 
 **Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSTextInput` with the same pattern applied to all other OUDS components.
+
+### Renamed `image:` and `leadingImage:` parameters in active initialisers
+
+Following the introduction of `OUDSImage`-based initialisers in the same release, a secondary naming ambiguity was discovered: because the deprecated initialisers keep `icon: Image? = nil` and the new active initialisers had `icon: OUDSImage? = nil`, Swift could not always resolve which overload to call when `nil` was passed (or the parameter was omitted).
+
+To resolve this, the active initialisers have been updated to use a distinct parameter label:
+- `icon: OUDSImage?` → `image: OUDSImage?`
+- `leadingIcon: OUDSImage?` → `leadingImage: OUDSImage?`
+
+The deprecated initialisers (`icon: Image?`, `leadingIcon: Image?`) are **unchanged**.
+
+**Impact**: Low
+
+**Components affected**:
+
+| Component | Old parameter (active init) | New parameter (active init) |
+|---|---|---|
+| `OUDSCheckboxItem` | `icon: OUDSImage?` | `image: OUDSImage?` |
+| `OUDSCheckboxItemIndeterminate` | `icon: OUDSImage?` | `image: OUDSImage?` |
+| `OUDSCheckboxPickerData` | `icon: OUDSImage?` | `image: OUDSImage?` |
+| `OUDSRadioItem` | `icon: OUDSImage?` | `image: OUDSImage?` |
+| `OUDSRadioPickerData` | `image: OUDSImage?` | unchanged (was already `image:`) |
+| `OUDSSwitchItem` | `icon: OUDSImage?` | `image: OUDSImage?` |
+| `OUDSTextInput` | `leadingIcon: OUDSImage?` | `leadingImage: OUDSImage?` |
+| `OUDSLink` | `icon: OUDSImage?` | `image: OUDSImage?` |
+
+**Before**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image("ic_heart")))
+OUDSCheckboxItemIndeterminate("Label", selection: $state, icon: OUDSImage(asset: Image("ic_heart")))
+OUDSCheckboxPickerData(tag: "a", label: "Option A", icon: OUDSImage(asset: Image(systemName: "flame")))
+OUDSRadioItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image("ic_heart")))
+OUDSSwitchItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image("ic_heart")))
+OUDSTextInput(label: "Email", text: $text, leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+```
+
+**After**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn, image: OUDSImage(asset: Image("ic_heart")))
+OUDSCheckboxItemIndeterminate("Label", selection: $state, image: OUDSImage(asset: Image("ic_heart")))
+OUDSCheckboxPickerData(tag: "a", label: "Option A", image: OUDSImage(asset: Image(systemName: "flame")))
+OUDSRadioItem("Label", isOn: $isOn, image: OUDSImage(asset: Image("ic_heart")))
+OUDSSwitchItem("Label", isOn: $isOn, image: OUDSImage(asset: Image("ic_heart")))
+OUDSTextInput(label: "Email", text: $text, leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
+OUDSLink(text: "Learn more", image: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+```
+
+**Required Action**:
+1. In any call site using `icon: OUDSImage(…)` on the above components, rename the label to `image:`
+2. In any call site using `leadingIcon: OUDSImage(…)` on `OUDSTextInput`, rename to `leadingImage:`
+3. Call sites using the deprecated `icon: Image(…)` form are **not affected** — they continue to compile with a deprecation warning
+
+**Reason for Change**: Swift cannot resolve `nil` between `icon: Image? = nil` (deprecated) and `icon: OUDSImage? = nil` (active) when the parameter is omitted, causing a compile-time ambiguity. Using distinct labels (`image:`, `leadingImage:`) removes the ambiguity without breaking the deprecated API.
+
+> **⚠ Residual ambiguity warning**
+>
+> Even after this rename, a call site that omits the image parameter entirely may still trigger a Swift compile-time ambiguity, because both the deprecated init (e.g. `icon: Image? = nil`) and the active init (e.g. `image: OUDSImage? = nil`) can be invoked with no image argument.
+>
+> **Symptom**: `error: ambiguous use of 'init(...)'`
+>
+> **Fix**: Pass the image parameter explicitly as `nil` to force Swift to select the active init:
+>
+> ```swift
+> // ❌ may be ambiguous while deprecated inits coexist:
+> OUDSCheckboxItem("Label", isOn: $isOn)
+> OUDSRadioItem("Label", isOn: $isOn)
+> OUDSSwitchItem("Label", isOn: $isOn)
+> OUDSLink(text: "Learn more", size: .default) {}
+> OUDSTextInput(label: "Email", text: $text)
+>
+> // ✅ unambiguous — active init selected:
+> OUDSCheckboxItem("Label", isOn: $isOn, image: nil)
+> OUDSRadioItem("Label", isOn: $isOn, image: nil)
+> OUDSSwitchItem("Label", isOn: $isOn, image: nil)
+> OUDSLink(text: "Learn more", image: nil, size: .default) {}
+> OUDSTextInput(label: "Email", text: $text, leadingImage: nil)
+> ```
+>
+> This workaround is only needed until the deprecated initialisers are removed in v3.
 
 ### Compatibility
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -99,10 +99,209 @@ OUDSButton(image: OUDSImage(asset: Image("ic_heart"), accessibilityLabel: Locali
 
 **Reason for Change**: Grouping image-related parameters (`icon`, `flipIcon`, `renderingMode`, `accessibilityLabel`) into one `OUDSImage` object makes the call site cleaner, reduces the number of parameters on `OUDSButton`, and aligns with the same pattern used by other components (`OUDSLink`, `OUDSSuggestionChip`, `OUDSFilterChip`, …).
 
+### Deprecated OUDSCheckboxItem, OUDSCheckboxItemIndeterminate and OUDSCheckboxPickerData initialisers with `icon` parameter
+
+Initialisers of `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate` and `OUDSCheckboxPickerData` that accepted a bare `Image` together with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Use the new initialisers that accept an `OUDSImage?` value instead; `OUDSImage` encapsulates the asset, the flip flag and the rendering mode in one object.
+
+**Impact**: Low
+
+**Parameter mapping** (applies to all three types):
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+#### OUDSCheckboxItem
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"), isReversed: true)
+OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(systemName: "figure.handball"),
+                 flipIcon: layoutDirection == .rightToLeft)
+OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
+                 icon: Image(decorative: "ic_heart"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                 flipped: layoutDirection == .rightToLeft))
+OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+```
+
+#### OUDSCheckboxItemIndeterminate
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: Image(decorative: "ic_heart"), isReversed: true)
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: Image(decorative: "il_brand"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+
+// New in v2.3.0: LocalizedStringKey variant now available
+OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module, selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+```
+
+#### OUDSCheckboxPickerData
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
+OUDSCheckboxPickerData(tag: "b", label: "Option B",
+                       icon: Image(decorative: "il_brand"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxPickerData(tag: "a", label: "Option A",
+                       icon: OUDSImage(asset: Image(systemName: "flame")))
+OUDSCheckboxPickerData(tag: "b", label: "Option B",
+                       icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+```
+
+**Required Action**:
+1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object reduces the number of parameters, makes the call site cleaner, and aligns `OUDSCheckboxItem` with the same pattern applied to `OUDSButton` and other components.
+
+### Deprecated OUDSRadioItem and OUDSRadioPickerData initialisers with `icon` parameter
+
+Initialisers of `OUDSRadioItem` and `OUDSRadioPickerData` that accepted a bare `Image` together with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Use the new initialisers that accept an `OUDSImage?` value instead.
+
+**Impact**: Low
+
+**Parameter mapping** (applies to both types):
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+#### OUDSRadioItem
+
+**Before (v2.2.0)**:
+```swift
+OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"), isReversed: true)
+OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSRadioItem("Label", isOn: $isOn, icon: Image(systemName: "chevron.right"),
+              flipIcon: layoutDirection == .rightToLeft)
+OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
+              icon: Image(decorative: "ic_heart"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
+                              flipped: layoutDirection == .rightToLeft))
+OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+```
+
+#### OUDSRadioPickerData
+
+**Before (v2.2.0)**:
+```swift
+OUDSRadioPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
+OUDSRadioPickerData(tag: "b", label: "Option B",
+                    icon: Image(decorative: "il_brand"))
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSRadioPickerData(tag: "a", label: "Option A",
+                    icon: OUDSImage(asset: Image(systemName: "flame")))
+OUDSRadioPickerData(tag: "b", label: "Option B",
+                    icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+```
+
+**Required Action**:
+1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object reduces the number of parameters, makes the call site cleaner, and aligns `OUDSRadioItem` with the same pattern applied to `OUDSButton`, `OUDSCheckboxItem` and other components.
+
+### Deprecated OUDSSwitchItem initialisers with `icon` parameter
+
+Initialisers of `OUDSSwitchItem` that accepted a bare `Image` together with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Use the new initialisers that accept an `OUDSImage?` value instead.
+
+**Impact**: Low
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSSwitchItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"), isReversed: true)
+OUDSSwitchItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: Image(systemName: "figure.handball"),
+               flipIcon: layoutDirection == .rightToLeft)
+OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
+               icon: Image(decorative: "ic_wifi"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "ic_heart")), isReversed: true)
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+                               flipped: layoutDirection == .rightToLeft))
+OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "ic_wifi"), renderingMode: .original))
+```
+
+**Required Action**:
+1. Replace every `icon: Image(…)` parameter with `icon: OUDSImage(asset: Image(…))`
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSSwitchItem` with the same pattern applied to `OUDSButton`, `OUDSCheckboxItem`, `OUDSRadioItem` and other components.
+
 ### Compatibility
 
 - **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning
-- **v2.2.0 Support**: None
+- **v2.2.0 Support**: Until next major version
 
 ## v2.0.0 → v2.2.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,6 @@
 # Migration Guide
 
+- [v2.2.0 → v2.3.0](#v220--v230)
 - [v2.0.0 → v2.2.0](#v200--v220)
 - [v1.4.0 → v2.0.0](#v140--v200)
 - [v1.3.0 → v1.4.0](#v130--v140)
@@ -7,6 +8,42 @@
 - [v1.1.0 → v1.2.0](#v110--v120)
 - [v1.0.0 → v1.1.0](#v100--v110)
 - [Support](#support)
+
+## v2.2.0 → v2.3.0
+
+### Overview
+
+Work on original images integrations in components brings API updates to group parameters related
+to images / icons into one single object type. `OUDSIcon` is now `OUDSImage`.
+
+### Before You Begin
+
+#### Prerequisites
+
+- Use version 2.2 or older
+
+### Renmaed OUDSIcon
+
+The `OUDSIcon` type is deprecated. Use instead `OUDSImage`.
+
+**Impact**: Low
+
+**Before (v2.2.0)**:
+```swift
+OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+```
+
+**Required Action**:
+- Rename the `OUDSIcon` calls by `OUDSImage`
+
+**Reason for Change**: "icon" is too strict in meanings, "image" is more open.
 
 ## v2.0.0 → v2.2.0
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -390,6 +390,48 @@ OUDSChipPickerData(tag: .w,
 
 **Reason for Change**: `@frozen` is preserved for ABI stability. Static factories provide a cleaner API aligned with `OUDSImage` without requiring a breaking enum change.
 
+### Deprecated OUDSTag.Status factories with `icon: Image` parameter
+
+The static factories `OUDSTag.Status.neutral(icon:flipIcon:renderingMode:)` and `OUDSTag.Status.accent(icon:flipIcon:renderingMode:)` are deprecated.
+Use the new overloads that accept an `OUDSImage` value instead.
+
+> Only the `.neutral(icon:)` and `.accent(icon:)` factories are affected.
+> All other factories (`.positive`, `.negative`, `.warning`, `.info`, `.neutral(bullet:)`, `.accent(bullet:)`) are unchanged.
+
+**Impact**: Low
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
+OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
+OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: .original))
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+```
+
+**Required Action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the factory call
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSTag.Status` with the same pattern applied to all other OUDS components.
+
 ### Compatibility
 
 - **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -476,6 +476,67 @@ OUDSLink(LocalizedStringKey("brand"), bundle: Bundle.module,
 
 **Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSLink` with the same pattern applied to all other OUDS components.
 
+### Deprecated OUDSTextInput initialisers and OUDSTextInput.TrailingAction
+
+Both `OUDSTextInput` and its nested `TrailingAction` struct have been updated to accept `OUDSImage` instead of separate `Image`, `flipIcon`/`flipLeadingIcon`, and `renderingMode` parameters.
+
+**Impact**: Low
+
+#### OUDSTextInput — leadingIcon
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `leadingIcon: Image(…)` | `leadingIcon: OUDSImage(asset: Image(…))` |
+| `flipLeadingIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `leadingIconRenderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSTextInput(label: "Email", text: $text, leadingIcon: Image(systemName: "envelope"))
+OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), flipLeadingIcon: true)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTextInput(label: "Email", text: $text, leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+OUDSTextInput(label: "Brand", text: $text, leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic"), flipped: true))
+```
+
+#### OUDSTextInput.TrailingAction
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
+OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", renderingMode: .original) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
+OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), actionHint: "Brand") {}
+```
+
+**Required Action**:
+1. Replace `leadingIcon: Image(…)` with `leadingIcon: OUDSImage(asset: Image(…))`
+2. Move `flipLeadingIcon:` → `OUDSImage(asset:, flipped:)` (omit if `false`)
+3. Move `leadingIconRenderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
+4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(icon: OUDSImage(asset: Image(…)), …)`
+5. Move `flipIcon:` and `renderingMode:` inside the `OUDSImage` construction
+
+**Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSTextInput` with the same pattern applied to all other OUDS components.
+
 ### Compatibility
 
 - **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -110,7 +110,7 @@ Use the new initialisers that accept an `OUDSImage?` value instead; `OUDSImage` 
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` |
 | `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
@@ -197,7 +197,7 @@ Use the new initialisers that accept an `OUDSImage?` value instead.
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` |
 | `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
@@ -262,7 +262,7 @@ Use the new initialisers that accept an `OUDSImage?` value instead.
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` |
 | `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
@@ -312,7 +312,7 @@ The `accessibilityLabel` parameter remains on the chip itself; do not set it on 
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` (FilterChip) / `icon: OUDSImage(asset: Image(…))` (SuggestionChip — see note) |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` (FilterChip) / `image: OUDSImage(asset: Image(…))` (SuggestionChip — see note) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
 > **Note on parameter label differences between the two chip components:**
@@ -338,10 +338,10 @@ OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original)
 **After (v2.3.0)**:
 ```swift
 // OUDSSuggestionChip — icon: OUDSImage (parameter label unchanged for these 3 variants)
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 
 // OUDSFilterChip — image: OUDSImage (parameter label renamed from icon: to image:)
 OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
@@ -404,7 +404,7 @@ OUDSChipPickerData(tag: .w,
 ### Deprecated OUDSTag.Status factories with `icon: Image` parameter
 
 The static factories `OUDSTag.Status.neutral(icon:flipIcon:renderingMode:)` and `OUDSTag.Status.accent(icon:flipIcon:renderingMode:)` are deprecated.
-Use the new overloads that accept an `OUDSImage` value instead.
+Use the new overloads that accept an `OUDSImage` value instead with parameter named `image` instead of `icon`.
 
 > Only the `.neutral(icon:)` and `.accent(icon:)` factories are affected.
 > All other factories (`.positive`, `.negative`, `.warning`, `.info`, `.neutral(bullet:)`, `.accent(bullet:)`) are unchanged.
@@ -429,14 +429,14 @@ OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: 
 
 **After (v2.3.0)**:
 ```swift
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
-OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"))))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
 ```
 
 **Required Action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`
+1. Replace `icon: Image(…)` with `image: OUDSImage(asset: Image(…))`
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the factory call
@@ -457,7 +457,7 @@ Use the new overloads that accept an `OUDSImage?` value instead.
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
 **Before (v2.2.0)**:
@@ -523,7 +523,7 @@ OUDSTextInput(label: "Label", text: $text, leadingImage: OUDSImage(asset: Image(
 
 | Old parameter | New location |
 |---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `icon: Image(…)` | `image: OUDSImage(asset: Image(…))` |
 | `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
 | `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
 
@@ -535,15 +535,15 @@ OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", rende
 
 **After (v2.3.0)**:
 ```swift
-OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
-OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), actionHint: "Brand") {}
+OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
+OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), actionHint: "Brand") {}
 ```
 
 **Required Action**:
 1. Replace `leadingIcon: Image(…)` with `leadingImage: OUDSImage(asset: Image(…))`
 2. Move `flipLeadingIcon:` → `OUDSImage(asset:, flipped:)` (omit if `false`)
 3. Move `leadingIconRenderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`)
-4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(icon: OUDSImage(asset: Image(…)), …)`
+4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(image: OUDSImage(asset: Image(…)), …)`
 5. Move `flipIcon:` and `renderingMode:` inside the `OUDSImage` construction
 
 **Reason for Change**: Grouping image-related parameters into one `OUDSImage` object aligns `OUDSTextInput` with the same pattern applied to all other OUDS components.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,7 +22,7 @@ to images / icons into one single object type. `OUDSIcon` is now `OUDSImage`.
 
 - Use version 2.2 or older
 
-### Renmaed OUDSIcon
+### Renamed OUDSIcon
 
 The `OUDSIcon` type is deprecated. Use instead `OUDSImage`.
 
@@ -44,6 +44,65 @@ OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .
 - Rename the `OUDSIcon` calls by `OUDSImage`
 
 **Reason for Change**: "icon" is too strict in meanings, "image" is more open.
+
+### Deprecated OUDSButton initialisers with `icon` parameter
+
+`OUDSButton` initialisers that accepted a bare `Image` together with separate `icon`, `flipIcon`, `renderingMode` and `accessibilityLabel` parameters are deprecated.
+Use the new initialisers that accept an `OUDSImage` value instead; `OUDSImage` encapsulates the asset, the flip flag, the rendering mode and the accessibility label in one object.
+
+**Impact**: Low
+
+**Before (v2.2.0)**:
+
+```swift
+// Text + icon (String label)
+OUDSButton(text: "Like", icon: Image("ic_heart"), appearance: .default) {}
+
+// Text + icon (flipped for RTL, original rendering)
+OUDSButton(text: "Back", icon: Image("ic_chevron"), flipIcon: true, renderingMode: .original, appearance: .default) {}
+
+// Text + icon (LocalizedStringKey)
+OUDSButton(LocalizedStringKey("action_like"), icon: Image("ic_heart"), appearance: .default) {}
+
+// Icon only (String accessibility label)
+OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) {}
+
+// Icon only (LocalizedStringKey accessibility label)
+OUDSButton(icon: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module, appearance: .default) {}
+```
+
+**After (v2.3.0)**:
+
+```swift
+// Text + icon (no accessibility label needed on OUDSImage — decorative in this context)
+OUDSButton(text: "Like", image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
+
+// Text + icon (flipped for RTL, original rendering)
+OUDSButton(text: "Back", image: OUDSImage(asset: Image("ic_chevron"), flipped: true, renderingMode: .original), appearance: .default) {}
+
+// Text + icon (LocalizedStringKey)
+OUDSButton(LocalizedStringKey("action_like"), image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
+
+// Icon only — accessibilityLabel is now carried by OUDSImage
+OUDSButton(image: OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like"), appearance: .default) {}
+
+// Icon only — LocalizedStringKey accessibility label
+OUDSButton(image: OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module), appearance: .default) {}
+```
+
+**Required Action**:
+1. Replace every `icon: Image(…)` parameter with `image: OUDSImage(asset: Image(…))`
+2. Move the `flipIcon: Bool` value to `OUDSImage(asset:flipped:)` (parameter renamed `flipped`)
+3. Move the `renderingMode:` value to `OUDSImage(asset:renderingMode:)`
+4. Move the `accessibilityLabel:` value (both `String` and `LocalizedStringKey` forms) to `OUDSImage(asset:accessibilityLabel:)` or `OUDSImage(asset:accessibilityLabel:tableName:bundle:)`
+5. Remove the now-unused `flipIcon`, `renderingMode` and `accessibilityLabel` parameters from the `OUDSButton` call site
+
+**Reason for Change**: Grouping image-related parameters (`icon`, `flipIcon`, `renderingMode`, `accessibilityLabel`) into one `OUDSImage` object makes the call site cleaner, reduces the number of parameters on `OUDSButton`, and aligns with the same pattern used by other components (`OUDSLink`, `OUDSSuggestionChip`, `OUDSFilterChip`, …).
+
+### Compatibility
+
+- **Backward Compatibility**: Yes — deprecated initialisers still compile with a warning
+- **v2.2.0 Support**: None
 
 ## v2.0.0 → v2.2.0
 

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -73,8 +73,7 @@ import SwiftUI
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
 ///     OUDSButton(text: "Button",
-///                image: OUDSImage(asset: Image(systemName: "figure.handball")),
-///                flipIcon: layoutDirection == .rightToLeft)
+///                image: OUDSImage(asset: Image(systemName: "figure.handball"), flipped: layoutDirection == .rightToLeft))
 /// ```
 ///
 /// ## Styles

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -45,6 +45,8 @@ import SwiftUI
 ///     OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) { /* the action to process */ }
 ///     // Or simpler
 ///     OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like") { /* the action to process */ }
+///     // With an image to keep raw without tint
+///     OUDSButton(icon: Image("il_someImage"), accessibilityLabel: "Like", renderingMode: .original) { /* the action to process */ }
 ///
 ///     // Text only with negative appearance
 ///     OUDSButton(text: "Delete", appearance: .negative,  style: .default) { /* the action to process */ }
@@ -141,11 +143,12 @@ public struct OUDSButton: View {
 
     private enum `Type` {
         case text(String)
-        case icon(Image, flipIcon: Bool, String)
-        case textAndIcon(text: String, icon: Image, flipIcon: Bool)
+        case icon(Image, flipIcon: Bool, renderingMode: Image.TemplateRenderingMode, String)
+        case textAndIcon(text: String, icon: Image, flipIcon: Bool, renderingMode: Image.TemplateRenderingMode)
     }
 
     /// Represents the appearance of an OUDS button, i.e. a kind of type
+    ///
     /// - Since: 0.10.0
     @frozen public enum Appearance {
         /// Default button is used for action
@@ -165,6 +168,7 @@ public struct OUDSButton: View {
     }
 
     /// Defines the style of the button, e.g. loading or not
+    ///
     /// - Since: 0.10.0
     @frozen public enum Style {
         /// The default style, the button could be in prossed, hover, disabled or enabled internal state
@@ -191,6 +195,7 @@ public struct OUDSButton: View {
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - icon: An image which shoud contains an icon
     ///    - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
@@ -200,13 +205,14 @@ public struct OUDSButton: View {
                 bundle: Bundle = .main,
                 icon: Image,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 appearance: Appearance = .default,
                 style: Style = .default,
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(text: resolvedText, icon: icon, flipIcon: flipIcon, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
+        self.init(text: resolvedText, icon: icon, flipIcon: flipIcon, renderingMode: renderingMode, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
     }
 
     // swiftlint:enable function_default_parameter_at_end
@@ -221,6 +227,7 @@ public struct OUDSButton: View {
     ///    - text: The text to display in the button
     ///    - icon: An image which shoud contains an icon
     ///    - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
@@ -228,12 +235,13 @@ public struct OUDSButton: View {
     public init(text: String,
                 icon: Image,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 appearance: Appearance = .default,
                 style: Style = .default,
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        type = .textAndIcon(text: text, icon: icon, flipIcon: flipIcon)
+        type = .textAndIcon(text: text, icon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
         self.appearance = appearance
         self.style = style
         self.isFullWidth = isFullWidth
@@ -249,6 +257,7 @@ public struct OUDSButton: View {
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
@@ -258,6 +267,7 @@ public struct OUDSButton: View {
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 appearance: Appearance = .default,
                 style: Style = .default,
                 isFullWidth: Bool = false,
@@ -277,6 +287,7 @@ public struct OUDSButton: View {
     ///    - icon: An image which shoud contains an icon
     ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the button action
     ///    - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///    - appearance: The button appearance, default set to `.default`
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
@@ -284,12 +295,13 @@ public struct OUDSButton: View {
     public init(icon: Image,
                 accessibilityLabel: String,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 appearance: Appearance = .default,
                 style: Style = .default,
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        type = .icon(icon, flipIcon: flipIcon, accessibilityLabel)
+        type = .icon(icon, flipIcon: flipIcon, renderingMode: renderingMode, accessibilityLabel)
         self.appearance = appearance
         self.style = style
         self.isFullWidth = isFullWidth
@@ -361,12 +373,12 @@ public struct OUDSButton: View {
 
         Button(action: action) {
             switch type {
-            case let .icon(icon, flipped, _):
-                ButtonIcon(icon: icon, flipped: flipped)
+            case let .icon(icon, flipped, renderingMode, _):
+                ButtonIcon(icon: icon, flipped: flipped, mode: renderingMode)
             case let .text(text):
                 ButtonText(text: text)
-            case let .textAndIcon(text, icon, flipped):
-                ButtonTextAndIcon(text: text, icon: icon, flipIcon: flipped)
+            case let .textAndIcon(text, icon, flipped, renderingMode):
+                ButtonTextAndIcon(text: text, icon: icon, flipIcon: flipped, mode: renderingMode)
             }
         }
         .buttonStyle(StyleForButton(appearance: appearance, style: style, isHover: isHover, isFullWidth: isFullWidth))
@@ -389,7 +401,7 @@ public struct OUDSButton: View {
             "core_common_loading_a11y".localized()
         } else {
             switch type {
-            case let .text(text), let .textAndIcon(text, _, _), let .icon(_, _, text):
+            case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, _, _, text):
                 text
             }
         }
@@ -404,9 +416,10 @@ private struct ButtonIcon: View {
 
     let icon: Image
     let flipped: Bool
+    let mode: Image.TemplateRenderingMode
 
     var body: some View {
-        ScaledIcon(icon: icon.renderingMode(.template),
+        ScaledIcon(icon: icon.renderingMode(mode),
                    size: theme.button.sizeIconOnly,
                    flipped: flipped)
             .padding(.all, theme.button.spaceInsetIconOnly)
@@ -439,10 +452,11 @@ private struct ButtonTextAndIcon: View {
     let text: String
     let icon: Image
     let flipIcon: Bool
+    let mode: Image.TemplateRenderingMode
 
     var body: some View {
         HStack(alignment: .center, spacing: theme.button.spaceColumnGapIcon) {
-            FixedIcon(icon: icon.resizable().renderingMode(.template),
+            FixedIcon(icon: icon.resizable().renderingMode(mode),
                       size: theme.button.sizeIcon,
                       flipped: flipIcon)
 

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -143,8 +143,8 @@ public struct OUDSButton: View {
 
     private enum `Type` {
         case text(String)
-        case icon(Image, flipIcon: Bool, renderingMode: Image.TemplateRenderingMode, String)
-        case textAndIcon(text: String, icon: Image, flipIcon: Bool, renderingMode: Image.TemplateRenderingMode)
+        case icon(OUDSImage)
+        case textAndIcon(text: String, icon: OUDSImage)
     }
 
     /// Represents the appearance of an OUDS button, i.e. a kind of type
@@ -200,6 +200,7 @@ public struct OUDSButton: View {
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
     ///    - action: The action to perform when the user triggers the button
+    @available(*, deprecated, message: "Use OUDSButton(_:tableName:bundle:image:appearance:style:isFullWidth:action) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -211,8 +212,42 @@ public struct OUDSButton: View {
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
+        let imageSetup = OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode)
+        self.init(key, tableName: tableName, bundle: bundle, image: imageSetup, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
+    }
+
+    /// Creates a button with a localized text and icon, looking up the key in the given bundle..
+    /// A raw string can also be given to be displayed.
+    ///
+    /// ```swift
+    ///     let imageSetup = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
+    ///     // Use localizable
+    ///     OUDSButton(LocalizedStringKey("validate_button"),
+    ///                bundle: Bundle.module,
+    ///                image: imageSetup,
+    ///                appearance: .strong) { }
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle, or a raw `String` to display
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - image: An image configuration defined asset to use, rendering mode or also flip to apply or not.
+    ///    - appearance: The button appearance, default set to `.default`
+    ///    - style: The button style, default set to `.default`
+    ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
+    ///    - action: The action to perform when the user triggers the button
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                image: OUDSImage,
+                appearance: Appearance = .default,
+                style: Style = .default,
+                isFullWidth: Bool = false,
+                action: @escaping () -> Void)
+    {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(text: resolvedText, icon: icon, flipIcon: flipIcon, renderingMode: renderingMode, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
+        self.init(text: resolvedText, image: image, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
     }
 
     // swiftlint:enable function_default_parameter_at_end
@@ -232,6 +267,7 @@ public struct OUDSButton: View {
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
     ///    - action: The action to perform when the user triggers the button
+    @available(*, deprecated, message: "Use OUDSButton(text:image:appearance:style:isFullWidth:action) instead.")
     public init(text: String,
                 icon: Image,
                 flipIcon: Bool = false,
@@ -241,7 +277,44 @@ public struct OUDSButton: View {
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        type = .textAndIcon(text: text, icon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
+        type = .textAndIcon(text: text, icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
+        self.appearance = appearance
+        self.style = style
+        self.isFullWidth = isFullWidth
+        self.action = action
+        isHover = false
+    }
+
+    /// Creates a button with text and image.
+    ///
+    /// ```swift
+    ///     // With default setup
+    ///     OUDSButton(text: "Validate",
+    ///                image: OUDSImage(asset: Image(systemName: "checkmark")),
+    ///                appearance: .strong) { }
+    ///
+    ///     // With more setup
+    ///     let imageSetup = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
+    ///     OUDSButton(text: "Validate",
+    ///                image: imageSetup,
+    ///                appearance: .strong) { }
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - text: The text to display in the button
+    ///    - image: An image configuration defined asset to use, rendering mode or also flip to apply or not.
+    ///    - appearance: The button appearance, default set to `.default`
+    ///    - style: The button style, default set to `.default`
+    ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
+    ///    - action: The action to perform when the user triggers the button
+    public init(text: String,
+                image: OUDSImage,
+                appearance: Appearance = .default,
+                style: Style = .default,
+                isFullWidth: Bool = false,
+                action: @escaping () -> Void)
+    {
+        type = .textAndIcon(text: text, icon: image)
         self.appearance = appearance
         self.style = style
         self.isFullWidth = isFullWidth
@@ -262,6 +335,7 @@ public struct OUDSButton: View {
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
     ///    - action: The action to perform when the user triggers the button
+    @available(*, deprecated, message: "Use OUDSButton(image:appearance:style:isFullWidth:action) instead.")
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -287,6 +361,37 @@ public struct OUDSButton: View {
     /// Creates a button with an icon only.
     ///
     /// ```swift
+    ///     let imageSetup = OUDSImage(asset: Image("someIcon"),
+    ///                                flipped: true,
+    ///                                accessibilityLabel: LocalizedStringKey("some.wording.key"),
+    ///                                renderingMode: .original)
+    ///     OUDSButton(text: "Validate",
+    ///                image: imageSetup,
+    ///                appearance: .strong) { }
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - image: An image configuration defined asset to use, rendering mode or also flip to apply or not.
+    ///    - appearance: The button appearance, default set to `.default`
+    ///    - style: The button style, default set to `.default`
+    ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
+    ///    - action: The action to perform when the user triggers the button
+    public init(image: OUDSImage,
+                appearance: Appearance = .default,
+                style: Style = .default,
+                isFullWidth: Bool = false,
+                action: @escaping () -> Void)
+    {
+        self.init(image: image,
+                  appearance: appearance,
+                  style: style,
+                  isFullWidth: isFullWidth,
+                  action: action)
+    }
+
+    /// Creates a button with an icon only.
+    ///
+    /// ```swift
     ///     OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like") { }
     /// ```
     ///
@@ -299,6 +404,7 @@ public struct OUDSButton: View {
     ///    - style: The button style, default set to `.default`
     ///    - isFullWidth: Flag to let button take all the screen width, set to *false* by default.
     ///    - action: The action to perform when the user triggers the button
+    @available(*, deprecated, message: "Use OUDSButton(image:appearance:style:isFullWidth:action) instead.")
     public init(icon: Image,
                 accessibilityLabel: String,
                 flipIcon: Bool = false,
@@ -308,7 +414,7 @@ public struct OUDSButton: View {
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        type = .icon(icon, flipIcon: flipIcon, renderingMode: renderingMode, accessibilityLabel)
+        type = .icon(OUDSImage(asset: icon, flipped: flipIcon, accessibilityLabel: accessibilityLabel, renderingMode: renderingMode))
         self.appearance = appearance
         self.style = style
         self.isFullWidth = isFullWidth
@@ -380,12 +486,12 @@ public struct OUDSButton: View {
 
         Button(action: action) {
             switch type {
-            case let .icon(icon, flipped, renderingMode, _):
-                ButtonIcon(icon: icon, flipped: flipped, mode: renderingMode)
+            case let .icon(image):
+                ButtonIcon(image: image)
             case let .text(text):
                 ButtonText(text: text)
-            case let .textAndIcon(text, icon, flipped, renderingMode):
-                ButtonTextAndIcon(text: text, icon: icon, flipIcon: flipped, mode: renderingMode)
+            case let .textAndIcon(text, image):
+                ButtonTextAndIcon(text: text, image: image)
             }
         }
         .buttonStyle(StyleForButton(appearance: appearance, style: style, isHover: isHover, isFullWidth: isFullWidth))
@@ -408,8 +514,12 @@ public struct OUDSButton: View {
             "core_common_loading_a11y".localized()
         } else {
             switch type {
-            case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, _, _, text):
+            case let .text(text):
                 text
+            case let .textAndIcon(text, _):
+                text
+            case let .icon(image):
+                image.accessibilityLabel ?? ""
             }
         }
     }
@@ -421,14 +531,11 @@ private struct ButtonIcon: View {
 
     @Environment(\.theme) private var theme
 
-    let icon: Image
-    let flipped: Bool
-    let mode: Image.TemplateRenderingMode
+    let image: OUDSImage
 
     var body: some View {
-        ScaledIcon(icon: icon.renderingMode(mode),
-                   size: theme.button.sizeIconOnly,
-                   flipped: flipped)
+        ScaledIcon(image: image,
+                   size: theme.button.sizeIconOnly)
             .padding(.all, theme.button.spaceInsetIconOnly)
             .frame(minWidth: theme.button.sizeMinWidth, minHeight: theme.button.sizeMinHeight)
     }
@@ -457,15 +564,12 @@ private struct ButtonTextAndIcon: View {
     @Environment(\.theme) private var theme
 
     let text: String
-    let icon: Image
-    let flipIcon: Bool
-    let mode: Image.TemplateRenderingMode
+    let image: OUDSImage
 
     var body: some View {
         HStack(alignment: .center, spacing: theme.button.spaceColumnGapIcon) {
-            FixedIcon(icon: icon.resizable().renderingMode(mode),
-                      size: theme.button.sizeIcon,
-                      flipped: flipIcon)
+            FixedIcon(image: image,
+                      size: theme.button.sizeIcon)
 
             TextForButton(text: text)
         }

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -44,11 +44,11 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only with default appearance
-///     OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) { /* the action to process */ }
+///     OUDSButton(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Like", appearance: .default) { /* the action to process */ }
 ///     // Or simpler
-///     OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like") { /* the action to process */ }
+///     OUDSButton(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Like") { /* the action to process */ }
 ///     // With an image to keep raw without tint
-///     OUDSButton(icon: Image("il_someImage"), accessibilityLabel: "Like", renderingMode: .original) { /* the action to process */ }
+///     OUDSButton(image: OUDSImage(asset: Image("il_someImage")), accessibilityLabel: "Like", renderingMode: .original) { /* the action to process */ }
 ///
 ///     // Text only with negative appearance
 ///     OUDSButton(text: "Delete", appearance: .negative,  style: .default) { /* the action to process */ }
@@ -59,10 +59,10 @@ import SwiftUI
 ///     OUDSButton(text: "Delete", style: .loading) { /* the action to process */ }
 ///
 ///     // Text and icon with strong appearance
-///     OUDSButton(text: "Validate", icon: Image("ic_heart"), appearance: .strong) { /* the action to process */ }
+///     OUDSButton(text: "Validate", image: OUDSImage(asset: Image("ic_heart")), appearance: .strong) { /* the action to process */ }
 ///
 ///     // Text and icon with strong appearance and button taking full width
-///     OUDSButton(text: "Validate", icon: Image("ic_heart"), appearance: .strong, isFullWidth: true) { /* the action to process */ }
+///     OUDSButton(text: "Validate", image: OUDSImage(asset: Image("ic_heart")), appearance: .strong, isFullWidth: true) { /* the action to process */ }
 ///
 ///     // Localizable from bundle can also be used
 ///     OUDSButton(LocalizedStringKey("validate_button"), bundle: Bundle.module, appearance: .strong) { }
@@ -73,7 +73,7 @@ import SwiftUI
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
 ///     OUDSButton(text: "Button",
-///                icon: Image(systemName: "figure.handball"),
+///                image: OUDSImage(asset: Image(systemName: "figure.handball")),
 ///                flipIcon: layoutDirection == .rightToLeft)
 /// ```
 ///

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -274,7 +274,14 @@ public struct OUDSButton: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, flipIcon: flipIcon, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
+        self.init(icon: icon,
+                  accessibilityLabel: resolvedText,
+                  flipIcon: flipIcon,
+                  renderingMode: renderingMode,
+                  appearance: appearance,
+                  style: style,
+                  isFullWidth: isFullWidth,
+                  action: action)
     }
 
     /// Creates a button with an icon only.

--- a/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
+++ b/OUDS/Core/Components/Sources/Actions/Button/OUDSButton.swift
@@ -14,6 +14,8 @@
 import OUDSFoundations
 import SwiftUI
 
+// swiftlint:disable file_length
+
 // MARK: - OUDS Button
 
 /// Button is a UI element that triggers an action or event, and is used to initiate tasks or confirming an action.
@@ -212,19 +214,19 @@ public struct OUDSButton: View {
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        let imageSetup = OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode)
-        self.init(key, tableName: tableName, bundle: bundle, image: imageSetup, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
+        let oudsImage = OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode)
+        self.init(key, tableName: tableName, bundle: bundle, image: oudsImage, appearance: appearance, style: style, isFullWidth: isFullWidth, action: action)
     }
 
     /// Creates a button with a localized text and icon, looking up the key in the given bundle..
     /// A raw string can also be given to be displayed.
     ///
     /// ```swift
-    ///     let imageSetup = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
+    ///     let oudsImage = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
     ///     // Use localizable
     ///     OUDSButton(LocalizedStringKey("validate_button"),
     ///                bundle: Bundle.module,
-    ///                image: imageSetup,
+    ///                image: oudsImage,
     ///                appearance: .strong) { }
     /// ```
     ///
@@ -294,9 +296,9 @@ public struct OUDSButton: View {
     ///                appearance: .strong) { }
     ///
     ///     // With more setup
-    ///     let imageSetup = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
+    ///     let oudsImage = OUDSImage(asset: Image("someIcon"), flipped: true, renderingMode: .original)
     ///     OUDSButton(text: "Validate",
-    ///                image: imageSetup,
+    ///                image: oudsImage,
     ///                appearance: .strong) { }
     /// ```
     ///
@@ -361,12 +363,12 @@ public struct OUDSButton: View {
     /// Creates a button with an icon only.
     ///
     /// ```swift
-    ///     let imageSetup = OUDSImage(asset: Image("someIcon"),
+    ///     let oudsImage = OUDSImage(asset: Image("someIcon"),
     ///                                flipped: true,
     ///                                accessibilityLabel: LocalizedStringKey("some.wording.key"),
     ///                                renderingMode: .original)
     ///     OUDSButton(text: "Validate",
-    ///                image: imageSetup,
+    ///                image: oudsImage,
     ///                appearance: .strong) { }
     /// ```
     ///
@@ -382,11 +384,12 @@ public struct OUDSButton: View {
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
-        self.init(image: image,
-                  appearance: appearance,
-                  style: style,
-                  isFullWidth: isFullWidth,
-                  action: action)
+        type = .icon(image)
+        self.appearance = appearance
+        self.style = style
+        self.isFullWidth = isFullWidth
+        self.action = action
+        isHover = false
     }
 
     /// Creates a button with an icon only.

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/Bullet.swift
@@ -95,7 +95,7 @@ struct UnorderedBullet: View {
     // MARK: Body
 
     var body: some View {
-        ScaledIcon(icon: image.renderingMode(.template), size: assetSize)
+        ScaledIcon(image: OUDSImage(asset: image, renderingMode: .template), size: assetSize)
             .foregroundColor(color)
     }
 

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -190,7 +190,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -319,7 +319,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -443,7 +443,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -548,7 +548,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with image: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -14,7 +14,12 @@
 import OUDSFoundations
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these warnings
+
 // swiftlint:disable file_length
+// swiftlint:disable function_default_parameter_at_end
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 
 /// Checkbox is a UI element that allows to select multiple options from a set of mutually non exclusive choices.
 /// Checkbox item covers a wider range of contexts by allowing to toggle the visibility of additional text labels and icon assets.
@@ -46,8 +51,8 @@ import SwiftUI
 /// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
 /// to have for example the indicator in trailing position for LTR mode and vice versa.
 /// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
-/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
-/// It prevents the user do implement its own rules to flip or not image.
+/// It could lead to a loss of meaning or semantics in the icon. Thus the ``OUDSImage`` `flipped` property can be used to flip the icon content
+/// whatever the layout direction is, preventing the user from implementing their own rules to flip or not the image.
 ///
 /// ## Rich text
 ///
@@ -77,37 +82,37 @@ import SwiftUI
 ///     @Published var isOn: Bool = false
 ///
 ///     // A leading checkbox with a label.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItem("Hello world", isOn: $isOn)
 ///
 ///     // Localizable from bundle can also be used
 ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn)
 ///
 ///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
-///     // The default layout will be used here.
 ///     OUDSCheckboxItem("Hello world", isOn: $isOn, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItem("Bazinga!", isOn: $isOn, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
-///     // A trailing checkbox with a label, a description and an icon.
-///     // The reversed layout will be used here.
+///     // A trailing checkbox with a label, a description and an icon (tinted, default rendering).
 ///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
-///                      icon: Image(decorative: "ic_heart"),
+///                      icon: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                      isReversed: true)
 ///
-///     // A trailing checkbox with a label, a description and an icon.
-///     // The reversed layout will be used here.
-///     // The image is kept as is and is not tinted.
+///     // A trailing checkbox with a raw (non-tinted) image.
 ///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
-///                      icon: Image(decorative: "il_someImage"),
-///                      renderingMode: .original,
+///                      icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                      isReversed: true)
+///
+///     // Flip the icon for RTL layouts using OUDSImage.
+///     OUDSCheckboxItem("Cocorico !",
+///                      isOn: $isOn,
+///                      icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                     flipped: layoutDirection == .rightToLeft),
+///                      isReversed: layoutDirection == .rightToLeft)
 ///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSCheckboxItem("We live in a fabled world",
@@ -117,7 +122,6 @@ import SwiftUI
 ///                      hasDivider: true)
 ///
 ///     // A leading checkbox with a label, but disabled.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItem("Hello world", isOn: $isOn)
 ///         .disabled(true)
 ///
@@ -125,17 +129,6 @@ import SwiftUI
 ///     // This is forbidden by design!
 ///     OUDSCheckboxItem("Hello world", isOn: $isOn, isError: true).disabled(true) // fatal error
 ///     OUDSCheckboxItem("Hello world", isOn: $isOn, isReadOnly: true).disabled(true) // fatal error
-/// ```
-///
-/// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
-/// ```swift
-///     @Environment(\.layoutDirection) var layoutDirection
-///
-///     OUDSCheckboxItem("Cocorico !",
-///                      isOn: $selection,
-///                      icon: Image(systemName: "figure.handball"),
-///                      flipIcon: layoutDirection == .rightToLeft,
-///                      isInversed: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Suggestions
@@ -179,7 +172,52 @@ public struct OUDSCheckboxItem: View {
 
     @Environment(\.isEnabled) private var isEnabled
 
-    // MARK: - Initializers
+    // MARK: - Initializers — String label + errorText: String?
+
+    /// Creates a checkbox with label and optional helper text, icon, divider.
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the checkbox, must not be empty
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additional helper text, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
 
     /// Creates a checkbox with label and optional helper text, icon, divider.
     ///
@@ -187,7 +225,7 @@ public struct OUDSCheckboxItem: View {
     ///     OUDSCheckboxItem("Virgin Holy Lava",
     ///                      isOn: $isOn,
     ///                      description: "Very spicy",
-    ///                      icon: Image(systemName: "flame")
+    ///                      icon: OUDSImage(asset: Image(systemName: "flame")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -199,13 +237,11 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
+    ///   The `errorText` can be different if switch is selected or not.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
     ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
@@ -215,9 +251,7 @@ public struct OUDSCheckboxItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: Image? = nil,
-                flipIcon: Bool = false,
-                renderingMode: Image.TemplateRenderingMode = .template,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -257,8 +291,6 @@ public struct OUDSCheckboxItem: View {
             extraLabel: nil,
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -269,16 +301,60 @@ public struct OUDSCheckboxItem: View {
         self.action = action
     }
 
-    // For API signature consistency disable this warning
-    // swiftlint:disable function_default_parameter_at_end
+    // MARK: - Initializers — String label + errorText: AttributedString
 
-    /// Creates a checkbox with label and optional helper text, icon, divider.
+    /// Creates a checkbox with label, optional helper text, icon, divider, and a rich attributed error text.
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the checkbox, must not be empty
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additional helper text, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a checkbox with label, optional helper text, icon, divider, and a rich attributed error text.
     ///
     /// ```swift
     ///     OUDSCheckboxItem("Virgin Holy Lava",
     ///                      isOn: $isOn,
     ///                      description: "Very spicy",
-    ///                      icon: Image(systemName: "flame"),
+    ///                      icon: OUDSImage(asset: Image(systemName: "flame")),
     ///                      errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
     ///                    // Manage in your side errors for init for AttributedString(markdown:)
     /// ```
@@ -292,13 +368,10 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
     ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
@@ -308,9 +381,7 @@ public struct OUDSCheckboxItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: Image? = nil,
-                flipIcon: Bool = false,
-                renderingMode: Image.TemplateRenderingMode = .template,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -342,8 +413,6 @@ public struct OUDSCheckboxItem: View {
             extraLabel: nil,
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -354,30 +423,27 @@ public struct OUDSCheckboxItem: View {
         self.action = action
     }
 
-    /// Creates a checkbox with a localized label, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    // MARK: - Initializers — LocalizedStringKey + errorText: String?
+
+    /// Creates a checkbox with a localized label.
     ///
     /// - Parameters:
     ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
     ///   - tableName: The name of the `.strings` file, or `nil` for the default
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
-    ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   - isReadOnly: True if component is in read only, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - description: An additional helper text, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -394,12 +460,11 @@ public struct OUDSCheckboxItem: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
+                  icon: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -410,6 +475,111 @@ public struct OUDSCheckboxItem: View {
     }
 
     /// Creates a checkbox with a localized label, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn)
+    ///
+    ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"),
+    ///                      bundle: Bundle.module,
+    ///                      isOn: $isOn,
+    ///                      icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  description: description,
+                  icon: icon,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    // MARK: - Initializers — LocalizedStringKey + errorText: AttributedString
+
+    /// Creates a checkbox with a localized label and a rich attributed error text.
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
+    ///   - description: An additional helper text, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a checkbox with a localized label and a rich attributed error text.
     ///
     /// ```swift
     ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"),
@@ -427,12 +597,10 @@ public struct OUDSCheckboxItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
     ///   - isReadOnly: True if component is in read only, default set to `false`
     ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
@@ -442,9 +610,7 @@ public struct OUDSCheckboxItem: View {
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: Image? = nil,
-                flipIcon: Bool = false,
-                renderingMode: Image.TemplateRenderingMode = .template,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -457,8 +623,6 @@ public struct OUDSCheckboxItem: View {
                   isOn: isOn,
                   description: description,
                   icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -468,9 +632,7 @@ public struct OUDSCheckboxItem: View {
                   action: action)
     }
 
-    // swiftlint:enable function_default_parameter_at_end
-
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         ControlItem(indicatorType: .checkBox(convertedState), layoutData: layoutData, action: action)
@@ -517,3 +679,7 @@ public struct OUDSCheckboxItem: View {
         }
     }
 }
+
+// swiftlint:enable function_default_parameter_at_end
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -97,21 +97,21 @@ import SwiftUI
 ///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
-///                      icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+///                      image: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                      isReversed: true)
 ///
 ///     // A trailing checkbox with a raw (non-tinted) image.
 ///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
-///                      icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
+///                      image: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                      isReversed: true)
 ///
 ///     // Flip the icon for RTL layouts using OUDSImage.
 ///     OUDSCheckboxItem("Cocorico !",
 ///                      isOn: $isOn,
-///                      icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-///                                     flipped: layoutDirection == .rightToLeft),
+///                      image: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                      flipped: layoutDirection == .rightToLeft),
 ///                      isReversed: layoutDirection == .rightToLeft)
 ///
 ///     // If on error, add an error message can help user to understand error context
@@ -190,7 +190,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -209,7 +209,7 @@ public struct OUDSCheckboxItem: View {
         self.init(label,
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -225,7 +225,7 @@ public struct OUDSCheckboxItem: View {
     ///     OUDSCheckboxItem("Virgin Holy Lava",
     ///                      isOn: $isOn,
     ///                      description: "Very spicy",
-    ///                      icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///                      image: OUDSImage(asset: Image(systemName: "flame")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -237,7 +237,7 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -251,7 +251,7 @@ public struct OUDSCheckboxItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -290,7 +290,7 @@ public struct OUDSCheckboxItem: View {
             label: label.localized(),
             extraLabel: nil,
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -319,7 +319,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -338,7 +338,7 @@ public struct OUDSCheckboxItem: View {
         self.init(label,
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -354,7 +354,7 @@ public struct OUDSCheckboxItem: View {
     ///     OUDSCheckboxItem("Virgin Holy Lava",
     ///                      isOn: $isOn,
     ///                      description: "Very spicy",
-    ///                      icon: OUDSImage(asset: Image(systemName: "flame")),
+    ///                      image: OUDSImage(asset: Image(systemName: "flame")),
     ///                      errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
     ///                    // Manage in your side errors for init for AttributedString(markdown:)
     /// ```
@@ -368,7 +368,7 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -381,7 +381,7 @@ public struct OUDSCheckboxItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -412,7 +412,7 @@ public struct OUDSCheckboxItem: View {
             label: label.localized(),
             extraLabel: nil,
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -443,7 +443,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -464,7 +464,7 @@ public struct OUDSCheckboxItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -482,7 +482,7 @@ public struct OUDSCheckboxItem: View {
     ///     OUDSCheckboxItem(LocalizedStringKey("agree_terms"),
     ///                      bundle: Bundle.module,
     ///                      isOn: $isOn,
-    ///                      icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    ///                      image: OUDSImage(asset: Image(decorative: "ic_heart")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -493,7 +493,7 @@ public struct OUDSCheckboxItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -506,7 +506,7 @@ public struct OUDSCheckboxItem: View {
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -518,7 +518,7 @@ public struct OUDSCheckboxItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -548,7 +548,7 @@ public struct OUDSCheckboxItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with image: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -569,7 +569,7 @@ public struct OUDSCheckboxItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -597,7 +597,7 @@ public struct OUDSCheckboxItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -610,7 +610,7 @@ public struct OUDSCheckboxItem: View {
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -622,7 +622,7 @@ public struct OUDSCheckboxItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -237,7 +237,7 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -368,7 +368,7 @@ public struct OUDSCheckboxItem: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -493,7 +493,7 @@ public struct OUDSCheckboxItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -597,7 +597,7 @@ public struct OUDSCheckboxItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the indicator is ticked (selected) or not (unselected)
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItem.swift
@@ -14,6 +14,8 @@
 import OUDSFoundations
 import SwiftUI
 
+// swiftlint:disable file_length
+
 /// Checkbox is a UI element that allows to select multiple options from a set of mutually non exclusive choices.
 /// Checkbox item covers a wider range of contexts by allowing to toggle the visibility of additional text labels and icon assets.
 ///
@@ -94,8 +96,18 @@ import SwiftUI
 ///     OUDSCheckboxItem("We live in a fabled world",
 ///                      isOn: $isOn,
 ///                      description: "Of dreaming boys and wide-eyed girls",
-///                      isReversed: true,
-///                      icon: Image(decorative: "ic_heart"))
+///                      icon: Image(decorative: "ic_heart"),
+///                      isReversed: true)
+///
+///     // A trailing checkbox with a label, a description and an icon.
+///     // The reversed layout will be used here.
+///     // The image is kept as is and is not tinted.
+///     OUDSCheckboxItem("We live in a fabled world",
+///                      isOn: $isOn,
+///                      description: "Of dreaming boys and wide-eyed girls",
+///                      icon: Image(decorative: "il_someImage"),
+///                      renderingMode: .original,
+///                      isReversed: true)
 ///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSCheckboxItem("We live in a fabled world",
@@ -189,6 +201,7 @@ public struct OUDSCheckboxItem: View {
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -204,6 +217,7 @@ public struct OUDSCheckboxItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -244,6 +258,7 @@ public struct OUDSCheckboxItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -279,6 +294,7 @@ public struct OUDSCheckboxItem: View {
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`. Will be replaced by `errorText` in case of error.
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -294,6 +310,7 @@ public struct OUDSCheckboxItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -326,6 +343,7 @@ public struct OUDSCheckboxItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -352,6 +370,7 @@ public struct OUDSCheckboxItem: View {
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -366,6 +385,7 @@ public struct OUDSCheckboxItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -379,6 +399,7 @@ public struct OUDSCheckboxItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -408,6 +429,7 @@ public struct OUDSCheckboxItem: View {
     ///   - description: An additional helper text, a description, which should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -422,6 +444,7 @@ public struct OUDSCheckboxItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -435,6 +458,7 @@ public struct OUDSCheckboxItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -88,7 +88,7 @@ import SwiftUI
 ///
 ///     // A trailing checkbox with a label, an helper text and an icon.
 ///     // The reversed layout will be used here.
-///     // Image is kept as is as raw imahge and not tinted
+///     // Image is kept as is as raw image and not tinted
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -14,6 +14,11 @@
 import OUDSFoundations
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these SwiftLint commands
+
+// swiftlint:disable function_default_parameter_at_end
+// swiftlint:disable line_length
+
 // MARK: - OUDS Checkbox Item Indeterminate
 
 /// Checkbox is a UI element that allows to select multiple options from a set of mutually non exclusive choices.
@@ -47,8 +52,8 @@ import SwiftUI
 /// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
 /// to have for example the indicator in trailing position for LTR mode and vice versa.
 /// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
-/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
-/// It prevents the user do implement its own rules to flip or not image.
+/// It could lead to a loss of meaning or semantics in the icon. Thus the ``OUDSImage`` `flipped` property can be used to flip the icon content
+/// whatever the layout direction is, preventing the user from implementing their own rules to flip or not the image.
 ///
 /// ## Accessibility considerations
 ///
@@ -67,34 +72,37 @@ import SwiftUI
 ///     @Published var selection: OUDSCheckboxIndicatorState = .indeterminate
 ///
 ///     // A leading checkbox with a label.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection)
 ///
-///     // A leading checkbox with a label, but in read only mode (user cannot interact yet, but not disabled).
-///     // The default layout will be used here.
+///     // Localizable from bundle can also be used
+///     OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module, selection: $selection)
+///
+///     // A leading checkbox with a label, but in read only mode.
 ///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isReadOnly: true)
 ///
 ///     // A leading checkbox with a label and a description as helper text.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItemIndeterminate("Bazinga!", selection: $selection, description: "Doll-Dagga Buzz-Buzz Ziggety-Zag")
 ///
-///     // A trailing checkbox with a label, an helper text and an icon.
-///     // The reversed layout will be used here.
+///     // A trailing checkbox with a label, an helper text and an icon (tinted, default rendering).
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
-///                                   icon: Image(decorative: "ic_heart"),
+///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                                   isReversed: true)
 ///
-///     // A trailing checkbox with a label, an helper text and an icon.
-///     // The reversed layout will be used here.
-///     // Image is kept as is as raw image and not tinted
+///     // A trailing checkbox with a raw (non-tinted) image.
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
-///                                   icon: Image(decorative: "il_someImage"),
-///                                   renderingMode: .original,
+///                                   icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                                   isReversed: true)
+///
+///     // Flip the icon for RTL layouts using OUDSImage.
+///     OUDSCheckboxItemIndeterminate("Cocorico !",
+///                                   selection: $selection,
+///                                   icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                                   flipped: layoutDirection == .rightToLeft),
+///                                   isReversed: layoutDirection == .rightToLeft)
 ///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
@@ -104,31 +112,13 @@ import SwiftUI
 ///                                   hasDivider: true)
 ///
 ///     // A leading checkbox with a label, but disabled.
-///     // The default layout will be used here.
 ///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection)
 ///         .disabled(true)
-///
-///     // A leading checkbox with a label and and icon but with the icon flipped vertically
-///     OUDSCheckboxItemIndeterminate("Cocorico !",
-///                                   selection: $selection,
-///                                   icon: Image(systemName: "figure.handball"),
-///                                   flipIcon: true)
 ///
 ///     // Never disable a read only or an error-related checkbox as it will crash
 ///     // This is forbidden by design!
 ///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isError: true).disabled(true) // fatal error
 ///     OUDSCheckboxItemIndeterminate("Hello world", selection: $selection, isReadOnly: true).disabled(true) // fatal error
-/// ```
-///
-/// If you want to manage the RTL mode quite easily and switch your layouts (flip image, indicator in RTL leading i.e. in the right):
-/// ```swift
-///     @Environment(\.layoutDirection) var layoutDirection
-///
-///     OUDSCheckboxItemIndeterminate("Cocorico !",
-///                                   selection: $selection,
-///                                   icon: Image(systemName: "figure.handball"),
-///                                   flipIcon: layoutDirection == .rightToLeft,
-///                                   isReversed: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Suggestions
@@ -175,38 +165,82 @@ public struct OUDSCheckboxItemIndeterminate: View {
 
     /// Creates a checkbox with label and optional helper text, icon, divider.
     ///
-    /// ```swift
-    ///     OUDSCheckboxItemIndeterminate("Select all", selection: $state)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
-    ///
     /// - Parameters:
     ///   - label: The main label text of the checkbox, must not be empty
-    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked).
+    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked
     ///   - description: A description, an additional helper text, should not be empty
-    ///   - icon: An optional icon
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
-    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
-    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///     modifier. Defaults to `false`.
-    ///   - action: An additional action to trigger when the checkbox has been pressed, default set to `nil`
-    ///
-    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
-    /// provide the localized string if key is stored in another bundle.**
+    ///   - icon: An optional icon image
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    ///   - action: An additional action to trigger when the checkbox has been pressed
+    @available(*, deprecated, message: "Use OUDSCheckboxItemIndeterminate(_:selection:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
                 renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  selection: selection,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a checkbox with label and optional helper text, icon, divider.
+    ///
+    /// ```swift
+    ///     OUDSCheckboxItemIndeterminate("Select all", selection: $state)
+    ///
+    ///     OUDSCheckboxItemIndeterminate("Select all",
+    ///                                   selection: $state,
+    ///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the checkbox, must not be empty
+    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked)
+    ///   - description: A description, an additional helper text, should not be empty
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the checkbox has been pressed, default set to `nil`
+    public init(_ label: String,
+                selection: Binding<OUDSCheckboxIndicatorState>,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -247,8 +281,6 @@ public struct OUDSCheckboxItemIndeterminate: View {
             extraLabel: nil,
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -256,6 +288,60 @@ public struct OUDSCheckboxItemIndeterminate: View {
             hasDivider: hasDivider,
             constrainedMaxWidth: constrainedMaxWidth,
             orientation: isReversed ? .reversed : .default)
+    }
+
+    /// Creates a checkbox with a localized label, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module, selection: $state)
+    ///
+    ///     OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"),
+    ///                                   bundle: Bundle.module,
+    ///                                   selection: $state,
+    ///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked
+    ///   - description: A description, an additional helper text, should not be empty
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - action: An additional action to trigger when the checkbox has been pressed, default set to `nil`
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                selection: Binding<OUDSCheckboxIndicatorState>,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  selection: selection,
+                  description: description,
+                  icon: icon,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
     }
 
     // MARK: Body
@@ -299,3 +385,6 @@ public struct OUDSCheckboxItemIndeterminate: View {
         }
     }
 }
+
+// swiftlint:enable function_default_parameter_at_end
+// swiftlint:enable line_length

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -179,7 +179,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItemIndeterminate(_:selection:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItemIndeterminate(_:selection:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ label: String,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -87,21 +87,21 @@ import SwiftUI
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
-///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+///                                   image: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                                   isReversed: true)
 ///
 ///     // A trailing checkbox with a raw (non-tinted) image.
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
-///                                   icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
+///                                   image: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                                   isReversed: true)
 ///
 ///     // Flip the icon for RTL layouts using OUDSImage.
 ///     OUDSCheckboxItemIndeterminate("Cocorico !",
 ///                                   selection: $selection,
-///                                   icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-///                                                   flipped: layoutDirection == .rightToLeft),
+///                                   image: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                                    flipped: layoutDirection == .rightToLeft),
 ///                                   isReversed: layoutDirection == .rightToLeft)
 ///
 ///     // If on error, add an error message can help user to understand error context
@@ -179,7 +179,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the checkbox has been pressed
-    @available(*, deprecated, message: "Use OUDSCheckboxItemIndeterminate(_:selection:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxItemIndeterminate(_:selection:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
@@ -198,7 +198,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
         self.init(label,
                   selection: selection,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -215,7 +215,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///
     ///     OUDSCheckboxItemIndeterminate("Select all",
     ///                                   selection: $state,
-    ///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    ///                                   image: OUDSImage(asset: Image(decorative: "ic_heart")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -227,7 +227,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - label: The main label text of the checkbox, must not be empty
     ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked (indeterminate / partially ticked)
     ///   - description: A description, an additional helper text, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -240,7 +240,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     public init(_ label: String,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -280,7 +280,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
             label: label.localized(),
             extraLabel: nil,
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -298,7 +298,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///     OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"),
     ///                                   bundle: Bundle.module,
     ///                                   selection: $state,
-    ///                                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    ///                                   image: OUDSImage(asset: Image(decorative: "ic_heart")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -309,7 +309,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - selection: A binding to a property that determines whether the indicator is ticked, unticked or preticked
     ///   - description: A description, an additional helper text, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -322,7 +322,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
                 bundle: Bundle = .main,
                 selection: Binding<OUDSCheckboxIndicatorState>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -334,7 +334,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   selection: selection,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,

--- a/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
+++ b/OUDS/Core/Components/Sources/Controls/Checkbox/OUDSCheckboxItemIndeterminate.swift
@@ -83,8 +83,18 @@ import SwiftUI
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
 ///                                   selection: $selection,
 ///                                   description: "Of dreaming boys and wide-eyed girls",
-///                                   isReversed: true,
-///                                   icon: Image(decorative: "ic_heart"))
+///                                   icon: Image(decorative: "ic_heart"),
+///                                   isReversed: true)
+///
+///     // A trailing checkbox with a label, an helper text and an icon.
+///     // The reversed layout will be used here.
+///     // Image is kept as is as raw imahge and not tinted
+///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
+///                                   selection: $selection,
+///                                   description: "Of dreaming boys and wide-eyed girls",
+///                                   icon: Image(decorative: "il_someImage"),
+///                                   renderingMode: .original,
+///                                   isReversed: true)
 ///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSCheckboxItemIndeterminate("We live in a fabled world",
@@ -177,6 +187,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
     ///   - description: A description, an additional helper text, should not be empty
     ///   - icon: An optional icon
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` if the checkbox indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -195,6 +206,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -236,6 +248,7 @@ public struct OUDSCheckboxItemIndeterminate: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -244,7 +244,7 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
         OUDSCheckboxItem(checkbox.label,
                          isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
                          description: checkbox.description,
-                         icon: checkbox.icon,
+                         image: checkbox.icon,
                          isReversed: isReversed ? true : checkbox.isReversed,
                          isError: isError ? true : checkbox.isError,
                          isReadOnly: isReadOnly ? true : checkbox.isReadOnly,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -245,6 +245,7 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
                          isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
                          description: checkbox.description,
                          icon: checkbox.icon,
+                         renderingMode: checkbox.renderingMode,
                          isReversed: isReversed ? true : checkbox.isReversed,
                          isError: isError ? true : checkbox.isError,
                          isReadOnly: isReadOnly ? true : checkbox.isReadOnly,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -44,18 +44,17 @@ import SwiftUI
 ///         [
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_1",
 ///                                        label: "Virgin Holy Lava",
-///                                        extraLabel: "Very spicy",
-///                                        helper: "No alcohol, only tasty flavors",
-///                                        icon: Image(systemName: "flame")),
+///                                        description: "No alcohol, only tasty flavors",
+///                                        image: Image(systemName: "flame")),
 ///
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_2",
 ///                                        label: "IPA beer",
-///                                        helper: "From Brewdog company",
-///                                        icon: Image(systemName: "dog.fill")),
+///                                        description: "From Brewdog company",
+///                                        image: Image(systemName: "dog.fill")),
 ///
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_3",
 ///                                        label: "Mineral water",
-///                                        icon: Image(systemName: "waterbottle.fill")),
+///                                        image: Image(systemName: "waterbottle.fill")),
 ///         ]
 ///     }
 ///

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -245,7 +245,6 @@ public struct OUDSCheckboxPicker<Tag>: View where Tag: Hashable {
                          isOn: isSelected(tag: checkbox.tag) ? .constant(true) : .constant(false),
                          description: checkbox.description,
                          icon: checkbox.icon,
-                         renderingMode: checkbox.renderingMode,
                          isReversed: isReversed ? true : checkbox.isReversed,
                          isError: isError ? true : checkbox.isError,
                          isReadOnly: isReadOnly ? true : checkbox.isReadOnly,

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPicker.swift
@@ -45,16 +45,16 @@ import SwiftUI
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_1",
 ///                                        label: "Virgin Holy Lava",
 ///                                        description: "No alcohol, only tasty flavors",
-///                                        image: Image(systemName: "flame")),
+///                                        image: OUDSImage(asset: Image(systemName: "flame")),
 ///
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_2",
 ///                                        label: "IPA beer",
 ///                                        description: "From Brewdog company",
-///                                        image: Image(systemName: "dog.fill")),
+///                                        image: OUDSImage(asset: Image(systemName: "dog.fill")),
 ///
 ///         OUDSCheckboxPickerData<String>(tag: "Choice_3",
 ///                                        label: "Mineral water",
-///                                        image: Image(systemName: "waterbottle.fill")),
+///                                        image: OUDSImage(asset: Image(systemName: "waterbottle.fill"))
 ///         ]
 ///     }
 ///

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
@@ -33,6 +33,9 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     /// An optional image the ``OUDSCheckboxItem`` can have
     let icon: Image?
 
+    /// The rendering mode for the `icon`, prefer `.original` for raw images, otherwise `.template` for tinted icons
+    let renderingMode: Image.TemplateRenderingMode
+
     /// Define if the ``OUDSCheckboxItem`` is reversed or not
     let isReversed: Bool
 
@@ -61,6 +64,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     ///    - label: the mandatory text to add to ``OUDSCheckboxItem``
     ///    - description: An optional text, default set to nil
     ///    - icon: An optional image, default set to nil
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///    - isReversed: True to use to reversed layout of the ``OUDSCheckboxItem``, false otherwise (default)
     ///    - isError: True if in an error context, false otherwise (default)
     ///    - isReadOnly: True if read only, false otherwise (default)
@@ -73,6 +77,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
                 label: String,
                 description: String? = nil,
                 icon: Image? = nil,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 isReadOnly: Bool = false,
@@ -83,6 +88,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
         self.label = label
         self.description = description
         self.icon = icon
+        self.renderingMode = renderingMode
         self.isReversed = isReversed
         self.isError = isError
         self.isReadOnly = isReadOnly

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
@@ -14,6 +14,8 @@
 #if !os(watchOS) && !os(tvOS)
 import SwiftUI
 
+// swiftlint:disable line_length
+
 /// The data to use to populate the picker of ``OUDSCheckboxItem`` objects.
 /// Each property in this ``OUDSCheckboxPickerData`` is used to define the suitable ``OUDSCheckboxItem``.
 ///
@@ -30,11 +32,8 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     /// An optional helper text the ``OUDSCheckboxItem`` can have
     let description: String?
 
-    /// An optional image the ``OUDSCheckboxItem`` can have
-    let icon: Image?
-
-    /// The rendering mode for the `icon`, prefer `.original` for raw images, otherwise `.template` for tinted icons
-    let renderingMode: Image.TemplateRenderingMode
+    /// An optional image the ``OUDSCheckboxItem`` can have, encapsulating the asset, flip flag and rendering mode
+    let icon: OUDSImage?
 
     /// Define if the ``OUDSCheckboxItem`` is reversed or not
     let isReversed: Bool
@@ -53,11 +52,56 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     /// By default is nil as the logic of identifiers is in the hand of the users.
     let accessibilityIdentifier: String?
 
-    /// Defines the data to use to define the radio buttons (``OUDSCheckboxItem``)
+    /// Defines the data to use to define the checkbox items (``OUDSCheckboxItem``)
     ///
     /// ```swift
     ///     OUDSCheckboxPickerData(tag: "option1", label: "Option 1")
+    ///
+    ///     OUDSCheckboxPickerData(tag: "option2",
+    ///                            label: "Option 2",
+    ///                            icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///
+    ///     // Raw (non-tinted) image:
+    ///     OUDSCheckboxPickerData(tag: "option3",
+    ///                            label: "Option 3",
+    ///                            icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
     /// ```
+    ///
+    /// - Parameters:
+    ///    - tag: a value to discriminate one checkbox to another
+    ///    - label: the mandatory text to add to ``OUDSCheckboxItem``
+    ///    - description: An optional text, default set to nil
+    ///    - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///    - isReversed: True to use to reversed layout of the ``OUDSCheckboxItem``, false otherwise (default)
+    ///    - isError: True if in an error context, false otherwise (default)
+    ///    - isReadOnly: True if read only, false otherwise (default)
+    ///    - hasDivider: True if a divider must be added for the current ``OUDSCheckboxItem``, false otherwise (default)
+    ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
+    ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    public init(tag: Tag,
+                label: String,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                accessibilityIdentifier: String? = nil)
+    {
+        self.tag = tag
+        self.label = label
+        self.description = description
+        self.icon = icon
+        self.isReversed = isReversed
+        self.isError = isError
+        self.isReadOnly = isReadOnly
+        self.hasDivider = hasDivider
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+
+    /// Defines the data to use to define the checkbox items (``OUDSCheckboxItem``)
     ///
     /// - Parameters:
     ///    - tag: a value to discriminate one checkbox to another
@@ -70,9 +114,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     ///    - isReadOnly: True if read only, false otherwise (default)
     ///    - hasDivider: True if a divider must be added for the current ``OUDSCheckboxItem``, false otherwise (default)
     ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    ///
-    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
-    /// provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use OUDSCheckboxPickerData(tag:label:description:icon:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
     public init(tag: Tag,
                 label: String,
                 description: String? = nil,
@@ -84,16 +126,18 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
                 hasDivider: Bool = false,
                 accessibilityIdentifier: String? = nil)
     {
-        self.tag = tag
-        self.label = label
-        self.description = description
-        self.icon = icon
-        self.renderingMode = renderingMode
-        self.isReversed = isReversed
-        self.isError = isError
-        self.isReadOnly = isReadOnly
-        self.hasDivider = hasDivider
-        self.accessibilityIdentifier = accessibilityIdentifier
+        let oudsImage = icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) }
+        self.init(tag: tag,
+                  label: label,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  accessibilityIdentifier: accessibilityIdentifier)
     }
 }
+
+// swiftlint:enable line_length
 #endif

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
@@ -14,8 +14,6 @@
 #if !os(watchOS) && !os(tvOS)
 import SwiftUI
 
-// swiftlint:disable line_length
-
 /// The data to use to populate the picker of ``OUDSCheckboxItem`` objects.
 /// Each property in this ``OUDSCheckboxPickerData`` is used to define the suitable ``OUDSCheckboxItem``.
 ///
@@ -51,6 +49,43 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     /// Can be useful for automated tests for examples or anything else.
     /// By default is nil as the logic of identifiers is in the hand of the users.
     let accessibilityIdentifier: String?
+
+    /// Defines the data to use to define the checkbox items (``OUDSCheckboxItem``)
+    ///
+    /// - Parameters:
+    ///    - tag: a value to discriminate one checkbox to another
+    ///    - label: the mandatory text to add to ``OUDSCheckboxItem``
+    ///    - description: An optional text, default set to nil
+    ///    - icon: An optional image, default set to nil
+    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///    - isReversed: True to use to reversed layout of the ``OUDSCheckboxItem``, false otherwise (default)
+    ///    - isError: True if in an error context, false otherwise (default)
+    ///    - isReadOnly: True if read only, false otherwise (default)
+    ///    - hasDivider: True if a divider must be added for the current ``OUDSCheckboxItem``, false otherwise (default)
+    ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
+    @available(*, deprecated, message: "Use OUDSCheckboxPickerData(tag:label:description:image:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:)  instead.")
+    public init(tag: Tag,
+                label: String,
+                description: String? = nil,
+                icon: Image? = nil,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                accessibilityIdentifier: String? = nil)
+    {
+        let oudsImage = icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) }
+        self.init(tag: tag,
+                  label: label,
+                  description: description,
+                  image: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  accessibilityIdentifier: accessibilityIdentifier)
+    }
 
     /// Defines the data to use to define the checkbox items (``OUDSCheckboxItem``)
     ///
@@ -100,44 +135,5 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
         self.hasDivider = hasDivider
         self.accessibilityIdentifier = accessibilityIdentifier
     }
-
-    /// Defines the data to use to define the checkbox items (``OUDSCheckboxItem``)
-    ///
-    /// - Parameters:
-    ///    - tag: a value to discriminate one checkbox to another
-    ///    - label: the mandatory text to add to ``OUDSCheckboxItem``
-    ///    - description: An optional text, default set to nil
-    ///    - icon: An optional image, default set to nil
-    ///    - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///    - isReversed: True to use to reversed layout of the ``OUDSCheckboxItem``, false otherwise (default)
-    ///    - isError: True if in an error context, false otherwise (default)
-    ///    - isReadOnly: True if read only, false otherwise (default)
-    ///    - hasDivider: True if a divider must be added for the current ``OUDSCheckboxItem``, false otherwise (default)
-    ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    @available(*, deprecated, message: "Use OUDSCheckboxPickerData(tag:label:description:image:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
-    public init(tag: Tag,
-                label: String,
-                description: String? = nil,
-                icon: Image? = nil,
-                renderingMode: Image.TemplateRenderingMode = .template,
-                isReversed: Bool = false,
-                isError: Bool = false,
-                isReadOnly: Bool = false,
-                hasDivider: Bool = false,
-                accessibilityIdentifier: String? = nil)
-    {
-        let oudsImage = icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) }
-        self.init(tag: tag,
-                  label: label,
-                  description: description,
-                  image: oudsImage,
-                  isReversed: isReversed,
-                  isError: isError,
-                  isReadOnly: isReadOnly,
-                  hasDivider: hasDivider,
-                  accessibilityIdentifier: accessibilityIdentifier)
-    }
 }
-
-// swiftlint:enable line_length
 #endif

--- a/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/CheckboxPicker/OUDSCheckboxPickerData.swift
@@ -59,19 +59,19 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     ///
     ///     OUDSCheckboxPickerData(tag: "option2",
     ///                            label: "Option 2",
-    ///                            icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///                            image: OUDSImage(asset: Image(systemName: "flame")))
     ///
     ///     // Raw (non-tinted) image:
     ///     OUDSCheckboxPickerData(tag: "option3",
     ///                            label: "Option 3",
-    ///                            icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+    ///                            image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
     /// ```
     ///
     /// - Parameters:
     ///    - tag: a value to discriminate one checkbox to another
     ///    - label: the mandatory text to add to ``OUDSCheckboxItem``
     ///    - description: An optional text, default set to nil
-    ///    - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///    - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///    - isReversed: True to use to reversed layout of the ``OUDSCheckboxItem``, false otherwise (default)
     ///    - isError: True if in an error context, false otherwise (default)
     ///    - isReadOnly: True if read only, false otherwise (default)
@@ -83,7 +83,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     public init(tag: Tag,
                 label: String,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = false,
                 isError: Bool = false,
                 isReadOnly: Bool = false,
@@ -93,7 +93,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
         self.tag = tag
         self.label = label
         self.description = description
-        self.icon = icon
+        icon = image
         self.isReversed = isReversed
         self.isError = isError
         self.isReadOnly = isReadOnly
@@ -114,7 +114,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
     ///    - isReadOnly: True if read only, false otherwise (default)
     ///    - hasDivider: True if a divider must be added for the current ``OUDSCheckboxItem``, false otherwise (default)
     ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    @available(*, deprecated, message: "Use OUDSCheckboxPickerData(tag:label:description:icon:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSCheckboxPickerData(tag:label:description:image:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
     public init(tag: Tag,
                 label: String,
                 description: String? = nil,
@@ -130,7 +130,7 @@ public struct OUDSCheckboxPickerData<Tag> where Tag: Hashable {
         self.init(tag: tag,
                   label: label,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   isReadOnly: isReadOnly,

--- a/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
@@ -37,8 +37,8 @@ struct Chip: View {
 
     enum Layout {
         case text(String)
-        case icon(Image, String, renderingMode: Image.TemplateRenderingMode = .template)
-        case textAndIcon(text: String, icon: Image, iconPosition: IconPosition = .leading, renderingMode: Image.TemplateRenderingMode = .template)
+        case icon(OUDSImage, String)
+        case textAndIcon(text: String, icon: OUDSImage, iconPosition: IconPosition = .leading)
     }
 
     // MARK: Initializers
@@ -81,7 +81,7 @@ struct Chip: View {
                 theme.chip.spacePaddingInlineIconNone
             case .icon:
                 theme.chip.spacePaddingInlineIcon
-            case let .textAndIcon(_, _, iconPosition, _):
+            case let .textAndIcon(_, _, iconPosition):
                 if iconPosition == .leading {
                     theme.chip.spacePaddingInlineIcon
                 } else {
@@ -97,7 +97,7 @@ struct Chip: View {
             theme.chip.spacePaddingInlineIconNone
         case .icon:
             theme.chip.spacePaddingInlineIcon
-        case let .textAndIcon(_, _, iconPosition, _):
+        case let .textAndIcon(_, _, iconPosition):
             if iconPosition == .trailing {
                 theme.chip.spacePaddingInlineIcon
             } else {
@@ -124,23 +124,25 @@ private struct ChipContent: View {
     var body: some View {
         Group {
             switch layout {
-            case let .icon(icon, accessibilityLabel, renderingMode):
-                ScaledIcon(icon: icon.renderingMode(renderingMode),
-                           size: theme.chip.sizeIcon)
-                    .accessibilityLabel(accessibilityLabel)
+            case let .icon(oudsImage, accessibilityLabel):
+                if let asset = oudsImage.asset {
+                    ScaledIcon(icon: asset.renderingMode(oudsImage.renderingMode),
+                               size: theme.chip.sizeIcon)
+                        .accessibilityLabel(accessibilityLabel)
+                }
             case let .text(text):
                 ChipText(text: text)
-            case let .textAndIcon(text, icon, iconPosition, renderingMode):
+            case let .textAndIcon(text, oudsImage, iconPosition):
                 HStack(alignment: .center, spacing: theme.chip.spaceColumnGapIcon) {
-                    if iconPosition == .leading {
-                        FixedIcon(icon: icon.resizable().renderingMode(renderingMode),
+                    if iconPosition == .leading, let asset = oudsImage.asset {
+                        FixedIcon(icon: asset.resizable().renderingMode(oudsImage.renderingMode),
                                   size: theme.chip.sizeIcon)
                     }
 
                     ChipText(text: text)
 
-                    if iconPosition == .trailing {
-                        FixedIcon(icon: icon.resizable().renderingMode(renderingMode),
+                    if iconPosition == .trailing, let asset = oudsImage.asset {
+                        FixedIcon(icon: asset.resizable().renderingMode(oudsImage.renderingMode),
                                   size: theme.chip.sizeIcon)
                     }
                 }

--- a/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
@@ -126,23 +126,25 @@ private struct ChipContent: View {
             switch layout {
             case let .icon(oudsImage, accessibilityLabel):
                 if let asset = oudsImage.asset {
-                    ScaledIcon(icon: asset.renderingMode(oudsImage.renderingMode),
+                    ScaledIcon(image: OUDSImage(asset: asset,
+                                                flipped: oudsImage.flipped,
+                                                accessibilityLabel: accessibilityLabel,
+                                                renderingMode: oudsImage.renderingMode),
                                size: theme.chip.sizeIcon)
-                        .accessibilityLabel(accessibilityLabel)
                 }
             case let .text(text):
                 ChipText(text: text)
             case let .textAndIcon(text, oudsImage, iconPosition):
                 HStack(alignment: .center, spacing: theme.chip.spaceColumnGapIcon) {
-                    if iconPosition == .leading, let asset = oudsImage.asset {
-                        FixedIcon(icon: asset.resizable().renderingMode(oudsImage.renderingMode),
+                    if iconPosition == .leading, oudsImage.asset != nil {
+                        FixedIcon(image: oudsImage,
                                   size: theme.chip.sizeIcon)
                     }
 
                     ChipText(text: text)
 
-                    if iconPosition == .trailing, let asset = oudsImage.asset {
-                        FixedIcon(icon: asset.resizable().renderingMode(oudsImage.renderingMode),
+                    if iconPosition == .trailing, oudsImage.asset != nil {
+                        FixedIcon(image: oudsImage,
                                   size: theme.chip.sizeIcon)
                     }
                 }
@@ -181,7 +183,7 @@ private struct ChipSelectionIndicator: View {
 
     var body: some View {
         if selected {
-            ScaledIcon(icon: Image(decorative: "ic_chip_tick", bundle: theme.resourcesBundle).renderingMode(.template),
+            ScaledIcon(image: OUDSImage(asset: Image(decorative: "ic_chip_tick", bundle: theme.resourcesBundle), renderingMode: .template),
                        size: theme.chip.sizeIcon)
                 .accessibilityHidden(true)
                 .foregroundColor(appliedColor)

--- a/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/Internal/Chip.swift
@@ -28,6 +28,8 @@ struct Chip: View {
 
     @Environment(\.theme) private var theme
 
+    // MARK: Enums
+
     enum IconPosition {
         case leading
         case trailing
@@ -35,8 +37,8 @@ struct Chip: View {
 
     enum Layout {
         case text(String)
-        case icon(Image, String)
-        case textAndIcon(text: String, icon: Image, iconPosition: IconPosition = .leading)
+        case icon(Image, String, renderingMode: Image.TemplateRenderingMode = .template)
+        case textAndIcon(text: String, icon: Image, iconPosition: IconPosition = .leading, renderingMode: Image.TemplateRenderingMode = .template)
     }
 
     // MARK: Initializers
@@ -79,7 +81,7 @@ struct Chip: View {
                 theme.chip.spacePaddingInlineIconNone
             case .icon:
                 theme.chip.spacePaddingInlineIcon
-            case let .textAndIcon(_, _, iconPosition):
+            case let .textAndIcon(_, _, iconPosition, _):
                 if iconPosition == .leading {
                     theme.chip.spacePaddingInlineIcon
                 } else {
@@ -95,7 +97,7 @@ struct Chip: View {
             theme.chip.spacePaddingInlineIconNone
         case .icon:
             theme.chip.spacePaddingInlineIcon
-        case let .textAndIcon(_, _, iconPosition):
+        case let .textAndIcon(_, _, iconPosition, _):
             if iconPosition == .trailing {
                 theme.chip.spacePaddingInlineIcon
             } else {
@@ -122,23 +124,23 @@ private struct ChipContent: View {
     var body: some View {
         Group {
             switch layout {
-            case let .icon(icon, accessibilityLabel):
-                ScaledIcon(icon: icon.renderingMode(.template),
+            case let .icon(icon, accessibilityLabel, renderingMode):
+                ScaledIcon(icon: icon.renderingMode(renderingMode),
                            size: theme.chip.sizeIcon)
                     .accessibilityLabel(accessibilityLabel)
             case let .text(text):
                 ChipText(text: text)
-            case let .textAndIcon(text, icon, iconPosition):
+            case let .textAndIcon(text, icon, iconPosition, renderingMode):
                 HStack(alignment: .center, spacing: theme.chip.spaceColumnGapIcon) {
                     if iconPosition == .leading {
-                        FixedIcon(icon: icon.resizable().renderingMode(.template),
+                        FixedIcon(icon: icon.resizable().renderingMode(renderingMode),
                                   size: theme.chip.sizeIcon)
                     }
 
                     ChipText(text: text)
 
                     if iconPosition == .trailing {
-                        FixedIcon(icon: icon.resizable().renderingMode(.template),
+                        FixedIcon(icon: icon.resizable().renderingMode(renderingMode),
                                   size: theme.chip.sizeIcon)
                     }
                 }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -111,7 +111,7 @@ public struct OUDSFilterChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
@@ -150,7 +150,7 @@ public struct OUDSFilterChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - text: The text to display in the chip, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip
@@ -200,7 +200,7 @@ public struct OUDSFilterChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
@@ -239,7 +239,7 @@ public struct OUDSFilterChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -314,7 +314,7 @@ public struct OUDSFilterChip: View {
 
     private var accessibilityLabel: String {
         switch layout {
-        case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, text, _):
+        case let .text(text), let .textAndIcon(text, _, _), let .icon(_, text):
             text
         }
     }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -22,22 +22,22 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only layout as selected
-///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) { /* the action to process */ }
+///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
 ///
 ///     // Icon only, raw image (not tinted)
-///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", renderingMode: .original) { /* the action to process */ }
+///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
 ///
 ///     // Text only as not selected (default unselected)
-///     OUDSFilterChip(text: "Label") { /* the action to process */ }
+///     OUDSFilterChip(text: "Label") {}
 ///
 ///     // Text from a localizable and a bundle
-///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) { }
+///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) {}
 ///
 ///     // Text and icon as selected
-///     OUDSFilterChip(icon: Image("ic_heart"), text: "Label", selected: true) { /* the action to process */ }
+///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
 ///
 ///     // Text and icon, raw image (not tinted)
-///     OUDSFilterChip(icon: Image("ic_heart"), text: "Label", renderingMode: .original) { /* the action to process */ }
+///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Label") {}
 /// ```
 ///
 /// ## Design documentation
@@ -73,22 +73,19 @@ public struct OUDSFilterChip: View {
     private let action: () -> Void
     private let selected: Bool
 
-    // MARK: - Initializers
+    // MARK: - Initializers — icon + LocalizedStringKey text
 
-    /// Creates a filter chip with a localized text and icon, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSFilterChip(icon: Image("ic_heart"), LocalizedStringKey("like_filter"), bundle: Bundle.module, selected: true) { }
-    /// ```
+    /// Creates a filter chip with a localized text and icon.
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
+    ///    - icon: An image which should contain an icon
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, _:tableName:bundle:selected:action:) instead.")
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -98,44 +95,87 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, selected: selected, renderingMode: renderingMode, action: action)
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode),
+                  text: resolvedText,
+                  selected: selected,
+                  action: action)
+    }
+
+    /// Creates a filter chip with a localized text and icon, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///                    LocalizedStringKey("like_filter"),
+    ///                    bundle: Bundle.module,
+    ///                    selected: true) {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - action: The action to perform when the user triggers the chip
+    public init(icon: OUDSImage,
+                _ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                selected: Bool = false,
+                action: @escaping () -> Void)
+    {
+        let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
+        self.init(icon: icon, text: resolvedText, selected: selected, action: action)
+    }
+
+    // MARK: - Initializers — icon + String text (canonical)
+
+    /// Creates a filter chip with text and icon.
+    ///
+    /// - Parameters:
+    ///    - icon: An image which should contain an icon
+    ///    - text: The text to display in the chip, should not be empty
+    ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon
+    ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, text:selected:action:) instead.")
+    public init(icon: Image, text: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
     }
 
     /// Creates a filter chip with text and icon.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: Image("ic_heart"), text: "Label", selected: true) { }
+    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
     ///    - text: The text to display in the chip, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, text: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+    public init(icon: OUDSImage, text: String, selected: Bool = false, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty text, prefer instead OUDSFilterChip(icon:accessibilityLabel:selected:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .trailing, renderingMode: renderingMode)
+        layout = .textAndIcon(text: text, icon: icon, iconPosition: .trailing)
         self.action = action
         self.selected = selected
     }
 
-    /// Create a chip with an icon only.
-    ///
-    /// ```swift
-    ///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_filter"), bundle: Bundle.module) { }
-    /// ```
+    // MARK: - Initializers — icon + LocalizedStringKey accessibilityLabel
+
+    /// Creates a filter chip with an icon only and a localized accessibility label.
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
-    ///    - key: The text to vocalize with *Voice Over* the component must have, as as `LocalizedStringKey` for the given `Bundle`
+    ///    - icon: An image which should contain an icon
+    ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, accessibilityLabel:tableName:bundle:selected:action:) instead.")
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -145,34 +185,79 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, selected: selected, renderingMode: renderingMode, action: action)
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode),
+                  accessibilityLabel: resolvedText,
+                  selected: selected,
+                  action: action)
     }
 
-    /// Create a chip with an icon only.
+    /// Creates a filter chip with an icon only and a localized accessibility label.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { }
+    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///                    accessibilityLabel: LocalizedStringKey("like_filter"),
+    ///                    bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
-    ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the chip action, should not be empty
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
+    public init(icon: OUDSImage,
+                accessibilityLabel key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                selected: Bool = false,
+                action: @escaping () -> Void)
+    {
+        let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
+        self.init(icon: icon, accessibilityLabel: resolvedText, selected: selected, action: action)
+    }
+
+    // MARK: - Initializers — icon + String accessibilityLabel (canonical)
+
+    /// Creates a filter chip with an icon only.
+    ///
+    /// - Parameters:
+    ///    - icon: An image which should contain an icon
+    ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action
+    ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon
+    ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, accessibilityLabel:selected:action:) instead.")
     public init(icon: Image, accessibilityLabel: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
+    }
+
+    /// Creates a filter chip with an icon only.
+    ///
+    /// ```swift
+    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
+    ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - action: The action to perform when the user triggers the chip
+    public init(icon: OUDSImage, accessibilityLabel: String, selected: Bool = false, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel, renderingMode: renderingMode)
+        layout = .icon(icon, accessibilityLabel)
         self.action = action
         self.selected = selected
     }
 
+    // MARK: - Initializers — text only
+
     /// Creates a filter chip with a localized text only, looking up the key in the given bundle.
     ///
     /// ```swift
-    ///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) { }
+    ///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
@@ -191,10 +276,10 @@ public struct OUDSFilterChip: View {
         self.init(text: resolvedText, selected: selected, action: action)
     }
 
-    /// Create a chip with a text only.
+    /// Creates a filter chip with a text only.
     ///
     /// ```swift
-    ///     OUDSFilterChip(text: "Label") { }
+    ///     OUDSFilterChip(text: "Label") {}
     /// ```
     ///
     /// - Parameters:
@@ -210,7 +295,7 @@ public struct OUDSFilterChip: View {
         self.selected = selected
     }
 
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         InteractionButton(action: action) {

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -22,22 +22,22 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only layout as selected
-///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
+///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
 ///
 ///     // Icon only, raw image (not tinted)
-///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
+///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
 ///
 ///     // Text only as not selected (default unselected)
-///     OUDSFilterChip(text: "Label") {}
+///     OUDSFilterChip(image: "Label") {}
 ///
 ///     // Text from a localizable and a bundle
 ///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) {}
 ///
 ///     // Text and icon as selected
-///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
+///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
 ///
 ///     // Text and icon, raw image (not tinted)
-///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Label") {}
+///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Label") {}
 /// ```
 ///
 /// ## Design documentation
@@ -85,7 +85,7 @@ public struct OUDSFilterChip: View {
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, _:tableName:bundle:selected:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSFilterChip(image:_:tableName:bundle:selected:action:) instead.")
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -95,7 +95,7 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode),
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode),
                   text: resolvedText,
                   selected: selected,
                   action: action)
@@ -104,20 +104,20 @@ public struct OUDSFilterChip: View {
     /// Creates a filter chip with a localized text and icon, looking up the key in the given bundle.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")),
     ///                    LocalizedStringKey("like_filter"),
     ///                    bundle: Bundle.module,
     ///                    selected: true) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage,
+    public init(image: OUDSImage,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -125,7 +125,7 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, selected: selected, action: action)
+        self.init(image: image, text: resolvedText, selected: selected, action: action)
     }
 
     // MARK: - Initializers — icon + String text (canonical)
@@ -138,27 +138,27 @@ public struct OUDSFilterChip: View {
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, text:selected:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSFilterChip(image:text:selected:action:) instead.")
     public init(icon: Image, text: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
     }
 
     /// Creates a filter chip with text and icon.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
+    ///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), text: "Label", selected: true) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - text: The text to display in the chip, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage, text: String, selected: Bool = false, action: @escaping () -> Void) {
+    public init(image: OUDSImage, text: String, selected: Bool = false, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty text, prefer instead OUDSFilterChip(icon:accessibilityLabel:selected:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .trailing)
+        layout = .textAndIcon(text: text, icon: image, iconPosition: .trailing)
         self.action = action
         self.selected = selected
     }
@@ -175,7 +175,7 @@ public struct OUDSFilterChip: View {
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, accessibilityLabel:tableName:bundle:selected:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSFilterChip(image:accessibilityLabel:tableName:bundle:selected:action:) instead.")
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -185,7 +185,7 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode),
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode),
                   accessibilityLabel: resolvedText,
                   selected: selected,
                   action: action)
@@ -194,19 +194,19 @@ public struct OUDSFilterChip: View {
     /// Creates a filter chip with an icon only and a localized accessibility label.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")),
     ///                    accessibilityLabel: LocalizedStringKey("like_filter"),
     ///                    bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage,
+    public init(image: OUDSImage,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -214,7 +214,7 @@ public struct OUDSFilterChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, selected: selected, action: action)
+        self.init(image: image, accessibilityLabel: resolvedText, selected: selected, action: action)
     }
 
     // MARK: - Initializers — icon + String accessibilityLabel (canonical)
@@ -227,27 +227,27 @@ public struct OUDSFilterChip: View {
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSFilterChip(icon: OUDSImage, accessibilityLabel:selected:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSFilterChip(image:accessibilityLabel:selected:action:) instead.")
     public init(icon: Image, accessibilityLabel: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
     }
 
     /// Creates a filter chip with an icon only.
     ///
     /// ```swift
-    ///     OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+    ///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage, accessibilityLabel: String, selected: Bool = false, action: @escaping () -> Void) {
+    public init(image: OUDSImage, accessibilityLabel: String, selected: Bool = false, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel)
+        layout = .icon(image, accessibilityLabel)
         self.action = action
         self.selected = selected
     }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -28,7 +28,7 @@ import SwiftUI
 ///     OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
 ///
 ///     // Text only as not selected (default unselected)
-///     OUDSFilterChip(image: "Label") {}
+///     OUDSFilterChip(text: "Label") {}
 ///
 ///     // Text from a localizable and a bundle
 ///     OUDSFilterChip(LocalizedStringKey("category_filter"), bundle: Bundle.module) {}
@@ -156,7 +156,7 @@ public struct OUDSFilterChip: View {
     ///    - action: The action to perform when the user triggers the chip
     public init(image: OUDSImage, text: String, selected: Bool = false, action: @escaping () -> Void) {
         if text.isEmpty {
-            OL.warning("The OUDSFilterChip should not have an empty text, prefer instead OUDSFilterChip(icon:accessibilityLabel:selected:action).")
+            OL.warning("The OUDSFilterChip should not have an empty text, prefer instead OUDSFilterChip(image:accessibilityLabel:selected:action).")
         }
         layout = .textAndIcon(text: text, icon: image, iconPosition: .trailing)
         self.action = action

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSFilterChip.swift
@@ -24,6 +24,9 @@ import SwiftUI
 ///     // Icon only layout as selected
 ///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) { /* the action to process */ }
 ///
+///     // Icon only, raw image (not tinted)
+///     OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", renderingMode: .original) { /* the action to process */ }
+///
 ///     // Text only as not selected (default unselected)
 ///     OUDSFilterChip(text: "Label") { /* the action to process */ }
 ///
@@ -32,6 +35,9 @@ import SwiftUI
 ///
 ///     // Text and icon as selected
 ///     OUDSFilterChip(icon: Image("ic_heart"), text: "Label", selected: true) { /* the action to process */ }
+///
+///     // Text and icon, raw image (not tinted)
+///     OUDSFilterChip(icon: Image("ic_heart"), text: "Label", renderingMode: .original) { /* the action to process */ }
 /// ```
 ///
 /// ## Design documentation
@@ -81,16 +87,18 @@ public struct OUDSFilterChip: View {
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 selected: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, selected: selected, action: action)
+        self.init(icon: icon, text: resolvedText, selected: selected, renderingMode: renderingMode, action: action)
     }
 
     /// Creates a filter chip with text and icon.
@@ -103,12 +111,13 @@ public struct OUDSFilterChip: View {
     ///    - icon: An image which shoud contains an icon
     ///    - text: The text to display in the chip, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, text: String, selected: Bool = false, action: @escaping () -> Void) {
+    public init(icon: Image, text: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty text, prefer instead OUDSFilterChip(icon:accessibilityLabel:selected:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .trailing)
+        layout = .textAndIcon(text: text, icon: icon, iconPosition: .trailing, renderingMode: renderingMode)
         self.action = action
         self.selected = selected
     }
@@ -125,16 +134,18 @@ public struct OUDSFilterChip: View {
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 selected: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, selected: selected, action: action)
+        self.init(icon: icon, accessibilityLabel: resolvedText, selected: selected, renderingMode: renderingMode, action: action)
     }
 
     /// Create a chip with an icon only.
@@ -147,12 +158,13 @@ public struct OUDSFilterChip: View {
     ///    - icon: An image which shoud contains an icon
     ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the chip action, should not be empty
     ///    - selected: Flag to know if chip is selected, by default is unselected
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, accessibilityLabel: String, selected: Bool = false, action: @escaping () -> Void) {
+    public init(icon: Image, accessibilityLabel: String, selected: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSFilterChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel)
+        layout = .icon(icon, accessibilityLabel, renderingMode: renderingMode)
         self.action = action
         self.selected = selected
     }
@@ -217,7 +229,7 @@ public struct OUDSFilterChip: View {
 
     private var accessibilityLabel: String {
         switch layout {
-        case let .text(text), let .textAndIcon(text, _, _), let .icon(_, text):
+        case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, text, _):
             text
         }
     }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -29,22 +29,22 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only
-///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { /* the action to process */ }
+///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
 ///
 ///     // Icon only, raw image (not tinted)
-///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", renderingMode: .original) { /* the action to process */ }
+///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
 ///
 ///     // Text only
-///     OUDSSuggestionChip(text: "Heart") { /* the action to process */ }
+///     OUDSSuggestionChip(text: "Heart") {}
 ///
 ///     // Text from a localizable and a bundle
-///     OUDSSuggestionChip(LocalizedStringKey("category_chip"), bundle: Bundle.module) { }
+///     OUDSSuggestionChip(LocalizedStringKey("category_chip"), bundle: Bundle.module) {}
 ///
 ///     // Text and icon
-///     OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") { /* the action to process */ }
+///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
 ///
 ///     // Text and icon, raw image (not tinted)
-///     OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart", renderingMode: .original) { /* the action to process */ }
+///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Heart") {}
 /// ```
 ///
 /// ## Design documentation
@@ -79,21 +79,18 @@ public struct OUDSSuggestionChip: View {
     private let layout: Chip.Layout
     private let action: () -> Void
 
-    // MARK: - Initializers
+    // MARK: - Initializers — icon + LocalizedStringKey text
 
-    /// Creates a chip with a localized text and icon, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSSuggestionChip(icon: Image("ic_heart"), LocalizedStringKey("like_chip"), bundle: Bundle.module) { }
-    /// ```
+    /// Creates a chip with a localized text and icon.
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
+    ///    - icon: An image which should contain an icon
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, _:tableName:bundle:action:) instead.")
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -102,44 +99,80 @@ public struct OUDSSuggestionChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, renderingMode: renderingMode, action: action)
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: resolvedText, action: action)
+    }
+
+    /// Creates a chip with a localized text and icon, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///                        LocalizedStringKey("like_chip"),
+    ///                        bundle: Bundle.module) {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - action: The action to perform when the user triggers the chip
+    public init(icon: OUDSImage,
+                _ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                action: @escaping () -> Void)
+    {
+        let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
+        self.init(icon: icon, text: resolvedText, action: action)
+    }
+
+    // MARK: - Initializers — icon + String text (canonical)
+
+    /// Creates a chip with text and icon.
+    ///
+    /// - Parameters:
+    ///    - icon: An image which should contain an icon
+    ///    - text: The text to display in the chip, should not be empty
+    ///    - renderingMode: The rendering mode to apply on the icon
+    ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, text:action:) instead.")
+    public init(icon: Image, text: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, action: action)
     }
 
     /// Creates a chip with text and icon.
     ///
+    /// ```swift
+    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+    /// ```
+    ///
     /// No accessibility hint is defined for this component.
     /// **Do not forget to define your own accessibility hint depending to what you want to do for the user when a tap is made.**
     ///
-    /// ```swift
-    ///     OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") { }
-    /// ```
-    ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
     ///    - text: The text to display in the chip, should not be empty
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, text: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+    public init(icon: OUDSImage, text: String, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty text! Prefer instead OUDSSuggestionChip(icon:accessibilityLabel:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .leading, renderingMode: renderingMode)
+        layout = .textAndIcon(text: text, icon: icon, iconPosition: .leading)
         self.action = action
     }
 
-    /// Creates a chip with an icon only.
-    ///
-    /// ```swift
-    ///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_chip"), bundle: Bundle.module) { }
-    /// ```
+    // MARK: - Initializers — icon + LocalizedStringKey accessibilityLabel
+
+    /// Creates a chip with an icon only and a localized accessibility label.
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
-    ///    - key: The text to vocalize with *Voice Over* the component must have, as as `LocalizedStringKey` for the given `Bundle`
+    ///    - icon: An image which should contain an icon
+    ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, accessibilityLabel:tableName:bundle:action:) instead.")
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -148,32 +181,71 @@ public struct OUDSSuggestionChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, renderingMode: renderingMode, action: action)
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: resolvedText, action: action)
+    }
+
+    /// Creates a chip with an icon only and a localized accessibility label.
+    ///
+    /// ```swift
+    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///                        accessibilityLabel: LocalizedStringKey("like_chip"),
+    ///                        bundle: Bundle.module) {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - action: The action to perform when the user triggers the chip
+    public init(icon: OUDSImage,
+                accessibilityLabel key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                action: @escaping () -> Void)
+    {
+        let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
+        self.init(icon: icon, accessibilityLabel: resolvedText, action: action)
+    }
+
+    // MARK: - Initializers — icon + String accessibilityLabel (canonical)
+
+    /// Creates a chip with an icon only.
+    ///
+    /// - Parameters:
+    ///    - icon: An image which should contain an icon
+    ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action
+    ///    - renderingMode: The rendering mode to apply on the icon
+    ///    - action: The action to perform when the user triggers the chip
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, accessibilityLabel:action:) instead.")
+    public init(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, action: action)
     }
 
     /// Creates a chip with an icon only.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { }
+    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An image which shoud contains an icon
-    ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the chip action, should not be empty
-    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+    public init(icon: OUDSImage, accessibilityLabel: String, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel, renderingMode: renderingMode)
+        layout = .icon(icon, accessibilityLabel)
         self.action = action
     }
+
+    // MARK: - Initializers — text only
 
     /// Creates a chip with a localized text only, looking up the key in the given bundle.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(LocalizedStringKey("category_chip"), bundle: Bundle.module) { }
+    ///     OUDSSuggestionChip(LocalizedStringKey("category_chip"), bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
@@ -193,11 +265,11 @@ public struct OUDSSuggestionChip: View {
     /// Creates a chip with a text only.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(text: "Heart") { }
+    ///     OUDSSuggestionChip(text: "Heart") {}
     /// ```
     ///
     /// - Parameters:
-    ///    - text: The text of the button to display,  must not be empty
+    ///    - text: The text of the button to display, must not be empty
     ///    - action: The action to perform when the user triggers the chip
     public init(text: String, action: @escaping () -> Void) {
         if text.isEmpty {
@@ -207,7 +279,7 @@ public struct OUDSSuggestionChip: View {
         self.action = action
     }
 
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         InteractionButton(action: action) {

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -99,7 +99,7 @@ public struct OUDSSuggestionChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: resolvedText, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), text: resolvedText, action: action)
     }
 
     /// Creates a chip with a localized text and icon, looking up the key in the given bundle.
@@ -123,7 +123,7 @@ public struct OUDSSuggestionChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: image, text: resolvedText, action: action)
+        self.init(image: image, text: resolvedText, action: action)
     }
 
     // MARK: - Initializers — icon + String text (canonical)
@@ -137,27 +137,27 @@ public struct OUDSSuggestionChip: View {
     ///    - action: The action to perform when the user triggers the chip
     @available(*, deprecated, message: "Use OUDSSuggestionChip(icon:text:action:) instead.")
     public init(icon: Image, text: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, action: action)
     }
 
     /// Creates a chip with text and icon.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+    ///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
     /// ```
     ///
     /// No accessibility hint is defined for this component.
     /// **Do not forget to define your own accessibility hint depending to what you want to do for the user when a tap is made.**
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - text: The text to display in the chip, should not be empty
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage, text: String, action: @escaping () -> Void) {
+    public init(image: OUDSImage, text: String, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty text! Prefer instead OUDSSuggestionChip(icon:accessibilityLabel:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .leading)
+        layout = .textAndIcon(text: text, icon: image, iconPosition: .leading)
         self.action = action
     }
 
@@ -172,7 +172,7 @@ public struct OUDSSuggestionChip: View {
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, accessibilityLabel:tableName:bundle:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(image:accessibilityLabel:tableName:bundle:action:) instead.")
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -181,31 +181,31 @@ public struct OUDSSuggestionChip: View {
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: resolvedText, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: resolvedText, action: action)
     }
 
     /// Creates a chip with an icon only and a localized accessibility label.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")),
     ///                        accessibilityLabel: LocalizedStringKey("like_chip"),
     ///                        bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage,
+    public init(image: OUDSImage,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, action: action)
+        self.init(image: image, accessibilityLabel: resolvedText, action: action)
     }
 
     // MARK: - Initializers — icon + String accessibilityLabel (canonical)
@@ -217,26 +217,26 @@ public struct OUDSSuggestionChip: View {
     ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, accessibilityLabel:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(image:accessibilityLabel:action:) instead.")
     public init(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
-        self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, action: action)
+        self.init(image: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, action: action)
     }
 
     /// Creates a chip with an icon only.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+    ///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage, accessibilityLabel: String, action: @escaping () -> Void) {
+    public init(image: OUDSImage, accessibilityLabel: String, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel)
+        layout = .icon(image, accessibilityLabel)
         self.action = action
     }
 

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -111,7 +111,7 @@ public struct OUDSSuggestionChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
@@ -150,7 +150,7 @@ public struct OUDSSuggestionChip: View {
     /// **Do not forget to define your own accessibility hint depending to what you want to do for the user when a tap is made.**
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - text: The text to display in the chip, should not be empty
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: OUDSImage, text: String, action: @escaping () -> Void) {
@@ -193,7 +193,7 @@ public struct OUDSSuggestionChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: The text to vocalize with Voice Over, as a `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
@@ -229,7 +229,7 @@ public struct OUDSSuggestionChip: View {
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode
+    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip action, should not be empty
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: OUDSImage, accessibilityLabel: String, action: @escaping () -> Void) {

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -291,7 +291,7 @@ public struct OUDSSuggestionChip: View {
 
     private var accessibilityLabel: String {
         switch layout {
-        case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, text, _):
+        case let .text(text), let .textAndIcon(text, _, _), let .icon(_, text):
             text
         }
     }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -29,10 +29,10 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Icon only
-///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
 ///
 ///     // Icon only, raw image (not tinted)
-///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
+///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), accessibilityLabel: "Heart") {}
 ///
 ///     // Text only
 ///     OUDSSuggestionChip(text: "Heart") {}
@@ -41,10 +41,10 @@ import SwiftUI
 ///     OUDSSuggestionChip(LocalizedStringKey("category_chip"), bundle: Bundle.module) {}
 ///
 ///     // Text and icon
-///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
 ///
 ///     // Text and icon, raw image (not tinted)
-///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Heart") {}
+///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart"), renderingMode: .original), text: "Heart") {}
 /// ```
 ///
 /// ## Design documentation
@@ -90,7 +90,7 @@ public struct OUDSSuggestionChip: View {
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, _:tableName:bundle:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(image:_:tableName:bundle:action:) instead.")
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
@@ -105,25 +105,25 @@ public struct OUDSSuggestionChip: View {
     /// Creates a chip with a localized text and icon, looking up the key in the given bundle.
     ///
     /// ```swift
-    ///     OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")),
+    ///     OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")),
     ///                        LocalizedStringKey("like_chip"),
     ///                        bundle: Bundle.module) {}
     /// ```
     ///
     /// - Parameters:
-    ///    - icon: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
+    ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode. Its accessibility label will be ignored.
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: OUDSImage,
+    public init(image: OUDSImage,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, action: action)
+        self.init(icon: image, text: resolvedText, action: action)
     }
 
     // MARK: - Initializers — icon + String text (canonical)
@@ -135,7 +135,7 @@ public struct OUDSSuggestionChip: View {
     ///    - text: The text to display in the chip, should not be empty
     ///    - renderingMode: The rendering mode to apply on the icon
     ///    - action: The action to perform when the user triggers the chip
-    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon: OUDSImage, text:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSSuggestionChip(icon:text:action:) instead.")
     public init(icon: Image, text: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
         self.init(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, action: action)
     }

--- a/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
+++ b/OUDS/Core/Components/Sources/Controls/Chip/OUDSSuggestionChip.swift
@@ -31,6 +31,9 @@ import SwiftUI
 ///     // Icon only
 ///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { /* the action to process */ }
 ///
+///     // Icon only, raw image (not tinted)
+///     OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", renderingMode: .original) { /* the action to process */ }
+///
 ///     // Text only
 ///     OUDSSuggestionChip(text: "Heart") { /* the action to process */ }
 ///
@@ -39,6 +42,9 @@ import SwiftUI
 ///
 ///     // Text and icon
 ///     OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") { /* the action to process */ }
+///
+///     // Text and icon, raw image (not tinted)
+///     OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart", renderingMode: .original) { /* the action to process */ }
 /// ```
 ///
 /// ## Design documentation
@@ -86,15 +92,17 @@ public struct OUDSSuggestionChip: View {
     ///    - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: Image,
                 _ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, text: resolvedText, action: action)
+        self.init(icon: icon, text: resolvedText, renderingMode: renderingMode, action: action)
     }
 
     /// Creates a chip with text and icon.
@@ -109,12 +117,13 @@ public struct OUDSSuggestionChip: View {
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
     ///    - text: The text to display in the chip, should not be empty
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, text: String, action: @escaping () -> Void) {
+    public init(icon: Image, text: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
         if text.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty text! Prefer instead OUDSSuggestionChip(icon:accessibilityLabel:action).")
         }
-        layout = .textAndIcon(text: text, icon: icon, iconPosition: .leading)
+        layout = .textAndIcon(text: text, icon: icon, iconPosition: .leading, renderingMode: renderingMode)
         self.action = action
     }
 
@@ -129,15 +138,17 @@ public struct OUDSSuggestionChip: View {
     ///    - key: The text to vocalize with *Voice Over* the component must have, as as `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
     public init(icon: Image,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 action: @escaping () -> Void)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(icon: icon, accessibilityLabel: resolvedText, action: action)
+        self.init(icon: icon, accessibilityLabel: resolvedText, renderingMode: renderingMode, action: action)
     }
 
     /// Creates a chip with an icon only.
@@ -149,12 +160,13 @@ public struct OUDSSuggestionChip: View {
     /// - Parameters:
     ///    - icon: An image which shoud contains an icon
     ///    - accessibilityLabel: The text to vocalize with *Voice Over* describing the chip action, should not be empty
+    ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - action: The action to perform when the user triggers the chip
-    public init(icon: Image, accessibilityLabel: String, action: @escaping () -> Void) {
+    public init(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
         if accessibilityLabel.isEmpty {
             OL.warning("The OUDSSuggestionChip should not have an empty accessibility label, think about your disabled users!")
         }
-        layout = .icon(icon, accessibilityLabel)
+        layout = .icon(icon, accessibilityLabel, renderingMode: renderingMode)
         self.action = action
     }
 
@@ -207,7 +219,7 @@ public struct OUDSSuggestionChip: View {
 
     private var accessibilityLabel: String {
         switch layout {
-        case let .text(text), let .textAndIcon(text, _, _), let .icon(_, text):
+        case let .text(text), let .textAndIcon(text, _, _, _), let .icon(_, text, _):
             text
         }
     }

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
@@ -326,10 +326,10 @@ public struct OUDSChipPicker<Tag: Hashable>: View {
         switch data.layout {
         case let .text(text):
             OUDSFilterChip(text: text, selected: selected, action: action)
-        case let .icon(icon, accessibilityLabel):
-            OUDSFilterChip(icon: icon, accessibilityLabel: accessibilityLabel, selected: selected, action: action)
-        case let .textAndIcon(text, icon):
-            OUDSFilterChip(icon: icon, text: text, selected: selected, action: action)
+        case let .icon(icon, accessibilityLabel, renderingMode):
+            OUDSFilterChip(icon: icon, accessibilityLabel: accessibilityLabel, selected: selected, renderingMode: renderingMode, action: action)
+        case let .textAndIcon(text, icon, renderingMode):
+            OUDSFilterChip(icon: icon, text: text, selected: selected, renderingMode: renderingMode, action: action)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
@@ -39,13 +39,13 @@ import SwiftUI
 ///     var someDataToPopulate: [OUDSChipPickerData<Drink>] {
 ///         [
 ///             OUDSChipPickerData(tag: Drink.virginHolyLava,
-///                                layout: .textAndIcon("Virgin Holy Lava", icon: Image(systemName: "flame")),
+///                                layout: .textAndIcon("Virgin Holy Lava", image: OUDSImage(asset: Image(systemName: "flame")))),
 ///
-///             OUDSChipPickerData(tag: Dring.ipaBeer,
-///                                layout: .textAndIcon("IPA Beer", icon: Image(systemName: "dog.fill")),
+///             OUDSChipPickerData(tag: Drink.ipaBeer,
+///                                layout: .textAndIcon("IPA Beer", image: OUDSImage(asset: Image(systemName: "dog.fill")))),
 ///
 ///             OUDSChipPickerData(tag: Drink.mineralWater,
-///                                layout: .textAndIcon("Mineral water", icon: Image(systemName: "waterbottle.fill")),
+///                                layout: .textAndIcon("Mineral water", image: OUDSImage(asset: Image(systemName: "waterbottle.fill")))),
 ///         ]
 ///     }
 ///
@@ -327,9 +327,9 @@ public struct OUDSChipPicker<Tag: Hashable>: View {
         case let .text(text):
             OUDSFilterChip(text: text, selected: selected, action: action)
         case let .icon(icon, accessibilityLabel, renderingMode):
-            OUDSFilterChip(icon: icon, accessibilityLabel: accessibilityLabel, selected: selected, renderingMode: renderingMode, action: action)
+            OUDSFilterChip(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
         case let .textAndIcon(text, icon, renderingMode):
-            OUDSFilterChip(icon: icon, text: text, selected: selected, renderingMode: renderingMode, action: action)
+            OUDSFilterChip(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPicker.swift
@@ -327,9 +327,9 @@ public struct OUDSChipPicker<Tag: Hashable>: View {
         case let .text(text):
             OUDSFilterChip(text: text, selected: selected, action: action)
         case let .icon(icon, accessibilityLabel, renderingMode):
-            OUDSFilterChip(icon: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
+            OUDSFilterChip(image: OUDSImage(asset: icon, renderingMode: renderingMode), accessibilityLabel: accessibilityLabel, selected: selected, action: action)
         case let .textAndIcon(text, icon, renderingMode):
-            OUDSFilterChip(icon: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
+            OUDSFilterChip(image: OUDSImage(asset: icon, renderingMode: renderingMode), text: text, selected: selected, action: action)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
@@ -41,11 +41,13 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         /// Layout with text only
         case text(text: String)
 
-        /// Layout with icon only and its accessibility label
-        case icon(icon: Image, accessibilityLabel: String)
+        /// Layout with icon only and its accessibility label.
+        /// The `renderingMode` controls whether the icon is tinted (`.template`, default) or displayed as-is (`.original`).
+        case icon(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template)
 
-        /// Layout with text and icon
-        case textAndIcon(text: String, icon: Image)
+        /// Layout with text and icon.
+        /// The `renderingMode` controls whether the icon is tinted (`.template`, default) or displayed as-is (`.original`).
+        case textAndIcon(text: String, icon: Image, renderingMode: Image.TemplateRenderingMode = .template)
     }
 
     /// Defines the data to use to define the chip (``OUDSFilterChip``)

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
@@ -71,8 +71,10 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         /// - Parameters:
         ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
         ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip
-        public static func icon(_ image: OUDSImage, accessibilityLabel: String) -> Layout {
-            .icon(icon: image.asset ?? Image(""), accessibilityLabel: accessibilityLabel, renderingMode: image.renderingMode)
+        @MainActor public static func icon(_ image: OUDSImage, accessibilityLabel: String) -> Layout {
+            precondition(image.asset != nil, "OUDSChipPickerData.Layout.icon(_:image:) requires an reliable OUDSImage")
+            // swiftlint:disable:next force_unwrapping
+            return .icon(icon: image.image!, accessibilityLabel: accessibilityLabel, renderingMode: image.renderingMode)
         }
 
         /// Creates a text + icon layout from an ``OUDSImage``.
@@ -92,8 +94,10 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         /// - Parameters:
         ///    - text: The text to display in the chip
         ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
-        public static func textAndIcon(_ text: String, image: OUDSImage) -> Layout {
-            .textAndIcon(text: text, icon: image.asset ?? Image(""), renderingMode: image.renderingMode)
+        @MainActor public static func textAndIcon(_ text: String, image: OUDSImage) -> Layout {
+            precondition(image.asset != nil, "OUDSChipPickerData.Layout.textAndIcon(_:image:) requires an reliable OUDSImage")
+            // swiftlint:disable:next force_unwrapping
+            return .textAndIcon(text: text, icon: image.image!, renderingMode: image.renderingMode)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
@@ -48,6 +48,49 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         /// Layout with text and icon.
         /// The `renderingMode` controls whether the icon is tinted (`.template`, default) or displayed as-is (`.original`).
         case textAndIcon(text: String, icon: Image, renderingMode: Image.TemplateRenderingMode = .template)
+
+        // MARK: - OUDSImage factories
+
+        /// Creates an icon-only layout from an ``OUDSImage``.
+        ///
+        /// ```swift
+        ///     OUDSChipPickerData(tag: "a",
+        ///                        layout: .icon(OUDSImage(asset: Image("ic_heart")),
+        ///                                      accessibilityLabel: "Heart"))
+        ///
+        ///     // Raw (non-tinted) image:
+        ///     OUDSChipPickerData(tag: "b",
+        ///                        layout: .icon(OUDSImage(asset: Image("ic_brand"), renderingMode: .original),
+        ///                                      accessibilityLabel: "Brand"))
+        /// ```
+        ///
+        /// - Parameters:
+        ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
+        ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip
+        public static func icon(_ image: OUDSImage, accessibilityLabel: String) -> Layout {
+            .icon(icon: image.asset ?? Image(""), accessibilityLabel: accessibilityLabel, renderingMode: image.renderingMode)
+        }
+
+        /// Creates a text + icon layout from an ``OUDSImage``.
+        ///
+        /// ```swift
+        ///     OUDSChipPickerData(tag: "a",
+        ///                        layout: .textAndIcon("Label",
+        ///                                             image: OUDSImage(asset: Image("ic_heart"))))
+        ///
+        ///     // Raw (non-tinted) image:
+        ///     OUDSChipPickerData(tag: "b",
+        ///                        layout: .textAndIcon("Brand",
+        ///                                             image: OUDSImage(asset: Image("ic_brand"),
+        ///                                                              renderingMode: .original)))
+        /// ```
+        ///
+        /// - Parameters:
+        ///    - text: The text to display in the chip
+        ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
+        public static func textAndIcon(_ text: String, image: OUDSImage) -> Layout {
+            .textAndIcon(text: text, icon: image.asset ?? Image(""), renderingMode: image.renderingMode)
+        }
     }
 
     /// Defines the data to use to define the chip (``OUDSFilterChip``)

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
@@ -72,7 +72,7 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
         ///    - accessibilityLabel: The text to vocalize with Voice Over describing the chip
         @MainActor public static func icon(_ image: OUDSImage, accessibilityLabel: String) -> Layout {
-            precondition(image.asset != nil, "OUDSChipPickerData.Layout.icon(_:image:) requires an reliable OUDSImage")
+            precondition(image.image != nil, "OUDSChipPickerData.Layout.icon(icon:accessibilityLabel:renderingMode:) requires a reliable OUDSImage")
             // swiftlint:disable:next force_unwrapping
             return .icon(icon: image.image!, accessibilityLabel: accessibilityLabel, renderingMode: image.renderingMode)
         }
@@ -95,7 +95,7 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         ///    - text: The text to display in the chip
         ///    - image: An ``OUDSImage`` encapsulating the asset and its rendering mode
         @MainActor public static func textAndIcon(_ text: String, image: OUDSImage) -> Layout {
-            precondition(image.asset != nil, "OUDSChipPickerData.Layout.textAndIcon(_:image:) requires an reliable OUDSImage")
+            precondition(image.image != nil, "OUDSChipPickerData.Layout.textAndIcon(text:icon:renderingMode:) requires a reliable OUDSImage")
             // swiftlint:disable:next force_unwrapping
             return .textAndIcon(text: text, icon: image.image!, renderingMode: image.renderingMode)
         }

--- a/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/ChipPicker/OUDSChipPickerData.swift
@@ -41,10 +41,14 @@ public struct OUDSChipPickerData<Tag> where Tag: Hashable {
         /// Layout with text only
         case text(text: String)
 
+        // TODO: For version v3, use OUDSImage instead of icon, accessibilityLabel and renderingMode
+        // Not done yet to not break public API
         /// Layout with icon only and its accessibility label.
         /// The `renderingMode` controls whether the icon is tinted (`.template`, default) or displayed as-is (`.original`).
         case icon(icon: Image, accessibilityLabel: String, renderingMode: Image.TemplateRenderingMode = .template)
 
+        // TODO: For version v3, use OUDSImage instead of icon, accessibilityLabel and renderingMode
+        // Not done yet to not break public API
         /// Layout with text and icon.
         /// The `renderingMode` controls whether the icon is tinted (`.template`, default) or displayed as-is (`.original`).
         case textAndIcon(text: String, icon: Image, renderingMode: Image.TemplateRenderingMode = .template)

--- a/OUDS/Core/Components/Sources/Controls/PasswordInput/OUDSPasswordInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/PasswordInput/OUDSPasswordInput.swift
@@ -375,18 +375,17 @@ public struct OUDSPasswordInput: View {
 
     // MARK: - Helpers
 
-    private var leadingIcon: Image? {
+    private var leadingIcon: OUDSImage? {
         // TODO: #997 - Should we add an accessibility label?
-        lockIcon ? Image(decorative: "ic_communication_security_and_safety_lock", bundle: theme.resourcesBundle) : nil
+        lockIcon ? OUDSImage(asset: Image(decorative: "ic_communication_security_and_safety_lock", bundle: theme.resourcesBundle)) : nil
     }
 
     private var trailingAction: OUDSTextInput.TrailingAction {
         let iconName = isHiddenPassword ? "ic_communication_accessibility_vision" : "ic_functional_settings_and_tools_hide"
         let actionHint = isHiddenPassword ? "core_passwordInput_showPassword_a11y" : "core_passwordInput_hidePassword_a11y"
 
-        return .init(icon: Image(decorative: iconName, bundle: theme.resourcesBundle),
-                     actionHint: actionHint.localized(),
-                     flipIcon: false)
+        return .init(icon: OUDSImage(asset: Image(decorative: iconName, bundle: theme.resourcesBundle)),
+                     actionHint: actionHint.localized())
         {
             isHiddenPassword.toggle()
         }

--- a/OUDS/Core/Components/Sources/Controls/PasswordInput/OUDSPasswordInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/PasswordInput/OUDSPasswordInput.swift
@@ -339,7 +339,7 @@ public struct OUDSPasswordInput: View {
                           text: password,
                           placeholder: placeholder,
                           prefix: prefix,
-                          leadingIcon: leadingIcon,
+                          leadingImage: leadingIcon,
                           trailingAction: trailingAction,
                           helperText: rawHelperText,
                           isOutlined: isOutlined,
@@ -351,7 +351,7 @@ public struct OUDSPasswordInput: View {
                           text: password,
                           placeholder: placeholder,
                           prefix: prefix,
-                          leadingIcon: leadingIcon,
+                          leadingImage: leadingIcon,
                           trailingAction: trailingAction,
                           helperText: richHelperText,
                           isOutlined: isOutlined,
@@ -363,7 +363,7 @@ public struct OUDSPasswordInput: View {
                           text: password,
                           placeholder: placeholder,
                           prefix: prefix,
-                          leadingIcon: leadingIcon,
+                          leadingImage: leadingIcon,
                           trailingAction: trailingAction,
                           helperText: nil,
                           isOutlined: isOutlined,
@@ -384,7 +384,7 @@ public struct OUDSPasswordInput: View {
         let iconName = isHiddenPassword ? "ic_communication_accessibility_vision" : "ic_functional_settings_and_tools_hide"
         let actionHint = isHiddenPassword ? "core_passwordInput_showPassword_a11y" : "core_passwordInput_hidePassword_a11y"
 
-        return .init(icon: OUDSImage(asset: Image(decorative: iconName, bundle: theme.resourcesBundle)),
+        return .init(image: OUDSImage(asset: Image(decorative: iconName, bundle: theme.resourcesBundle)),
                      actionHint: actionHint.localized())
         {
             isHiddenPassword.toggle()

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -193,7 +193,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -338,7 +338,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -479,7 +479,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -598,7 +598,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action: instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -106,6 +106,18 @@ import SwiftUI
 ///                   isError: true,
 ///                   hasDivider: true)
 ///
+///     // A trailing radio with a label, a description, an icon, a divider and is about an error.
+///     // The reversed layout will be used here.
+///     // The image is kept as is, raw, and not tinted.
+///     OUDSRadioItem("Rescue from this world!",
+///                   isOn: $selection,
+///                   description: "Put your hand in mine",
+///                   icon: Image(decorative: "il_someImage"),
+///                   renderingMode: .original,
+///                   isReversed: true,
+///                   isError: true,
+///                   hasDivider: true)
+///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
@@ -193,6 +205,7 @@ public struct OUDSRadioItem: View {
     ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -215,6 +228,7 @@ public struct OUDSRadioItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -260,6 +274,7 @@ public struct OUDSRadioItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: isOutlined,
             isError: isError,
             errorText: errorTextContent,
@@ -294,6 +309,7 @@ public struct OUDSRadioItem: View {
     ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -316,6 +332,7 @@ public struct OUDSRadioItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -353,6 +370,7 @@ public struct OUDSRadioItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: isOutlined,
             isError: isError,
             errorText: .attributed(errorText),
@@ -382,6 +400,7 @@ public struct OUDSRadioItem: View {
     ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -398,6 +417,7 @@ public struct OUDSRadioItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -413,6 +433,7 @@ public struct OUDSRadioItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -444,6 +465,7 @@ public struct OUDSRadioItem: View {
     ///   - description: A description, like an helper text, should not be empty, default set to `nil`
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -460,6 +482,7 @@ public struct OUDSRadioItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -475,6 +498,7 @@ public struct OUDSRadioItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -14,7 +14,12 @@
 import OUDSFoundations
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these warnings
+
 // swiftlint:disable file_length
+// swiftlint:disable function_default_parameter_at_end
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 
 /// Radio button item is a UI element that allows to select a single option from a set of mutually exclusive choices.
 /// Radio button item covers a wider range of contexts by allowing to toggle the visibility of additional text labels and icon assets.
@@ -45,8 +50,8 @@ import SwiftUI
 /// The component does not follow the right-to-left (RTL) / left-to-right (LTR) mode returned by the system as it could have some meaning
 /// to have for example the indicator in trailing position for LTR mode and vice versa.
 /// However, if the component has an icon in leading position (RTL mode) or in trailing position (LTR), the content of the icon is never changed.
-/// It could lead to a loss of meaning or semantics in the icon. Thus a specific flag can be used to flip the icon content whatever the layout direction is.
-/// It prevents the user do implement its own rules to flip or not image.
+/// It could lead to a loss of meaning or semantics in the icon. Thus the ``OUDSImage`` `flipped` property can be used to flip the icon content
+/// whatever the layout direction is, preventing the user from implementing their own rules to flip or not the image.
 ///
 /// ## Rich text
 ///
@@ -71,52 +76,49 @@ import SwiftUI
 ///
 /// ## Code samples
 ///
-/// The ``OUDSRadioItem``can be used outside a dedicated picker, thus it does not need any tag and associated type.
+/// The ``OUDSRadioItem`` can be used outside a dedicated picker, thus it does not need any tag and associated type.
 ///
 /// ```swift
 ///     // Supposing we have an unselected state
 ///     @Published var selection: Bool = false
 ///
 ///     // A leading radio with a label.
-///     // The default layout will be used here.
 ///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection)
 ///
 ///     // Localizable from bundle can also be used
 ///     OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $selection)
 ///
 ///     // A leading radio with a label, but in read only mode (user cannot interact yet, but not disabled).
-///     // The default layout will be used here.
 ///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, isReadOnly: true)
 ///
-///     // A leading radio with a label, and an additional label but without text.
-///     // The default layout will be used here.
-///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles")
+///     // A leading radio with an additional label and a description.
+///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection,
+///                   extraLabel: "The Beatles", description: "1967")
 ///
-///     // A leading radio with an additional label.
-///     // The default layout will be used here.
-///     OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $selection, extraLabel: "The Beatles", description: "1967")
-///
-///     // A trailing radio with a label, a description, an icon, a divider and is about an error.
-///     // The reversed layout will be used here.
+///     // A trailing radio with a label, a description, a tinted icon, a divider and an error.
 ///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
-///                   icon: Image(decorative: "ic_heart"),
+///                   icon: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                   isReversed: true,
 ///                   isError: true,
 ///                   hasDivider: true)
 ///
-///     // A trailing radio with a label, a description, an icon, a divider and is about an error.
-///     // The reversed layout will be used here.
-///     // The image is kept as is, raw, and not tinted.
+///     // A trailing radio with a raw (non-tinted) image.
 ///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
-///                   icon: Image(decorative: "il_someImage"),
-///                   renderingMode: .original,
+///                   icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                   isReversed: true,
 ///                   isError: true,
 ///                   hasDivider: true)
+///
+///     // Flip the icon for RTL layouts using OUDSImage.
+///     OUDSRadioItem("Cocorico !",
+///                   isOn: $selection,
+///                   icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                   flipped: layoutDirection == .rightToLeft),
+///                   isReversed: layoutDirection == .rightToLeft)
 ///
 ///     // If on error, add an error message can help user to understand error context
 ///     OUDSRadioItem("Rescue from this world!",
@@ -126,7 +128,6 @@ import SwiftUI
 ///                   hasDivider: true)
 ///
 ///     // A leading radio with a label, but disabled.
-///     // The default layout will be used here.
 ///     OUDSRadioItem("Rescue from this world!", isOn: $selection)
 ///         .disabled(true)
 ///
@@ -134,17 +135,6 @@ import SwiftUI
 ///     // This is forbidden by design!
 ///     OUDSRadioItem("Kaboom!", isOn: $selection, isError: true).disabled(true) // fatal error
 ///     OUDSRadioItem("Kaboom!", isOn: $selection, isReadOnly: true).disabled(true) // fatal error
-/// ```
-///
-/// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
-/// ```swift
-///     @Environment(\.layoutDirection) var layoutDirection
-///
-///     OUDSRadioItem("Cocorico !",
-///                   isOn: $selection,
-///                   icon: Image(systemName: "figure.handball"),
-///                   flipIcon: layoutDirection == .rightToLeft,
-///                   isInversed: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Design documentation
@@ -183,45 +173,27 @@ public struct OUDSRadioItem: View {
 
     @Environment(\.isEnabled) private var isEnabled
 
-    // MARK: - Initializer
+    // MARK: - Initializers — String label + errorText: String?
 
     /// Creates a radio with label and optional helper text as description, icon, divider.
-    /// Supposed to be integrated inside a ``OUDSRadioPicker``.
-    ///
-    /// ```swift
-    ///     OUDSRadioItem("Virgin Holy Lava",
-    ///                   isOn: $selection,
-    ///                   extraLabel: "Very spicy",
-    ///                   description: "No alcohol, only tasty flavors",
-    ///                   icon: Image(systemName: "flame")
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
     ///
     /// - Parameters:
     ///   - label: The main label text of the radio, must not be empty
-    ///   - isOn: A binding to a property that determines whether the toggle is on or off.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
-    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view.
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
-    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///     modifier. Defaults to `false`.
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    ///
-    /// **Remark 1: As divider and outline effect are not supposed to be displayed at the same time, the divider is not displayed if the outline effect is active.**
-    ///
-    /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
-    /// provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -229,6 +201,69 @@ public struct OUDSRadioItem: View {
                 icon: Image? = nil,
                 flipIcon: Bool = false,
                 renderingMode: Image.TemplateRenderingMode = .template,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: oudsImage,
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a radio with label and optional helper text as description, icon, divider.
+    ///
+    /// ```swift
+    ///     OUDSRadioItem("Virgin Holy Lava",
+    ///                   isOn: $selection,
+    ///                   extraLabel: "Very spicy",
+    ///                   description: "No alcohol, only tasty flavors",
+    ///                   icon: OUDSImage(asset: Image(systemName: "flame")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// **Remark 1: As divider and outline effect are not supposed to be displayed at the same time, the divider is not displayed if the outline effect is active.**
+    ///
+    /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the radio, must not be empty
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - extraLabel: An additional label text of the radio, default set to `nil`
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isOutlined: Flag to get an outlined radio, default set to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the radio button has been pressed
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -273,8 +308,6 @@ public struct OUDSRadioItem: View {
             extraLabel: extraLabel?.localized(),
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: isOutlined,
             isError: isError,
             errorText: errorTextContent,
@@ -285,47 +318,27 @@ public struct OUDSRadioItem: View {
         self.action = action
     }
 
-    // For API signature consistency disable this warning
-    // swiftlint:disable function_default_parameter_at_end
+    // MARK: - Initializers — String label + errorText: AttributedString
 
     /// Creates a radio with label and optional helper text as description, icon, divider.
     ///
-    /// ```swift
-    ///     OUDSRadioItem("Virgin Holy Lava",
-    ///                   isOn: $selection,
-    ///                   extraLabel: "Very spicy",
-    ///                   description: "No alcohol, only tasty flavors",
-    ///                   icon: Image(systemName: "flame"),
-    ///                   errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
-    ///                    // Manage in your side errors for init for AttributedString(markdown:)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
-    ///
     /// - Parameters:
     ///   - label: The main label text of the radio, must not be empty
-    ///   - isOn: A binding to a property that determines whether the toggle is on or off.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
-    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view.
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
-    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///     modifier. Defaults to `false`.
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    ///
-    /// **Remark 1: As divider and outline effect are not supposed to be displayed at the same time, the divider is not displayed if the outline effect is active.**
-    ///
-    /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
-    /// provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -333,6 +346,71 @@ public struct OUDSRadioItem: View {
                 icon: Image? = nil,
                 flipIcon: Bool = false,
                 renderingMode: Image.TemplateRenderingMode = .template,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: oudsImage,
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a radio with label, optional helper text, icon, divider, and a rich attributed error text.
+    ///
+    /// ```swift
+    ///     OUDSRadioItem("Virgin Holy Lava",
+    ///                   isOn: $selection,
+    ///                   extraLabel: "Very spicy",
+    ///                   description: "No alcohol, only tasty flavors",
+    ///                   icon: OUDSImage(asset: Image(systemName: "flame")),
+    ///                   errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
+    ///                    // Manage in your side errors for init for AttributedString(markdown:)
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// **Remark 1: As divider and outline effect are not supposed to be displayed at the same time, the divider is not displayed if the outline effect is active.**
+    ///
+    /// **Remark 2: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are automatically localized. Else, prefer to
+    /// provide the localized string if key is stored in another bundle.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the radio, must not be empty
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - extraLabel: An additional label text of the radio, default set to `nil`
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isOutlined: Flag to get an outlined radio, default set to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    ///   - action: An additional action to trigger when the radio button has been pressed
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -369,8 +447,6 @@ public struct OUDSRadioItem: View {
             extraLabel: extraLabel?.localized(),
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: isOutlined,
             isError: isError,
             errorText: .attributed(errorText),
@@ -381,15 +457,9 @@ public struct OUDSRadioItem: View {
         self.action = action
     }
 
-    /// Creates a radio with a localized label, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSRadioItem(LocalizedStringKey("option_label"),
-    ///                   bundle: Bundle.module,
-    ///                   isOn: $selection)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    // MARK: - Initializers — LocalizedStringKey + errorText: String?
+
+    /// Creates a radio with a localized label.
     ///
     /// - Parameters:
     ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
@@ -397,18 +467,19 @@ public struct OUDSRadioItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -427,13 +498,12 @@ public struct OUDSRadioItem: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
+                  icon: oudsImage,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -449,9 +519,12 @@ public struct OUDSRadioItem: View {
     /// ```swift
     ///     OUDSRadioItem(LocalizedStringKey("option_label"),
     ///                   bundle: Bundle.module,
+    ///                   isOn: $selection)
+    ///
+    ///     OUDSRadioItem(LocalizedStringKey("option_label"),
+    ///                   bundle: Bundle.module,
     ///                   isOn: $selection,
-    ///                   errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
-    ///                    // Manage in your side errors for init for AttributedString(markdown:)
+    ///                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -462,18 +535,70 @@ public struct OUDSRadioItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
-    ///   - description: A description, like an helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
-    ///   - isReversed: `true` of the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
     ///   - isReadOnly: True if component is in read only, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
     ///   - action: An additional action to trigger when the radio button has been pressed
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: icon,
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    // MARK: - Initializers — LocalizedStringKey + errorText: AttributedString
+
+    /// Creates a radio with a localized label and a rich attributed error text.
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - extraLabel: An additional label text of the radio, default set to `nil`
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isOutlined: Flag to get an outlined radio, default set to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    ///   - action: An additional action to trigger when the radio button has been pressed
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -492,13 +617,71 @@ public struct OUDSRadioItem: View {
                 constrainedMaxWidth: Bool = false,
                 action: (() -> Void)? = nil)
     {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: oudsImage,
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  action: action)
+    }
+
+    /// Creates a radio with a localized label and a rich attributed error text.
+    ///
+    /// ```swift
+    ///     OUDSRadioItem(LocalizedStringKey("option_label"),
+    ///                   bundle: Bundle.module,
+    ///                   isOn: $selection,
+    ///                   errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
+    ///                    // Manage in your side errors for init for AttributedString(markdown:)
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - extraLabel: An additional label text of the radio, default set to `nil`
+    ///   - description: A description, like a helper text, should not be empty, default set to `nil`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isOutlined: Flag to get an outlined radio, default set to `false`
+    ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - action: An additional action to trigger when the radio button has been pressed
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                action: (() -> Void)? = nil)
+    {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
                   icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -511,7 +694,7 @@ public struct OUDSRadioItem: View {
 
     // swiftlint:enable function_default_parameter_at_end
 
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         ControlItem(indicatorType: .radioButton($isOn), layoutData: layoutData, action: action)
@@ -555,4 +738,5 @@ public struct OUDSRadioItem: View {
     }
 }
 
-// swiftlint:enable file_length
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -99,7 +99,7 @@ import SwiftUI
 ///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
-///                   icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+///                   image: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                   isReversed: true,
 ///                   isError: true,
 ///                   hasDivider: true)
@@ -108,7 +108,7 @@ import SwiftUI
 ///     OUDSRadioItem("Rescue from this world!",
 ///                   isOn: $selection,
 ///                   description: "Put your hand in mine",
-///                   icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
+///                   image: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                   isReversed: true,
 ///                   isError: true,
 ///                   hasDivider: true)
@@ -116,7 +116,7 @@ import SwiftUI
 ///     // Flip the icon for RTL layouts using OUDSImage.
 ///     OUDSRadioItem("Cocorico !",
 ///                   isOn: $selection,
-///                   icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                   image: OUDSImage(asset: Image(systemName: "figure.handball"),
 ///                                   flipped: layoutDirection == .rightToLeft),
 ///                   isReversed: layoutDirection == .rightToLeft)
 ///
@@ -193,7 +193,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -215,7 +215,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -233,7 +233,7 @@ public struct OUDSRadioItem: View {
     ///                   isOn: $selection,
     ///                   extraLabel: "Very spicy",
     ///                   description: "No alcohol, only tasty flavors",
-    ///                   icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///                   image: OUDSImage(asset: Image(systemName: "flame")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -248,7 +248,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -263,7 +263,7 @@ public struct OUDSRadioItem: View {
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -307,7 +307,7 @@ public struct OUDSRadioItem: View {
             label: label.localized(),
             extraLabel: extraLabel?.localized(),
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: isOutlined,
             isError: isError,
             errorText: errorTextContent,
@@ -338,7 +338,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
@@ -360,7 +360,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -378,7 +378,7 @@ public struct OUDSRadioItem: View {
     ///                   isOn: $selection,
     ///                   extraLabel: "Very spicy",
     ///                   description: "No alcohol, only tasty flavors",
-    ///                   icon: OUDSImage(asset: Image(systemName: "flame")),
+    ///                   image: OUDSImage(asset: Image(systemName: "flame")),
     ///                   errorText: AttributedString(markdown: "Please select **one flavor** for this drink"))
     ///                    // Manage in your side errors for init for AttributedString(markdown:)
     /// ```
@@ -395,7 +395,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -410,7 +410,7 @@ public struct OUDSRadioItem: View {
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -446,7 +446,7 @@ public struct OUDSRadioItem: View {
             label: label.localized(),
             extraLabel: extraLabel?.localized(),
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: isOutlined,
             isError: isError,
             errorText: .attributed(errorText),
@@ -479,7 +479,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -503,7 +503,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -524,7 +524,7 @@ public struct OUDSRadioItem: View {
     ///     OUDSRadioItem(LocalizedStringKey("option_label"),
     ///                   bundle: Bundle.module,
     ///                   isOn: $selection,
-    ///                   icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+    ///                   image: OUDSImage(asset: Image(decorative: "ic_heart")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -536,7 +536,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -551,7 +551,7 @@ public struct OUDSRadioItem: View {
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -565,7 +565,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -598,7 +598,7 @@ public struct OUDSRadioItem: View {
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
     ///   - action: An additional action to trigger when the radio button has been pressed
-    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:icon:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioItem(_:tableName:bundle:isOn:extraLabel:description:image:isOutlined:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:action:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -622,7 +622,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -652,7 +652,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -667,7 +667,7 @@ public struct OUDSRadioItem: View {
                 isOn: Binding<Bool>,
                 extraLabel: String? = nil,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -681,7 +681,7 @@ public struct OUDSRadioItem: View {
                   isOn: isOn,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,

--- a/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Radio/OUDSRadioItem.swift
@@ -248,7 +248,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -395,7 +395,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -536,7 +536,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
@@ -652,7 +652,7 @@ public struct OUDSRadioItem: View {
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - extraLabel: An additional label text of the radio, default set to `nil`
     ///   - description: A description, like a helper text, should not be empty, default set to `nil`
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isOutlined: Flag to get an outlined radio, default set to `false`
     ///   - isReversed: `true` if the radio indicator must be in trailing position, `false` otherwise. Default to `false`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
@@ -210,7 +210,7 @@ public struct OUDSRadioPicker<Tag>: View where Tag: Hashable {
                       isOn: selection.wrappedValue == radio.tag ? .constant(true) : .constant(false),
                       extraLabel: radio.extraLabel,
                       description: radio.description,
-                      icon: radio.icon,
+                      image: radio.icon,
                       isOutlined: isOutlined ? true : radio.isOutlined,
                       isReversed: isReversed ? true : radio.isReversed,
                       isError: isError ? true : radio.isError,

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
@@ -45,16 +45,16 @@ import SwiftUI
 ///                                         label: "Virgin Holy Lava",
 ///                                         extraLabel: "Very spicy",
 ///                                         description: "No alcohol, only tasty flavors",
-///                                         icon: Image(systemName: "flame")),
+///                                         image: Image(systemName: "flame")),
 ///
 ///             OUDSRadioPickerData<String>(tag: "Choice_2",
 ///                                         label: "IPA beer",
 ///                                         description: "From Brewdog company",
-///                                         icon: Image(systemName: "dog.fill")),
+///                                         image: Image(systemName: "dog.fill")),
 ///
 ///             OUDSRadioPickerData<String>(tag: "Choice_3",
 ///                                         label: "Mineral water",
-///                                         icon: Image(systemName: "waterbottle.fill")),
+///                                         image: Image(systemName: "waterbottle.fill")),
 ///         ]
 ///     }
 ///

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPicker.swift
@@ -45,16 +45,16 @@ import SwiftUI
 ///                                         label: "Virgin Holy Lava",
 ///                                         extraLabel: "Very spicy",
 ///                                         description: "No alcohol, only tasty flavors",
-///                                         image: Image(systemName: "flame")),
+///                                         image: OUDSImage(asset: Image(systemName: "flame")),
 ///
 ///             OUDSRadioPickerData<String>(tag: "Choice_2",
 ///                                         label: "IPA beer",
 ///                                         description: "From Brewdog company",
-///                                         image: Image(systemName: "dog.fill")),
+///                                         image: OUDSImage(asset: Image(systemName: "dog.fill")),
 ///
 ///             OUDSRadioPickerData<String>(tag: "Choice_3",
 ///                                         label: "Mineral water",
-///                                         image: Image(systemName: "waterbottle.fill")),
+///                                         image: OUDSImage(asset: Image(systemName: "waterbottle.fill")),
 ///         ]
 ///     }
 ///

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
@@ -74,7 +74,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
     ///    - isReadOnly: True if read only, false otherwise (default)
     ///    - hasDivider: True if a divider must be added for the current ``OUDSRadioItem``, false otherwise (default)
     ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    @available(*, deprecated, message: "Use OUDSRadioPickerData(tag:label:extraLabel:description:image:isOutlined:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioPickerData(tag:label:extraLabel:description:image:isOutlined:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) instead.")
     public init(tag: Tag,
                 label: String,
                 extraLabel: String? = nil,

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
@@ -74,7 +74,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
     ///    - isReadOnly: True if read only, false otherwise (default)
     ///    - hasDivider: True if a divider must be added for the current ``OUDSRadioItem``, false otherwise (default)
     ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    @available(*, deprecated, message: "Use OUDSRadioPickerData(tag:label:extraLabel:description:icon:isOutlined:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSRadioPickerData(tag:label:extraLabel:description:image:isOutlined:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
     public init(tag: Tag,
                 label: String,
                 extraLabel: String? = nil,
@@ -91,7 +91,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
                   label: label,
                   extraLabel: extraLabel,
                   description: description,
-                  icon: icon.map { OUDSImage(asset: $0) },
+                  image: icon.map { OUDSImage(asset: $0) },
                   isOutlined: isOutlined,
                   isReversed: isReversed,
                   isError: isError,
@@ -107,12 +107,12 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
     ///
     ///     OUDSRadioPickerData(tag: "option2",
     ///                         label: "Option 2",
-    ///                         icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///                         image: OUDSImage(asset: Image(systemName: "flame")))
     ///
     ///     // Raw (non-tinted) image:
     ///     OUDSRadioPickerData(tag: "option3",
     ///                         label: "Option 3",
-    ///                         icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+    ///                         image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
     /// ```
     ///
     /// - Parameters:
@@ -120,7 +120,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
     ///    - label: the mandatory text to add to ``OUDSRadioItem``
     ///    - extraLabel: An optional additional text, default set to nil
     ///    - description: Another optional text, a description, default set to nil
-    ///    - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///    - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
     ///    - isOutlined: True to outline the ``OUDSRadioItem``, false otherwise (default)
     ///    - isReversed: True to use to reversed layout of the ``OUDSRadioItem``, false otherwise (default)
     ///    - isError: True if in an error context, false otherwise (default)
@@ -134,7 +134,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
                 label: String,
                 extraLabel: String? = nil,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -146,7 +146,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
         self.label = label
         self.extraLabel = extraLabel
         self.description = description
-        self.icon = icon
+        icon = image
         self.isOutlined = isOutlined
         self.isReversed = isReversed
         self.isError = isError

--- a/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
+++ b/OUDS/Core/Components/Sources/Controls/RadioPicker/OUDSRadioPickerData.swift
@@ -14,6 +14,10 @@
 #if !os(watchOS) && !os(tvOS)
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these warnings
+
+// swiftlint:disable line_length
+
 /// The data to use to populate the picker of ``OUDSRadioItem`` objects.
 /// Each property in this ``OUDSRadioPickerData`` is used to define the suitable ``OUDSRadioItem``.
 ///
@@ -33,8 +37,8 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
     /// A description the ``OUDSRadioItem`` can have
     let description: String?
 
-    /// An optional image the ``OUDSRadioItem`` can have
-    let icon: Image?
+    /// An optional image the ``OUDSRadioItem`` can have, encapsulating the asset, flip flag and rendering mode
+    let icon: OUDSImage?
 
     /// Define if the ``OUDSRadioItem`` is outlined or not
     let isOutlined: Bool
@@ -58,30 +62,79 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
 
     /// Defines the data to use to define the radio buttons (``OUDSRadioItem``)
     ///
-    /// ```swift
-    ///     OUDSRadioPickerData(tag: "option1", label: "Option 1")
-    /// ```
-    ///
     /// - Parameters:
     ///    - tag: a value to discriminate one radio to another
     ///    - label: the mandatory text to add to ``OUDSRadioItem``
-    ///    - extraLabel: An optional additinal text, default set to nil
+    ///    - extraLabel: An optional additional text, default set to nil
     ///    - description: Another optional text, a description, default set to nil
     ///    - icon: An optional image, default set to nil
     ///    - isOutlined: True to outline the ``OUDSRadioItem``, false otherwise (default)
-    ///    - isReversed: True to use to reversed layour of the ``OUDSRadioItem``, false otherwise (default)
+    ///    - isReversed: True to use to reversed layout of the ``OUDSRadioItem``, false otherwise (default)
     ///    - isError: True if in an error context, false otherwise (default)
     ///    - isReadOnly: True if read only, false otherwise (default)
     ///    - hasDivider: True if a divider must be added for the current ``OUDSRadioItem``, false otherwise (default)
     ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
-    ///
-    /// **Remark: If `label`, `extraLabel` and `helper` strings are wording keys from strings catalog stored in `Bundle.main`, they are
-    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
+    @available(*, deprecated, message: "Use OUDSRadioPickerData(tag:label:extraLabel:description:icon:isOutlined:isReversed:isError:isReadOnly:hasDivider:accessibilityIdentifier:) with icon: OUDSImage? instead.")
     public init(tag: Tag,
                 label: String,
                 extraLabel: String? = nil,
                 description: String? = nil,
                 icon: Image? = nil,
+                isOutlined: Bool = false,
+                isReversed: Bool = false,
+                isError: Bool = false,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                accessibilityIdentifier: String? = nil)
+    {
+        self.init(tag: tag,
+                  label: label,
+                  extraLabel: extraLabel,
+                  description: description,
+                  icon: icon.map { OUDSImage(asset: $0) },
+                  isOutlined: isOutlined,
+                  isReversed: isReversed,
+                  isError: isError,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  accessibilityIdentifier: accessibilityIdentifier)
+    }
+
+    /// Defines the data to use to define the radio buttons (``OUDSRadioItem``)
+    ///
+    /// ```swift
+    ///     OUDSRadioPickerData(tag: "option1", label: "Option 1")
+    ///
+    ///     OUDSRadioPickerData(tag: "option2",
+    ///                         label: "Option 2",
+    ///                         icon: OUDSImage(asset: Image(systemName: "flame")))
+    ///
+    ///     // Raw (non-tinted) image:
+    ///     OUDSRadioPickerData(tag: "option3",
+    ///                         label: "Option 3",
+    ///                         icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - tag: a value to discriminate one radio to another
+    ///    - label: the mandatory text to add to ``OUDSRadioItem``
+    ///    - extraLabel: An optional additional text, default set to nil
+    ///    - description: Another optional text, a description, default set to nil
+    ///    - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///    - isOutlined: True to outline the ``OUDSRadioItem``, false otherwise (default)
+    ///    - isReversed: True to use to reversed layout of the ``OUDSRadioItem``, false otherwise (default)
+    ///    - isError: True if in an error context, false otherwise (default)
+    ///    - isReadOnly: True if read only, false otherwise (default)
+    ///    - hasDivider: True if a divider must be added for the current ``OUDSRadioItem``, false otherwise (default)
+    ///    - accessibilityIdentifier: The accessibility identifier to add to the item, nil by default
+    ///
+    /// **Remark: If `label`, `extraLabel` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are
+    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
+    public init(tag: Tag,
+                label: String,
+                extraLabel: String? = nil,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
                 isOutlined: Bool = false,
                 isReversed: Bool = false,
                 isError: Bool = false,
@@ -102,4 +155,7 @@ public struct OUDSRadioPickerData<Tag> where Tag: Hashable {
         self.accessibilityIdentifier = accessibilityIdentifier
     }
 }
+
+// swiftlint:enable line_length
+
 #endif

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -174,7 +174,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -297,7 +297,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -413,7 +413,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -512,7 +512,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -14,6 +14,13 @@
 import OUDSFoundations
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these warnings
+
+// swiftlint:disable file_length
+// swiftlint:disable function_default_parameter_at_end
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
+
 // MARK: - OUDS Switch Item
 
 /// Switch item is a UI element that allows to toggle between two states, typically "On" and "Off", and used to enable or disable features, options or settings.
@@ -38,7 +45,6 @@ import SwiftUI
 ///
 /// In addition, the ``OUDSSwitchItem`` can be in read only mode, i.e. the user cannot interact with the component yet but this component must not be considered
 /// as disabled.
-/// The switch can be also outlined in some cases.
 ///
 /// ## Accessibility considerations
 ///
@@ -57,53 +63,38 @@ import SwiftUI
 ///     @Published var isOn: Bool = false
 ///
 ///     // A leading switch with a label.
-///     // The default layout will be used here.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn)
 ///
 ///     // Localizable from bundle can also be used
 ///     OUDSSwitchItem(LocalizedStringKey("notifications_setting"), bundle: Bundle.module, isOn: $isOn)
 ///
 ///     // A leading switch with a label, but in read only mode (user cannot interact yet, but not disabled).
-///     // The default layout will be used here.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, isReadOnly: true)
 ///
-///     // A leading switch with a label, and a description text.
-///     // The default layout will be used here.
+///     // A leading switch with a label and a description text.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, description: "The Beatles")
 ///
-///     // A leading switch with an additional label.
-///     // The default layout will be used here.
-///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, description: "The Beatles")
-///
-///     // A trailing switch with a label, an additional label, a description text and an icon.
-///     // The reversed layout will be used here.
+///     // A trailing switch with a label, a description and a tinted icon.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
 ///                    description: "The Beatles",
-///                    icon: Image(decorative: "ic_heart"),
+///                    icon: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                    isReversed: true)
 ///
-///     // A trailing switch with a label, an additional label, a description text and an icon.
-///     // The reversed layout will be used here.
-///     // Image is kept as is, raw, without tint.
+///     // A trailing switch with a raw (non-tinted) image.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
 ///                    description: "The Beatles",
-///                    icon: Image(decorative: "il_someImage"),
-///                    renderingMode: .original,
+///                    icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                    isReversed: true)
 ///
-///     // A trailing switch with a label, a description text, an icon, a divider and is about an error.
-///     // The inverse layout will be used here.
-///     OUDSSwitchItem("Rescue from this world!",
+///     // Flip the icon for RTL layouts using OUDSImage.
+///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
-///                    description: "Put your hand in mine",
-///                    icon: Image(decorative: "ic_heart"),
-///                    isReversed: true,
-///                    isError: true,
-///                    hasDivider: true)
+///                    icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                                    flipped: layoutDirection == .rightToLeft))
 ///
-///     // If on error, add an error message can help user to understand error context
+///     // If on error, add an error message to help user understand the error context
 ///     OUDSSwitchItem("Rescue from this world!",
 ///                    isOn: $isOn,
 ///                    isError: true,
@@ -111,7 +102,6 @@ import SwiftUI
 ///                    hasDivider: true)
 ///
 ///     // A leading switch with a label, but disabled.
-///     // The default layout will be used here.
 ///     OUDSSwitchItem("Rescue from this world!", isOn: $isOn)
 ///         .disabled(true)
 ///
@@ -119,13 +109,6 @@ import SwiftUI
 ///     // This is forbidden by design!
 ///     OUDSSwitchItem("Kaboom!", isOn: $isOn, isError: true).disabled(true) // fatal error
 ///     OUDSSwitchItem("Kaboom!", isOn: $isOn, isReadOnly: true).disabled(true) // fatal error
-/// ```
-///
-/// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
-/// ```swift
-///     @Environment(\.layoutDirection) var layoutDirection
-///
-///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, flipLeadingIcon: layoutDirection == .rightToLeft)
 /// ```
 ///
 /// ## Rich text
@@ -174,44 +157,82 @@ public struct OUDSSwitchItem: View {
 
     @Environment(\.isEnabled) private var isEnabled
 
-    // MARK: - Initializers
-
-    // For API signature consistency disable this warning
-    // swiftlint:disable function_default_parameter_at_end
+    // MARK: - Initializers — String label + errorText: String?
 
     /// Creates a switch with label and optional description text, icon, divider.
     ///
-    /// ```swift
-    ///     OUDSSwitchItem("Wi-Fi", isOn: $isOn)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
-    ///
     /// - Parameters:
     ///   - label: The main label text of the switch, must not be empty
-    ///   - isOn: A binding to a property that determines whether the toggle is on or off.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
-    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view.
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
-    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///     modifier. Defaults to `false`.
-    ///
-    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are
-    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
                 renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = true,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth)
+    }
+
+    /// Creates a switch with label and optional description text, icon, divider.
+    ///
+    /// ```swift
+    ///     OUDSSwitchItem("Wi-Fi", isOn: $isOn)
+    ///
+    ///     OUDSSwitchItem("Wi-Fi", isOn: $isOn,
+    ///                    icon: OUDSImage(asset: Image(decorative: "ic_wifi")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are
+    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the switch, must not be empty
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - description: An additional helper text, a description, should not be empty
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   The `errorText` can be different if switch is selected or not.
+    ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
+    ///     modifier. Defaults to `false`.
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -250,8 +271,6 @@ public struct OUDSSwitchItem: View {
             extraLabel: nil,
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -259,6 +278,50 @@ public struct OUDSSwitchItem: View {
             hasDivider: hasDivider,
             constrainedMaxWidth: constrainedMaxWidth,
             orientation: isReversed ? .reversed : .default)
+    }
+
+    // MARK: - Initializers — String label + errorText: AttributedString
+
+    /// Creates a switch with label, optional description text, icon, divider, and an error message in rich text format.
+    ///
+    /// - Parameters:
+    ///   - label: The main label text of the switch, must not be empty
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - description: An additional helper text, a description, should not be empty
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    public init(_ label: String,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = true,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(label,
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth)
     }
 
     /// Creates a switch with label, optional description text, icon, divider, and an error message in rich text format.
@@ -272,31 +335,26 @@ public struct OUDSSwitchItem: View {
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
     ///
+    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are
+    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
+    ///
     /// - Parameters:
     ///   - label: The main label text of the switch, must not be empty
-    ///   - isOn: A binding to a property that determines whether the toggle is on or off.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   The `errorText`can be different if switch is selected or not.
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
     ///   - isReadOnly: True if component is in read only, i.e. not really disabled but user cannot interact with it yet, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view.
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
     ///     When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
     ///     modifier. Defaults to `false`.
-    ///
-    /// **Remark: If `label` and `description` strings are wording keys from strings catalog stored in `Bundle.main`, they are
-    /// automatically localized. Else, prefer to provide the localized string if key is stored in another bundle.**
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: Image? = nil,
-                flipIcon: Bool = false,
-                renderingMode: Image.TemplateRenderingMode = .template,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -327,8 +385,6 @@ public struct OUDSSwitchItem: View {
             extraLabel: nil,
             description: description?.localized(),
             icon: icon,
-            flipIcon: flipIcon,
-            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -338,13 +394,9 @@ public struct OUDSSwitchItem: View {
             orientation: isReversed ? .reversed : .default)
     }
 
-    /// Creates a switch with a localized label, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSSwitchItem(LocalizedStringKey("notifications_setting"), bundle: Bundle.module, isOn: $isOn)
-    /// ```
-    ///
-    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    // MARK: - Initializers — LocalizedStringKey + errorText: String?
+
+    /// Creates a switch with a localized label.
     ///
     /// - Parameters:
     ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
@@ -352,15 +404,16 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
-    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
-    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An optional error message to display at the bottom
+    ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
-    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -376,12 +429,11 @@ public struct OUDSSwitchItem: View {
                 hasDivider: Bool = false,
                 constrainedMaxWidth: Bool = false)
     {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
+                  icon: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -391,6 +443,105 @@ public struct OUDSSwitchItem: View {
     }
 
     /// Creates a switch with a localized label, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSSwitchItem(LocalizedStringKey("notifications_setting"), bundle: Bundle.module, isOn: $isOn)
+    ///
+    ///     OUDSSwitchItem(LocalizedStringKey("wifi_setting"),
+    ///                    bundle: Bundle.module,
+    ///                    isOn: $isOn,
+    ///                    icon: OUDSImage(asset: Image(decorative: "ic_wifi")))
+    /// ```
+    ///
+    /// **The design system does not allow to have both an error situation and a read only mode for the component.**
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - description: An additional helper text, a description, should not be empty
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
+    ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - isReadOnly: True if component is in read only, default set to `false`
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
+    ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: OUDSImage? = nil,
+                isReversed: Bool = true,
+                isError: Bool = false,
+                errorText: String? = nil,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false)
+    {
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  description: description,
+                  icon: icon,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth)
+    }
+
+    // MARK: - Initializers — LocalizedStringKey + errorText: AttributedString
+
+    /// Creates a switch with a localized label and a rich attributed error text.
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - isOn: A binding to a property that determines whether the toggle is on or off
+    ///   - description: An additional helper text, a description, should not be empty
+    ///   - icon: An optional icon image, default set to `nil`
+    ///   - flipIcon: Default set to `false`, set to `true` to reverse the image
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - isError: `true` if the look and feel of the component must reflect an error state
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`
+    ///   - isReadOnly: True if component is in read only
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                isOn: Binding<Bool>,
+                description: String? = nil,
+                icon: Image? = nil,
+                flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                isReversed: Bool = true,
+                isError: Bool = false,
+                errorText: AttributedString,
+                isReadOnly: Bool = false,
+                hasDivider: Bool = false,
+                constrainedMaxWidth: Bool = false)
+    {
+        let oudsImage: OUDSImage? = icon.map { OUDSImage(asset: $0, flipped: flipIcon, renderingMode: renderingMode) }
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  isOn: isOn,
+                  description: description,
+                  icon: oudsImage,
+                  isReversed: isReversed,
+                  isError: isError,
+                  errorText: errorText,
+                  isReadOnly: isReadOnly,
+                  hasDivider: hasDivider,
+                  constrainedMaxWidth: constrainedMaxWidth)
+    }
+
+    /// Creates a switch with a localized label and a rich attributed error text.
     ///
     /// ```swift
     ///     OUDSSwitchItem(LocalizedStringKey("enable_payments"),
@@ -408,23 +559,19 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional icon, default set to `nil`
-    ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
-    ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
-    ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
+    ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
     ///   - isReadOnly: True if component is in read only, default set to `false`
-    ///   - hasDivider: If `true` a divider is added at the bottom of the view
+    ///   - hasDivider: If `true` a divider is added at the bottom of the view, by default set to `false`
     ///   - constrainedMaxWidth: When `true`, the item width is constrained to a maximum value defined by the design system.
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: Image? = nil,
-                flipIcon: Bool = false,
-                renderingMode: Image.TemplateRenderingMode = .template,
+                icon: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -436,8 +583,6 @@ public struct OUDSSwitchItem: View {
                   isOn: isOn,
                   description: description,
                   icon: icon,
-                  flipIcon: flipIcon,
-                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -446,9 +591,7 @@ public struct OUDSSwitchItem: View {
                   constrainedMaxWidth: constrainedMaxWidth)
     }
 
-    // swiftlint:enable function_default_parameter_at_end
-
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         ControlItem(indicatorType: .switch($isOn), layoutData: layoutData)
@@ -457,6 +600,8 @@ public struct OUDSSwitchItem: View {
             .accessibilityValue(accessibilityValue)
             .accessibilityHint(accessibilityHint)
     }
+
+    // MARK: - A11Y helpers
 
     /// Forge a string to vocalize the component label based on label, extraLabel and description
     private var accessibilityLabel: String {
@@ -487,3 +632,7 @@ public struct OUDSSwitchItem: View {
         }
     }
 }
+
+// swiftlint:enable function_default_parameter_at_end
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -78,20 +78,20 @@ import SwiftUI
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
 ///                    description: "The Beatles",
-///                    icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+///                    image: OUDSImage(asset: Image(decorative: "ic_heart")),
 ///                    isReversed: true)
 ///
 ///     // A trailing switch with a raw (non-tinted) image.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
 ///                    description: "The Beatles",
-///                    icon: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
+///                    image: OUDSImage(asset: Image(decorative: "il_someImage"), renderingMode: .original),
 ///                    isReversed: true)
 ///
 ///     // Flip the icon for RTL layouts using OUDSImage.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
-///                    icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+///                    image: OUDSImage(asset: Image(systemName: "figure.handball"),
 ///                                    flipped: layoutDirection == .rightToLeft))
 ///
 ///     // If on error, add an error message to help user understand the error context
@@ -174,7 +174,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -192,7 +192,7 @@ public struct OUDSSwitchItem: View {
         self.init(label,
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -207,7 +207,7 @@ public struct OUDSSwitchItem: View {
     ///     OUDSSwitchItem("Wi-Fi", isOn: $isOn)
     ///
     ///     OUDSSwitchItem("Wi-Fi", isOn: $isOn,
-    ///                    icon: OUDSImage(asset: Image(decorative: "ic_wifi")))
+    ///                    image: OUDSImage(asset: Image(decorative: "ic_wifi")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -219,7 +219,7 @@ public struct OUDSSwitchItem: View {
     ///   - label: The main label text of the switch, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -232,7 +232,7 @@ public struct OUDSSwitchItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -270,7 +270,7 @@ public struct OUDSSwitchItem: View {
             label: label.localized(),
             extraLabel: nil,
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -297,7 +297,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
@@ -315,7 +315,7 @@ public struct OUDSSwitchItem: View {
         self.init(label,
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -342,7 +342,7 @@ public struct OUDSSwitchItem: View {
     ///   - label: The main label text of the switch, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -354,7 +354,7 @@ public struct OUDSSwitchItem: View {
     public init(_ label: String,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -384,7 +384,7 @@ public struct OUDSSwitchItem: View {
             label: label.localized(),
             extraLabel: nil,
             description: description?.localized(),
-            icon: icon,
+            icon: image,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -413,7 +413,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -433,7 +433,7 @@ public struct OUDSSwitchItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -450,7 +450,7 @@ public struct OUDSSwitchItem: View {
     ///     OUDSSwitchItem(LocalizedStringKey("wifi_setting"),
     ///                    bundle: Bundle.module,
     ///                    isOn: $isOn,
-    ///                    icon: OUDSImage(asset: Image(decorative: "ic_wifi")))
+    ///                    image: OUDSImage(asset: Image(decorative: "ic_wifi")))
     /// ```
     ///
     /// **The design system does not allow to have both an error situation and a read only mode for the component.**
@@ -461,7 +461,7 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -473,7 +473,7 @@ public struct OUDSSwitchItem: View {
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -484,7 +484,7 @@ public struct OUDSSwitchItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -512,7 +512,7 @@ public struct OUDSSwitchItem: View {
     ///   - isReadOnly: True if component is in read only
     ///   - hasDivider: If `true` a divider is added at the bottom of the view
     ///   - constrainedMaxWidth: Constrains the item width to the design system maximum when `true`
-    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:icon:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
+    @available(*, deprecated, message: "Use OUDSSwitchItem(_:tableName:bundle:isOn:description:image:isReversed:isError:errorText:isReadOnly:hasDivider:constrainedMaxWidth:) with icon: OUDSImage? instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -532,7 +532,7 @@ public struct OUDSSwitchItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: oudsImage,
+                  image: oudsImage,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -559,7 +559,7 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -571,7 +571,7 @@ public struct OUDSSwitchItem: View {
                 bundle: Bundle = .main,
                 isOn: Binding<Bool>,
                 description: String? = nil,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -582,7 +582,7 @@ public struct OUDSSwitchItem: View {
         self.init(key.resolved(tableName: tableName, bundle: bundle),
                   isOn: isOn,
                   description: description,
-                  icon: icon,
+                  image: image,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -76,12 +76,22 @@ import SwiftUI
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds", isOn: $isOn, description: "The Beatles")
 ///
 ///     // A trailing switch with a label, an additional label, a description text and an icon.
-///     // The inverse layout will be used here.
+///     // The reversed layout will be used here.
 ///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
 ///                    isOn: $isOn,
 ///                    description: "The Beatles",
-///                    isReversed: true,
-///                    icon: Image(decorative: "ic_heart"))
+///                    icon: Image(decorative: "ic_heart"),
+///                    isReversed: true)
+///
+///     // A trailing switch with a label, an additional label, a description text and an icon.
+///     // The reversed layout will be used here.
+///     // Image is kept as is, raw, without tint.
+///     OUDSSwitchItem("Lucy in the Sky with Diamonds",
+///                    isOn: $isOn,
+///                    description: "The Beatles",
+///                    icon: Image(decorative: "il_someImage"),
+///                    renderingMode: .original,
+///                    isReversed: true)
 ///
 ///     // A trailing switch with a label, a description text, an icon, a divider and is about an error.
 ///     // The inverse layout will be used here.
@@ -183,6 +193,7 @@ public struct OUDSSwitchItem: View {
     ///   - description: An additional helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -200,6 +211,7 @@ public struct OUDSSwitchItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -239,6 +251,7 @@ public struct OUDSSwitchItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: errorTextContent,
@@ -265,6 +278,7 @@ public struct OUDSSwitchItem: View {
     ///   - description: An additional helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -282,6 +296,7 @@ public struct OUDSSwitchItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -313,6 +328,7 @@ public struct OUDSSwitchItem: View {
             description: description?.localized(),
             icon: icon,
             flipIcon: flipIcon,
+            renderingMode: renderingMode,
             isOutlined: false,
             isError: isError,
             errorText: .attributed(errorText),
@@ -338,6 +354,7 @@ public struct OUDSSwitchItem: View {
     ///   - description: An additional helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -351,6 +368,7 @@ public struct OUDSSwitchItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: String? = nil,
@@ -363,6 +381,7 @@ public struct OUDSSwitchItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,
@@ -391,6 +410,7 @@ public struct OUDSSwitchItem: View {
     ///   - description: An additional helper text, a description, should not be empty
     ///   - icon: An optional icon, default set to `nil`
     ///   - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
+    ///   - renderingMode: Default set to `.template`, forces the rendering mode of the image. Should be `.original` for raw images.
     ///   - isReversed: `true` of the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -404,6 +424,7 @@ public struct OUDSSwitchItem: View {
                 description: String? = nil,
                 icon: Image? = nil,
                 flipIcon: Bool = false,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 isReversed: Bool = true,
                 isError: Bool = false,
                 errorText: AttributedString,
@@ -416,6 +437,7 @@ public struct OUDSSwitchItem: View {
                   description: description,
                   icon: icon,
                   flipIcon: flipIcon,
+                  renderingMode: renderingMode,
                   isReversed: isReversed,
                   isError: isError,
                   errorText: errorText,

--- a/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
+++ b/OUDS/Core/Components/Sources/Controls/Switch/OUDSSwitchItem.swift
@@ -219,7 +219,7 @@ public struct OUDSSwitchItem: View {
     ///   - label: The main label text of the switch, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -342,7 +342,7 @@ public struct OUDSSwitchItem: View {
     ///   - label: The main label text of the switch, must not be empty
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.
@@ -461,7 +461,7 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An optional error message to display at the bottom. This message is ignored if `isError` is `false`.
@@ -559,7 +559,7 @@ public struct OUDSSwitchItem: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - isOn: A binding to a property that determines whether the toggle is on or off
     ///   - description: An additional helper text, a description, should not be empty
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode. Default set to `nil`. If defined, its accessibility label will be ignored.
     ///   - isReversed: `true` if the switch indicator must be in trailing position, `false` otherwise. Default to `true`
     ///   - isError: `true` if the look and feel of the component must reflect an error state, default set to `false`
     ///   - errorText: An error message to display at the bottom as rich `AttributedString`. This message is ignored if `isError` is `false`.

--- a/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaTrailingContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaTrailingContainer.swift
@@ -54,8 +54,7 @@ struct TextAreaTrailingContainer: View {
             } else if isOverLimit {
                 errorIcon
             } else if case .loading = status {
-                OUDSButton(icon: Image(decorative: "ic_heart"), // Image won't never be displayed
-                           accessibilityLabel: "",
+                OUDSButton(image: OUDSImage(asset: Image(decorative: "ic_heart"), accessibilityLabel: ""), // Image won't never be displayed
                            appearance: .minimal,
                            style: .loading,
                            action: {})

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/LeadingIconContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/LeadingIconContainer.swift
@@ -21,6 +21,7 @@ struct LeadingIconContainer: View {
 
     let leadingIcon: Image?
     let flip: Bool
+    let renderingMode: Image.TemplateRenderingMode
     let status: OUDSTextInput.Status
 
     @Environment(\.theme) private var theme
@@ -30,7 +31,7 @@ struct LeadingIconContainer: View {
     var body: some View {
         leadingIcon?
             .resizable()
-            .renderingMode(.template)
+            .renderingMode(renderingMode)
             .aspectRatio(contentMode: .fit)
             .frame(height: theme.textInput.sizeLeadingIcon, alignment: .center)
             .foregroundColor(color)

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/LeadingIconContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/LeadingIconContainer.swift
@@ -19,9 +19,7 @@ struct LeadingIconContainer: View {
 
     // MARK: - Properties
 
-    let leadingIcon: Image?
-    let flip: Bool
-    let renderingMode: Image.TemplateRenderingMode
+    let leadingIcon: OUDSImage?
     let status: OUDSTextInput.Status
 
     @Environment(\.theme) private var theme
@@ -29,13 +27,13 @@ struct LeadingIconContainer: View {
     // MARK: - Body
 
     var body: some View {
-        leadingIcon?
+        leadingIcon?.asset?
             .resizable()
-            .renderingMode(renderingMode)
+            .renderingMode(leadingIcon?.renderingMode ?? .template)
             .aspectRatio(contentMode: .fit)
             .frame(height: theme.textInput.sizeLeadingIcon, alignment: .center)
             .foregroundColor(color)
-            .toFlip(flip)
+            .toFlip(leadingIcon?.flipped ?? false)
             .accessibilityHidden(true)
     }
 

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
@@ -23,9 +23,7 @@ struct TextInputContainer: View {
     let placeholder: String?
     let prefix: String?
     let suffix: String?
-    let leadingIcon: Image?
-    let flipIcon: Bool
-    let leadingIconRenderingMode: Image.TemplateRenderingMode
+    let leadingIcon: OUDSImage?
     let trailingAction: OUDSTextInput.TrailingAction?
     let isOutlined: Bool
     let status: OUDSTextInput.Status
@@ -44,7 +42,7 @@ struct TextInputContainer: View {
         HStack(alignment: .center, spacing: theme.textInput.spaceColumnGapDefault) {
             HStack(alignment: .center, spacing: theme.textInput.spaceColumnGapDefault) {
                 // Leading icon container
-                LeadingIconContainer(leadingIcon: leadingIcon, flip: flipIcon, renderingMode: leadingIconRenderingMode, status: status)
+                LeadingIconContainer(leadingIcon: leadingIcon, status: status)
 
                 // ZStack here to add the label above the textField when
                 // the text is empty, the placeholder is empty and not focused

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
@@ -25,6 +25,7 @@ struct TextInputContainer: View {
     let suffix: String?
     let leadingIcon: Image?
     let flipIcon: Bool
+    let leadingIconRenderingMode: Image.TemplateRenderingMode
     let trailingAction: OUDSTextInput.TrailingAction?
     let isOutlined: Bool
     let status: OUDSTextInput.Status
@@ -43,7 +44,7 @@ struct TextInputContainer: View {
         HStack(alignment: .center, spacing: theme.textInput.spaceColumnGapDefault) {
             HStack(alignment: .center, spacing: theme.textInput.spaceColumnGapDefault) {
                 // Leading icon container
-                LeadingIconContainer(leadingIcon: leadingIcon, flip: flipIcon, status: status)
+                LeadingIconContainer(leadingIcon: leadingIcon, flip: flipIcon, renderingMode: leadingIconRenderingMode, status: status)
 
                 // ZStack here to add the label above the textField when
                 // the text is empty, the placeholder is empty and not focused

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
@@ -49,7 +49,7 @@ struct TrailingActionContainer: View {
                 }
             }
         case .loading:
-            trailingButton(for: .init(icon: OUDSImage(asset: Image(decorative: "ic_heart")), actionHint: "", action: {}))
+            trailingButton(for: .init(image: OUDSImage(asset: Image(decorative: "ic_heart")), actionHint: "", action: {}))
                 .accessibilityHidden(true)
         }
     }

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
@@ -67,18 +67,19 @@ struct TrailingActionContainer: View {
         }
     }
 
-    // swiftlint:disable accessibility_label_for_image
     private func trailingButton(for trailingAction: OUDSTextInput.TrailingAction) -> some View {
+        precondition(trailingAction.icon.asset != nil, "OUDSTextInput.TrailingAction.icon must be created with an asset Image")
         // Inject the actionHint as accessibilityLabel into a new OUDSImage for OUDSButton icon-only
-        let imageWithA11y = OUDSImage(asset: trailingAction.icon.asset ?? Image(""), // Never happens
+        // swiftlint:disable:next force_unwrapping
+        let imageWithA11y = OUDSImage(asset: trailingAction.icon.asset!,
                                       flipped: trailingAction.icon.flipped,
                                       accessibilityLabel: trailingAction.actionHint,
                                       renderingMode: trailingAction.icon.renderingMode)
+
         return OUDSButton(image: imageWithA11y,
                           appearance: .minimal,
                           style: status == .loading ? .loading : .default,
                           action: trailingAction.action)
     }
-    // swiftlint:enable accessibility_label_for_image
 }
 #endif

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
@@ -49,7 +49,7 @@ struct TrailingActionContainer: View {
                 }
             }
         case .loading:
-            trailingButton(for: .init(icon: Image(decorative: "ic_heart"), actionHint: "", action: {}))
+            trailingButton(for: .init(icon: OUDSImage(asset: Image(decorative: "ic_heart")), actionHint: "", action: {}))
                 .accessibilityHidden(true)
         }
     }
@@ -67,14 +67,18 @@ struct TrailingActionContainer: View {
         }
     }
 
+    // swiftlint:disable accessibility_label_for_image
     private func trailingButton(for trailingAction: OUDSTextInput.TrailingAction) -> some View {
-        OUDSButton(icon: trailingAction.icon,
-                   accessibilityLabel: trailingAction.actionHint,
-                   flipIcon: trailingAction.flipIcon,
-                   renderingMode: trailingAction.renderingMode,
-                   appearance: .minimal,
-                   style: status == .loading ? .loading : .default,
-                   action: trailingAction.action)
+        // Inject the actionHint as accessibilityLabel into a new OUDSImage for OUDSButton icon-only
+        let imageWithA11y = OUDSImage(asset: trailingAction.icon.asset ?? Image(""), // Never happens
+                                      flipped: trailingAction.icon.flipped,
+                                      accessibilityLabel: trailingAction.actionHint,
+                                      renderingMode: trailingAction.icon.renderingMode)
+        return OUDSButton(image: imageWithA11y,
+                          appearance: .minimal,
+                          style: status == .loading ? .loading : .default,
+                          action: trailingAction.action)
     }
+    // swiftlint:enable accessibility_label_for_image
 }
 #endif

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TrailingActionContainer.swift
@@ -71,6 +71,7 @@ struct TrailingActionContainer: View {
         OUDSButton(icon: trailingAction.icon,
                    accessibilityLabel: trailingAction.actionHint,
                    flipIcon: trailingAction.flipIcon,
+                   renderingMode: trailingAction.renderingMode,
                    appearance: .minimal,
                    style: status == .loading ? .loading : .default,
                    action: trailingAction.action)

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -161,7 +161,7 @@ import SwiftUI
 ///                   leadingImage: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
 ///
 ///     // Add a trailing button with local image named "ic_cross" for additional action
-///     let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
+///     let trailingAction = OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
 ///     OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
 ///
 ///     // With helper text
@@ -258,7 +258,7 @@ public struct OUDSTextInput: View {
         ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
         ///   - renderingMode: The rendering mode to apply on the icon
         ///   - action: The action to perform when the user triggers the button
-        @available(*, deprecated, message: "Use OUDSTextInput.TrailingAction(icon: OUDSImage, actionHint:action:) instead.")
+        @available(*, deprecated, message: "Use OUDSTextInput.TrailingAction(image:actionHint:action:) instead.")
         public init(icon: Image, actionHint: String, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
             self.init(image: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode),
                       actionHint: actionHint,

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -147,6 +147,9 @@ import SwiftUI
 ///     // Add a leading icon for more context
 ///     OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com", leadingIcon: Image(systemName: "envelope"))
 ///
+///     // Add a leading icon displayed as raw image (not tinted)
+///     OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+///
 ///     // Add a trailing button with local image namde "ic_cross" for additional action
 ///     let trailingAction = OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
 ///     OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
@@ -211,6 +214,7 @@ public struct OUDSTextInput: View {
     let suffix: String?
     let leadingIcon: Image?
     let flipLeadingIcon: Bool
+    let leadingIconRenderingMode: Image.TemplateRenderingMode
     let trailingAction: TrailingAction?
     let helperText: TextualContent?
     let helperLink: Helperlink?
@@ -236,6 +240,7 @@ public struct OUDSTextInput: View {
         let icon: Image
         let actionHint: String
         let flipIcon: Bool
+        let renderingMode: Image.TemplateRenderingMode
         let action: () -> Void
 
         /// Creates a trailing action.
@@ -244,14 +249,16 @@ public struct OUDSTextInput: View {
         ///   - icon: The icon set in the ``OUDSButton``
         ///   - actionHint: A string that describes the purpose of the button's `action`
         ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
+        ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
         ///   - action: The action to perform when the user triggers the button
-        public init(icon: Image, actionHint: String, flipIcon: Bool = false, action: @escaping () -> Void) {
+        public init(icon: Image, actionHint: String, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
             if actionHint.isEmpty {
                 OL.warning("The accessibility action hint for the OUDSTextInput trailing action should not be empty, think about your disabled users!")
             }
             self.icon = icon
             self.actionHint = actionHint
             self.flipIcon = flipIcon
+            self.renderingMode = renderingMode
             self.action = action
         }
     }
@@ -341,6 +348,7 @@ public struct OUDSTextInput: View {
     ///    - leadingIcon: An optional leading icon to provide more context (magnifying glass for search,
     ///      envelope for email, etc.), by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon (e.g. in RTL case)
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - trailingAction: An optional trailing action related to the field: (clear input,
     ///      toggle password visibility, etc.), by default is *nil*
     ///    - helperText: An optional helper text displayed below the text input. It conveys additional, by default is *nil*
@@ -360,6 +368,7 @@ public struct OUDSTextInput: View {
                 suffix: String? = nil,
                 leadingIcon: Image? = nil,
                 flipLeadingIcon: Bool = false,
+                leadingIconRenderingMode: Image.TemplateRenderingMode = .template,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: String? = nil,
                 helperLink: Self.Helperlink? = nil,
@@ -379,6 +388,7 @@ public struct OUDSTextInput: View {
         self.suffix = suffix
         self.leadingIcon = leadingIcon
         self.flipLeadingIcon = flipLeadingIcon
+        self.leadingIconRenderingMode = leadingIconRenderingMode
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -407,6 +417,7 @@ public struct OUDSTextInput: View {
     ///    - leadingIcon: An optional leading icon to provide more context (magnifying glass for search,
     ///      envelope for email, etc.), by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon (e.g. in RTL case)
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - trailingAction: An optional trailing action related to the field: (clear input,
     ///      toggle password visibility, etc.), by default is *nil*
     ///    - helperText: An optional helper text displayed below the text input. It conveys additional, by default is *nil*
@@ -426,6 +437,7 @@ public struct OUDSTextInput: View {
                 suffix: String? = nil,
                 leadingIcon: Image? = nil,
                 flipLeadingIcon: Bool = false,
+                leadingIconRenderingMode: Image.TemplateRenderingMode = .template,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: AttributedString,
                 helperLink: Self.Helperlink? = nil,
@@ -441,6 +453,7 @@ public struct OUDSTextInput: View {
         self.suffix = suffix
         self.leadingIcon = leadingIcon
         self.flipLeadingIcon = flipLeadingIcon
+        self.leadingIconRenderingMode = leadingIconRenderingMode
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -464,6 +477,7 @@ public struct OUDSTextInput: View {
     ///    - suffix: Text placed after the user's input, by default is *nil*
     ///    - leadingIcon: An optional leading icon, by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: An optional helper text, by default is *nil*
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -479,6 +493,7 @@ public struct OUDSTextInput: View {
                 suffix: String? = nil,
                 leadingIcon: Image? = nil,
                 flipLeadingIcon: Bool = false,
+                leadingIconRenderingMode: Image.TemplateRenderingMode = .template,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: String? = nil,
                 helperLink: Self.Helperlink? = nil,
@@ -493,6 +508,7 @@ public struct OUDSTextInput: View {
                   suffix: suffix,
                   leadingIcon: leadingIcon,
                   flipLeadingIcon: flipLeadingIcon,
+                  leadingIconRenderingMode: leadingIconRenderingMode,
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -520,6 +536,7 @@ public struct OUDSTextInput: View {
     ///    - suffix: Text placed after the user's input, by default is *nil*
     ///    - leadingIcon: An optional leading icon, by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: An helper text in rich text
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -535,6 +552,7 @@ public struct OUDSTextInput: View {
                 suffix: String? = nil,
                 leadingIcon: Image? = nil,
                 flipLeadingIcon: Bool = false,
+                leadingIconRenderingMode: Image.TemplateRenderingMode = .template,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: AttributedString,
                 helperLink: Self.Helperlink? = nil,
@@ -549,6 +567,7 @@ public struct OUDSTextInput: View {
                   suffix: suffix,
                   leadingIcon: leadingIcon,
                   flipLeadingIcon: flipLeadingIcon,
+                  leadingIconRenderingMode: leadingIconRenderingMode,
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -571,6 +590,7 @@ public struct OUDSTextInput: View {
                                    suffix: suffix,
                                    leadingIcon: leadingIcon,
                                    flipIcon: flipLeadingIcon,
+                                   leadingIconRenderingMode: leadingIconRenderingMode,
                                    trailingAction: trailingAction,
                                    isOutlined: isOutlined,
                                    status: status,

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -150,7 +150,7 @@ import SwiftUI
 ///     // Add a leading icon displayed as raw image (not tinted)
 ///     OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
 ///
-///     // Add a trailing button with local image namde "ic_cross" for additional action
+///     // Add a trailing button with local image named "ic_cross" for additional action
 ///     let trailingAction = OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
 ///     OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
 ///

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -150,15 +150,15 @@ import SwiftUI
 ///
 ///     // Add a leading icon for more context
 ///     OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com",
-///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+///                   leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
 ///
 ///     // Add a leading icon displayed as raw image (not tinted)
 ///     OUDSTextInput(label: "Brand", text: $text,
-///                   leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+///                   leadingImage: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
 ///
 ///     // Flip the leading icon for RTL layouts using OUDSImage.flipped
 ///     OUDSTextInput(label: "Label", text: $text,
-///                   leadingIcon: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
+///                   leadingImage: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
 ///
 ///     // Add a trailing button with local image named "ic_cross" for additional action
 ///     let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
@@ -186,7 +186,7 @@ import SwiftUI
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
 ///     OUDSTextInput(label: "Label", text: $text,
-///                   leadingIcon: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
+///                   leadingImage: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
 /// ```
 ///
 /// ## Design documentation
@@ -260,7 +260,7 @@ public struct OUDSTextInput: View {
         ///   - action: The action to perform when the user triggers the button
         @available(*, deprecated, message: "Use OUDSTextInput.TrailingAction(icon: OUDSImage, actionHint:action:) instead.")
         public init(icon: Image, actionHint: String, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
-            self.init(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode),
+            self.init(image: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode),
                       actionHint: actionHint,
                       action: action)
         }
@@ -268,23 +268,23 @@ public struct OUDSTextInput: View {
         /// Creates a trailing action.
         ///
         /// ```swift
-        ///     OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")),
-        ///                                 actionHint: "Delete") { text = "" }
+        ///     OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_cross")),
+        ///                                  actionHint: "Delete") { text = "" }
         ///
         ///     // Raw (non-tinted) icon:
-        ///     OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original),
-        ///                                 actionHint: "Brand") { }
+        ///     OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original),
+        ///                                  actionHint: "Brand") { }
         /// ```
         ///
         /// - Parameters:
-        ///   - icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        ///   - image: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
         ///   - actionHint: A string that describes the purpose of the button's `action`
         ///   - action: The action to perform when the user triggers the button
-        public init(icon: OUDSImage, actionHint: String, action: @escaping () -> Void) {
+        public init(image: OUDSImage, actionHint: String, action: @escaping () -> Void) {
             if actionHint.isEmpty {
                 OL.warning("The accessibility action hint for the OUDSTextInput trailing action should not be empty, think about your disabled users!")
             }
-            self.icon = icon
+            icon = image
             self.actionHint = actionHint
             self.action = action
         }
@@ -375,7 +375,7 @@ public struct OUDSTextInput: View {
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
-    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
+    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(label: String,
                 text: Binding<String>,
                 placeholder: String? = nil,
@@ -396,7 +396,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  leadingImage: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -411,10 +411,10 @@ public struct OUDSTextInput: View {
     ///     OUDSTextInput(label: "Email", text: $text)
     ///
     ///     OUDSTextInput(label: "Email", text: $text,
-    ///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+    ///                   leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
     ///
     ///     OUDSTextInput(label: "Brand", text: $text,
-    ///                   leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+    ///                   leadingImage: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
     /// ```
     ///
     /// - Parameters:
@@ -423,7 +423,7 @@ public struct OUDSTextInput: View {
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
     ///    - prefix: Text placed before the user's input, by default is *nil*
     ///    - suffix: Text placed after the user's input, by default is *nil*
-    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - leadingImage: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: An optional helper text, by default is *nil*
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -435,7 +435,7 @@ public struct OUDSTextInput: View {
                 placeholder: String? = nil,
                 prefix: String? = nil,
                 suffix: String? = nil,
-                leadingIcon: OUDSImage? = nil,
+                leadingImage: OUDSImage? = nil,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: String? = nil,
                 helperLink: Self.Helperlink? = nil,
@@ -453,7 +453,7 @@ public struct OUDSTextInput: View {
         self.placeholder = placeholder
         self.prefix = prefix
         self.suffix = suffix
-        self.leadingIcon = leadingIcon
+        leadingIcon = leadingImage
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -480,7 +480,7 @@ public struct OUDSTextInput: View {
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
-    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
+    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(label: String,
                 text: Binding<String>,
                 placeholder: String? = nil,
@@ -501,7 +501,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  leadingImage: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -524,7 +524,7 @@ public struct OUDSTextInput: View {
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
     ///    - prefix: Text placed before the user's input, by default is *nil*
     ///    - suffix: Text placed after the user's input, by default is *nil*
-    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - leadingImage: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: A rich `AttributedString` helper text
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -536,7 +536,7 @@ public struct OUDSTextInput: View {
                 placeholder: String? = nil,
                 prefix: String? = nil,
                 suffix: String? = nil,
-                leadingIcon: OUDSImage? = nil,
+                leadingImage: OUDSImage? = nil,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: AttributedString,
                 helperLink: Self.Helperlink? = nil,
@@ -550,7 +550,7 @@ public struct OUDSTextInput: View {
         self.placeholder = placeholder
         self.prefix = prefix
         self.suffix = suffix
-        self.leadingIcon = leadingIcon
+        leadingIcon = leadingImage
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -579,7 +579,7 @@ public struct OUDSTextInput: View {
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
-    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
+    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -602,7 +602,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  leadingImage: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -617,7 +617,7 @@ public struct OUDSTextInput: View {
     ///     OUDSTextInput(LocalizedStringKey("email_label"), bundle: Bundle.module, text: $text)
     ///
     ///     OUDSTextInput(LocalizedStringKey("email_label"), bundle: Bundle.module, text: $text,
-    ///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+    ///                   leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
     /// ```
     ///
     /// - Parameters:
@@ -628,7 +628,7 @@ public struct OUDSTextInput: View {
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
     ///    - prefix: Text placed before the user's input, by default is *nil*
     ///    - suffix: Text placed after the user's input, by default is *nil*
-    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - leadingImage: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: An optional helper text, by default is *nil*
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -642,7 +642,7 @@ public struct OUDSTextInput: View {
                 placeholder: String? = nil,
                 prefix: String? = nil,
                 suffix: String? = nil,
-                leadingIcon: OUDSImage? = nil,
+                leadingImage: OUDSImage? = nil,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: String? = nil,
                 helperLink: Self.Helperlink? = nil,
@@ -655,7 +655,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon,
+                  leadingImage: leadingImage,
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -685,7 +685,7 @@ public struct OUDSTextInput: View {
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
-    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
+    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -708,7 +708,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  leadingImage: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -734,7 +734,7 @@ public struct OUDSTextInput: View {
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
     ///    - prefix: Text placed before the user's input, by default is *nil*
     ///    - suffix: Text placed after the user's input, by default is *nil*
-    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - leadingImage: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: A rich `AttributedString` helper text
     ///    - helperLink: An optional helper link, by default is *nil*
@@ -748,7 +748,7 @@ public struct OUDSTextInput: View {
                 placeholder: String? = nil,
                 prefix: String? = nil,
                 suffix: String? = nil,
-                leadingIcon: OUDSImage? = nil,
+                leadingImage: OUDSImage? = nil,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: AttributedString,
                 helperLink: Self.Helperlink? = nil,
@@ -761,7 +761,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon,
+                  leadingImage: leadingImage,
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -18,7 +18,11 @@ import OUDSTokensComponent
 import OUDSTokensSemantic
 import SwiftUI
 
+// TODO: When v3 in development and deprecated API removed, fine-tune these warnings
 // swiftlint:disable file_length
+// swiftlint:disable function_default_parameter_at_end
+// swiftlint:disable line_length
+// swiftlint:disable type_body_length
 
 /// Text input is a UI element that allows to enter, edit, or select single-line textual data.
 /// Text input is one of the most fundamental form elements used to capture user input such as names, emails, passwords, or search queries.
@@ -145,13 +149,19 @@ import SwiftUI
 ///     OUDSTextInput(label: "Email", text: $text, prefix: "Distance", suffix: "km")
 ///
 ///     // Add a leading icon for more context
-///     OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com", leadingIcon: Image(systemName: "envelope"))
+///     OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com",
+///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
 ///
 ///     // Add a leading icon displayed as raw image (not tinted)
-///     OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+///     OUDSTextInput(label: "Brand", text: $text,
+///                   leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+///
+///     // Flip the leading icon for RTL layouts using OUDSImage.flipped
+///     OUDSTextInput(label: "Label", text: $text,
+///                   leadingIcon: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
 ///
 ///     // Add a trailing button with local image named "ic_cross" for additional action
-///     let trailingAction = OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
+///     let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
 ///     OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
 ///
 ///     // With helper text
@@ -171,11 +181,12 @@ import SwiftUI
 ///     OUDSTextInput(label: "Label", text: $text, placeholder: "Placeholder", helperLink: helperLink)
 /// ```
 ///
-/// If you need to flip your icon depending to the layout direction or not (e.g. if RTL mode lose semantics  / meanings):
+/// If you need to flip your leading icon for RTL, use the `flipped` property of ``OUDSImage``:
 /// ```swift
 ///     @Environment(\.layoutDirection) var layoutDirection
 ///
-///     OUDSTextInput(label: "Label", text: $text, flipLeadingIcon: layoutDirection == .rightToLeft)
+///     OUDSTextInput(label: "Label", text: $text,
+///                   leadingIcon: OUDSImage(asset: Image("ic_arrow"), flipped: layoutDirection == .rightToLeft))
 /// ```
 ///
 /// ## Design documentation
@@ -212,9 +223,7 @@ public struct OUDSTextInput: View {
     let placeholder: String?
     let prefix: String?
     let suffix: String?
-    let leadingIcon: Image?
-    let flipLeadingIcon: Bool
-    let leadingIconRenderingMode: Image.TemplateRenderingMode
+    let leadingIcon: OUDSImage?
     let trailingAction: TrailingAction?
     let helperText: TextualContent?
     let helperLink: Helperlink?
@@ -237,10 +246,8 @@ public struct OUDSTextInput: View {
     /// - Since: 0.20.0
     public struct TrailingAction {
 
-        let icon: Image
+        let icon: OUDSImage
         let actionHint: String
-        let flipIcon: Bool
-        let renderingMode: Image.TemplateRenderingMode
         let action: () -> Void
 
         /// Creates a trailing action.
@@ -249,16 +256,36 @@ public struct OUDSTextInput: View {
         ///   - icon: The icon set in the ``OUDSButton``
         ///   - actionHint: A string that describes the purpose of the button's `action`
         ///   - flipIcon: Default set to `false`, set to `true` to reverse the image (i.e. flip vertically)
-        ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+        ///   - renderingMode: The rendering mode to apply on the icon
         ///   - action: The action to perform when the user triggers the button
+        @available(*, deprecated, message: "Use OUDSTextInput.TrailingAction(icon: OUDSImage, actionHint:action:) instead.")
         public init(icon: Image, actionHint: String, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template, action: @escaping () -> Void) {
+            self.init(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode),
+                      actionHint: actionHint,
+                      action: action)
+        }
+
+        /// Creates a trailing action.
+        ///
+        /// ```swift
+        ///     OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")),
+        ///                                 actionHint: "Delete") { text = "" }
+        ///
+        ///     // Raw (non-tinted) icon:
+        ///     OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original),
+        ///                                 actionHint: "Brand") { }
+        /// ```
+        ///
+        /// - Parameters:
+        ///   - icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        ///   - actionHint: A string that describes the purpose of the button's `action`
+        ///   - action: The action to perform when the user triggers the button
+        public init(icon: OUDSImage, actionHint: String, action: @escaping () -> Void) {
             if actionHint.isEmpty {
                 OL.warning("The accessibility action hint for the OUDSTextInput trailing action should not be empty, think about your disabled users!")
             }
             self.icon = icon
             self.actionHint = actionHint
-            self.flipIcon = flipIcon
-            self.renderingMode = renderingMode
             self.action = action
         }
     }
@@ -329,38 +356,26 @@ public struct OUDSTextInput: View {
         }
     }
 
-    // MARK: - Initializers
+    // MARK: - Initializers — String label + helperText: String?
 
     /// Creates a text input.
     ///
-    /// ```swift
-    ///     OUDSTextInput(label: "Email", text: $text)
-    /// ```
-    ///
     /// - Parameters:
-    ///    - label: The label displayed above the text input. It describes the purpose of the input
+    ///    - label: The label displayed above the text input
     ///    - text: The text to display and edit
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
-    ///    - prefix: Text placed before the user's input. Commonly used to indicate expected formatting like a country code, a unit...
-    ///      The `prefix` is hidden if a `placeholder` is not provided or empty. But it is visible in focus state or if the value is not empty.
-    ///    - suffix: Text placed after the user's input, often used to display a currency or a unit (kg, %, cm…).
-    ///      The `suffix` is hidden if a `placeholder` is not provided or empty. But it is visible in focus state or if the value is not empty.
-    ///    - leadingIcon: An optional leading icon to provide more context (magnifying glass for search,
-    ///      envelope for email, etc.), by default is *nil*
-    ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon (e.g. in RTL case)
-    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
-    ///    - trailingAction: An optional trailing action related to the field: (clear input,
-    ///      toggle password visibility, etc.), by default is *nil*
-    ///    - helperText: An optional helper text displayed below the text input. It conveys additional, by default is *nil*
-    ///      information about the input field, such as how it will be used., by default is *nil*. If `status` is set to OUDSTextInput.Status.Error,
-    ///      this `helperText` is ignored.
-    ///    - helperLink: An optional helper link displayed below or in place of the helper text., by default is *nil*
-    ///    - isOutlined: Controls the style of the text input. When `true`, it displays a minimalist
-    ///      text input with a transparent background and a visible stroke outlining the field, by default is *false*
-    ///    - constrainedMaxWidth: When `true`, the width is constrained to a maximum value defined by the design system.
-    ///      When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///      modifier. Defaults to `false`.
-    ///    - status: The current status of the text input, by default to set *enabled*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional leading icon, by default is *nil*
+    ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: An optional helper text, by default is *nil*
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(label: String,
                 text: Binding<String>,
                 placeholder: String? = nil,
@@ -369,6 +384,58 @@ public struct OUDSTextInput: View {
                 leadingIcon: Image? = nil,
                 flipLeadingIcon: Bool = false,
                 leadingIconRenderingMode: Image.TemplateRenderingMode = .template,
+                trailingAction: Self.TrailingAction? = nil,
+                helperText: String? = nil,
+                helperLink: Self.Helperlink? = nil,
+                isOutlined: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                status: Self.Status = .enabled)
+    {
+        self.init(label: label,
+                  text: text,
+                  placeholder: placeholder,
+                  prefix: prefix,
+                  suffix: suffix,
+                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  trailingAction: trailingAction,
+                  helperText: helperText,
+                  helperLink: helperLink,
+                  isOutlined: isOutlined,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  status: status)
+    }
+
+    /// Creates a text input.
+    ///
+    /// ```swift
+    ///     OUDSTextInput(label: "Email", text: $text)
+    ///
+    ///     OUDSTextInput(label: "Email", text: $text,
+    ///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+    ///
+    ///     OUDSTextInput(label: "Brand", text: $text,
+    ///                   leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - label: The label displayed above the text input. It describes the purpose of the input
+    ///    - text: The text to display and edit
+    ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: An optional helper text, by default is *nil*
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    public init(label: String,
+                text: Binding<String>,
+                placeholder: String? = nil,
+                prefix: String? = nil,
+                suffix: String? = nil,
+                leadingIcon: OUDSImage? = nil,
                 trailingAction: Self.TrailingAction? = nil,
                 helperText: String? = nil,
                 helperLink: Self.Helperlink? = nil,
@@ -387,8 +454,6 @@ public struct OUDSTextInput: View {
         self.prefix = prefix
         self.suffix = suffix
         self.leadingIcon = leadingIcon
-        self.flipLeadingIcon = flipLeadingIcon
-        self.leadingIconRenderingMode = leadingIconRenderingMode
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -396,40 +461,26 @@ public struct OUDSTextInput: View {
         self.constrainedMaxWidth = constrainedMaxWidth
     }
 
-    // swiftlint:disable function_default_parameter_at_end
+    // MARK: - Initializers — String label + helperText: AttributedString
 
     /// Creates a text input.
     ///
-    /// ```swift
-    ///     OUDSTextInput(label: "Email",
-    ///                   text: $text,
-    ///                   helperText: AttributedString(markdown: "You should use your **corporate email**"))  // Manage in your side errors for init
-    /// ```
-    ///
     /// - Parameters:
-    ///    - label: The label displayed above the text input. It describes the purpose of the input
+    ///    - label: The label displayed above the text input
     ///    - text: The text to display and edit
     ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
-    ///    - prefix: Text placed before the user's input. Commonly used to indicate expected formatting like a country code, a unit...
-    ///      The `prefix` is hidden if a `placeholder` is not provided or empty. But it is visible in focus state or if the value is not empty.
-    ///    - suffix: Text placed after the user's input, often used to display a currency or a unit (kg, %, cm…).
-    ///      The `suffix` is hidden if a `placeholder` is not provided or empty. But it is visible in focus state or if the value is not empty.
-    ///    - leadingIcon: An optional leading icon to provide more context (magnifying glass for search,
-    ///      envelope for email, etc.), by default is *nil*
-    ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon (e.g. in RTL case)
-    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
-    ///    - trailingAction: An optional trailing action related to the field: (clear input,
-    ///      toggle password visibility, etc.), by default is *nil*
-    ///    - helperText: An optional helper text displayed below the text input. It conveys additional, by default is *nil*
-    ///      information about the input field, such as how it will be used., by default is *nil*. If `status` is set to OUDSTextInput.Status.Error,
-    ///      this `helperText` is ignored.
-    ///    - helperLink: An helper link displayed below or in place of the helper text., by default is *nil*
-    ///    - isOutlined: Controls the style of the text input. When `true`, it displays a minimalist
-    ///      text input with a transparent background and a visible stroke outlining the field, by default is *false*
-    ///    - constrainedMaxWidth: When `true`, the width is constrained to a maximum value defined by the design system.
-    ///      When `false`, no specific width constraint is applied, allowing the component to size itself or follow external
-    ///      modifier. Defaults to `false`.
-    ///    - status: The current status of the text input, by default to set *enabled*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional leading icon, by default is *nil*
+    ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: A rich `AttributedString` helper text
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    @available(*, deprecated, message: "Use OUDSTextInput(label:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(label: String,
                 text: Binding<String>,
                 placeholder: String? = nil,
@@ -445,6 +496,54 @@ public struct OUDSTextInput: View {
                 constrainedMaxWidth: Bool = false,
                 status: Self.Status = .enabled)
     {
+        self.init(label: label,
+                  text: text,
+                  placeholder: placeholder,
+                  prefix: prefix,
+                  suffix: suffix,
+                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
+                  trailingAction: trailingAction,
+                  helperText: helperText,
+                  helperLink: helperLink,
+                  isOutlined: isOutlined,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  status: status)
+    }
+
+    /// Creates a text input with a rich attributed helper text.
+    ///
+    /// ```swift
+    ///     OUDSTextInput(label: "Email",
+    ///                   text: $text,
+    ///                   helperText: AttributedString(markdown: "You should use your **corporate email**"))
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - label: The label displayed above the text input
+    ///    - text: The text to display and edit
+    ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: A rich `AttributedString` helper text
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    public init(label: String,
+                text: Binding<String>,
+                placeholder: String? = nil,
+                prefix: String? = nil,
+                suffix: String? = nil,
+                leadingIcon: OUDSImage? = nil,
+                trailingAction: Self.TrailingAction? = nil,
+                helperText: AttributedString,
+                helperLink: Self.Helperlink? = nil,
+                isOutlined: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                status: Self.Status = .enabled)
+    {
         self.label = label
         self.text = text
         self.helperText = .attributed(helperText)
@@ -452,8 +551,6 @@ public struct OUDSTextInput: View {
         self.prefix = prefix
         self.suffix = suffix
         self.leadingIcon = leadingIcon
-        self.flipLeadingIcon = flipLeadingIcon
-        self.leadingIconRenderingMode = leadingIconRenderingMode
         self.trailingAction = trailingAction
         self.helperLink = helperLink
         self.status = status
@@ -461,11 +558,9 @@ public struct OUDSTextInput: View {
         self.constrainedMaxWidth = constrainedMaxWidth
     }
 
-    /// Creates a text input with a localized label, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSTextInput(LocalizedStringKey("email_label"), bundle: Bundle.module, text: $text)
-    /// ```
+    // MARK: - Initializers — LocalizedStringKey + helperText: String?
+
+    /// Creates a text input with a localized label.
     ///
     /// - Parameters:
     ///    - key: A `LocalizedStringKey` used to look up the label in the given bundle
@@ -477,13 +572,14 @@ public struct OUDSTextInput: View {
     ///    - suffix: Text placed after the user's input, by default is *nil*
     ///    - leadingIcon: An optional leading icon, by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
-    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon
     ///    - trailingAction: An optional trailing action, by default is *nil*
     ///    - helperText: An optional helper text, by default is *nil*
     ///    - helperLink: An optional helper link, by default is *nil*
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
+    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -506,9 +602,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon,
-                  flipLeadingIcon: flipLeadingIcon,
-                  leadingIconRenderingMode: leadingIconRenderingMode,
+                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -520,11 +614,59 @@ public struct OUDSTextInput: View {
     /// Creates a text input with a localized label, looking up the key in the given bundle.
     ///
     /// ```swift
-    ///     OUDSTextInput(LocalizedStringKey("email_label"),
-    ///                   bundle: Bundle.module,
-    ///                   text: $text,
-    ///                   helperText: AttributedString(markdown: "You should use your **corporate email**"))  // Manage in your side errors for init
+    ///     OUDSTextInput(LocalizedStringKey("email_label"), bundle: Bundle.module, text: $text)
+    ///
+    ///     OUDSTextInput(LocalizedStringKey("email_label"), bundle: Bundle.module, text: $text,
+    ///                   leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
     /// ```
+    ///
+    /// - Parameters:
+    ///    - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - text: The text to display and edit
+    ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: An optional helper text, by default is *nil*
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                text: Binding<String>,
+                placeholder: String? = nil,
+                prefix: String? = nil,
+                suffix: String? = nil,
+                leadingIcon: OUDSImage? = nil,
+                trailingAction: Self.TrailingAction? = nil,
+                helperText: String? = nil,
+                helperLink: Self.Helperlink? = nil,
+                isOutlined: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                status: Self.Status = .enabled)
+    {
+        self.init(label: key.resolved(tableName: tableName, bundle: bundle),
+                  text: text,
+                  placeholder: placeholder,
+                  prefix: prefix,
+                  suffix: suffix,
+                  leadingIcon: leadingIcon,
+                  trailingAction: trailingAction,
+                  helperText: helperText,
+                  helperLink: helperLink,
+                  isOutlined: isOutlined,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  status: status)
+    }
+
+    // MARK: - Initializers — LocalizedStringKey + helperText: AttributedString
+
+    /// Creates a text input with a localized label and a rich attributed helper text.
     ///
     /// - Parameters:
     ///    - key: A `LocalizedStringKey` used to look up the label in the given bundle
@@ -536,13 +678,14 @@ public struct OUDSTextInput: View {
     ///    - suffix: Text placed after the user's input, by default is *nil*
     ///    - leadingIcon: An optional leading icon, by default is *nil*
     ///    - flipLeadingIcon: Default set to *false*, set to *true* to mirror the leading icon
-    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///    - leadingIconRenderingMode: The rendering mode to apply on the leading icon
     ///    - trailingAction: An optional trailing action, by default is *nil*
-    ///    - helperText: An helper text in rich text
+    ///    - helperText: A rich `AttributedString` helper text
     ///    - helperLink: An optional helper link, by default is *nil*
     ///    - isOutlined: Controls the style of the text input, by default is *false*
     ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
     ///    - status: The current status of the text input, default set to *enabled*
+    @available(*, deprecated, message: "Use OUDSTextInput(_:tableName:bundle:text:placeholder:prefix:suffix:leadingIcon:OUDSImage:trailingAction:helperText:AttributedString:helperLink:isOutlined:constrainedMaxWidth:status:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -565,9 +708,7 @@ public struct OUDSTextInput: View {
                   placeholder: placeholder,
                   prefix: prefix,
                   suffix: suffix,
-                  leadingIcon: leadingIcon,
-                  flipLeadingIcon: flipLeadingIcon,
-                  leadingIconRenderingMode: leadingIconRenderingMode,
+                  leadingIcon: leadingIcon.map { OUDSImage(asset: $0, flipped: flipLeadingIcon, renderingMode: leadingIconRenderingMode) },
                   trailingAction: trailingAction,
                   helperText: helperText,
                   helperLink: helperLink,
@@ -576,9 +717,60 @@ public struct OUDSTextInput: View {
                   status: status)
     }
 
-    // swiftlint:enable function_default_parameter_at_end
+    /// Creates a text input with a localized label and a rich attributed helper text.
+    ///
+    /// ```swift
+    ///     OUDSTextInput(LocalizedStringKey("email_label"),
+    ///                   bundle: Bundle.module,
+    ///                   text: $text,
+    ///                   helperText: AttributedString(markdown: "You should use your **corporate email**"))
+    /// ```
+    ///
+    /// - Parameters:
+    ///    - key: A `LocalizedStringKey` used to look up the label in the given bundle
+    ///    - tableName: The name of the `.strings` file, or `nil` for the default
+    ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - text: The text to display and edit
+    ///    - placeholder: The text displayed when the text input is empty, by default is *nil*
+    ///    - prefix: Text placed before the user's input, by default is *nil*
+    ///    - suffix: Text placed after the user's input, by default is *nil*
+    ///    - leadingIcon: An optional ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode, by default is *nil*
+    ///    - trailingAction: An optional trailing action, by default is *nil*
+    ///    - helperText: A rich `AttributedString` helper text
+    ///    - helperLink: An optional helper link, by default is *nil*
+    ///    - isOutlined: Controls the style of the text input, by default is *false*
+    ///    - constrainedMaxWidth: When `true`, the width is constrained, defaults to `false`
+    ///    - status: The current status of the text input, default set to *enabled*
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                text: Binding<String>,
+                placeholder: String? = nil,
+                prefix: String? = nil,
+                suffix: String? = nil,
+                leadingIcon: OUDSImage? = nil,
+                trailingAction: Self.TrailingAction? = nil,
+                helperText: AttributedString,
+                helperLink: Self.Helperlink? = nil,
+                isOutlined: Bool = false,
+                constrainedMaxWidth: Bool = false,
+                status: Self.Status = .enabled)
+    {
+        self.init(label: key.resolved(tableName: tableName, bundle: bundle),
+                  text: text,
+                  placeholder: placeholder,
+                  prefix: prefix,
+                  suffix: suffix,
+                  leadingIcon: leadingIcon,
+                  trailingAction: trailingAction,
+                  helperText: helperText,
+                  helperLink: helperLink,
+                  isOutlined: isOutlined,
+                  constrainedMaxWidth: constrainedMaxWidth,
+                  status: status)
+    }
 
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.fixedNone) {
@@ -589,8 +781,6 @@ public struct OUDSTextInput: View {
                                    prefix: prefix,
                                    suffix: suffix,
                                    leadingIcon: leadingIcon,
-                                   flipIcon: flipLeadingIcon,
-                                   leadingIconRenderingMode: leadingIconRenderingMode,
                                    trailingAction: trailingAction,
                                    isOutlined: isOutlined,
                                    status: status,
@@ -612,4 +802,8 @@ public struct OUDSTextInput: View {
                alignment: .leading)
     }
 }
+
+// swiftlint:enable function_default_parameter_at_end
+// swiftlint:enable line_length
+// swiftlint:enable type_body_length
 #endif

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertLeadingIcon.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertLeadingIcon.swift
@@ -44,15 +44,15 @@ struct AlertLeadingIcon: View {
             case let .neutral(icon):
                 icon?.update(with: theme.icon.colorContentDefault)
             case .negative:
-                OUDSIcon(assetName: "ic_alert_important_fill", color: theme.colors.contentStatusNegative)
+                OUDSImage(assetName: "ic_alert_important_fill", color: theme.colors.contentStatusNegative)
             case .positive:
-                OUDSIcon(assetName: "ic_alert_tick_confirmation_fill", color: theme.colors.contentStatusPositive)
+                OUDSImage(assetName: "ic_alert_tick_confirmation_fill", color: theme.colors.contentStatusPositive)
             case .info:
-                OUDSIcon(assetName: "ic_alert_info_fill", color: theme.colors.contentStatusInfo)
+                OUDSImage(assetName: "ic_alert_info_fill", color: theme.colors.contentStatusInfo)
             case .warning:
                 ZStack {
-                    OUDSIcon(assetName: "ic_alert_warning_external_shape", color: theme.icon.colorContentStatusWarningExternalShape)
-                    OUDSIcon(assetName: "ic_alert_warning_internal_shape", color: theme.icon.colorContentStatusWarningInternalShape)
+                    OUDSImage(assetName: "ic_alert_warning_external_shape", color: theme.icon.colorContentStatusWarningExternalShape)
+                    OUDSImage(assetName: "ic_alert_warning_internal_shape", color: theme.icon.colorContentStatusWarningInternalShape)
                 }
             }
         }

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageAction.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageAction.swift
@@ -32,8 +32,8 @@ struct AlertMessageAction: View {
             }
 
             if let onClose {
-                OUDSButton(icon: Image(decorative: "ic_button_expurge", bundle: theme.resourcesBundle),
-                           accessibilityLabel: "core_alertMessage_close_a11y".localized(),
+                OUDSButton(image: OUDSImage(asset: Image(decorative: "ic_button_expurge", bundle: theme.resourcesBundle),
+                                            accessibilityLabel: "core_alertMessage_close_a11y".localized()),
                            appearance: .minimal,
                            action: onClose)
             }

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBulletList.swift
@@ -31,7 +31,7 @@ struct AlertMessageBulletListItem: View {
     var body: some View {
         HStack(alignment: .top, spacing: theme.bulletList.spaceColumnGapBodyMedium) {
             HStack(alignment: .center) {
-                OUDSIcon(assetName: "ic_bullet_list_level0", color: foregroundColor)
+                OUDSImage(assetName: "ic_bullet_list_level0", color: foregroundColor)
                     .frame(width: iconSize, height: iconSize)
             }
             .frame(width: width, alignment: .trailing)

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
@@ -38,8 +38,10 @@ import SwiftUI
 ///         }
 ///
 ///         // Add a custom icon for accent and neutral status
+///         // with original rendering mode (to avoid tints) or not.
+///         // By default, tinted, template mode.
 ///         OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-///         OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"))))
+///         OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)))
 ///
 ///         // Add a custom action (i.e Link) at bottom (could also at top trailing position)
 ///         @Environment(\.openURL) private var openUrl

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertMessage.swift
@@ -40,8 +40,8 @@ import SwiftUI
 ///         // Add a custom icon for accent and neutral status
 ///         // with original rendering mode (to avoid tints) or not.
 ///         // By default, tinted, template mode.
-///         OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-///         OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)))
+///         OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_heart"))))
+///         OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original)))
 ///
 ///         // Add a custom action (i.e Link) at bottom (could also at top trailing position)
 ///         @Environment(\.openURL) private var openUrl

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertStatus.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertStatus.swift
@@ -31,15 +31,15 @@ import SwiftUI
     /// Suitable for a wide range of contexts — such as tips, general information, or descriptive labels — where
     /// no specific feedback or urgency is required. Appropriate for help sections, dashboards, or onboarding flows.
     ///
-    /// - Parameter icon: Optional `OUDSIcon`  to be displayed in the alert. Pass `nil` if no icon is needed.
-    case neutral(icon: OUDSIcon? = nil)
+    /// - Parameter icon: Optional `OUDSImage`  to be displayed in the alert. Pass `nil` if no icon is needed.
+    case neutral(icon: OUDSImage? = nil)
 
     /// Accent status uses brand colours to draw attention to promotional or highlighted information while remaining non-critical. Ideal for marketing content,
     /// announcements, or feature highlights, where you want to subtly engage users without introducing functional semantics. Ideal for promotional banners,
     /// product updates, or customer engagement moments.
     ///
-    /// - Parameter icon: Optional `OUDSIcon`  to be displayed in the alert. Pass `nil` if no icon is needed.
-    case accent(icon: OUDSIcon? = nil)
+    /// - Parameter icon: Optional `OUDSImage`  to be displayed in the alert. Pass `nil` if no icon is needed.
+    case accent(icon: OUDSImage? = nil)
 
     /// Positive status indicates that a task or process has been completed successfully. These alerts reassure users and confirm that no further action is needed.
     /// This status displays a dedicated default icon.

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertStatus.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSAlertStatus.swift
@@ -27,6 +27,7 @@ import SwiftUI
 ///  These messages carry functional meaning and help guide user response or acknowledgment.
 @frozen public enum OUDSAlertStatus {
 
+    // TODO: For v3, rename the "icon" parameter to "image" to be aligned with other enums
     /// Neutral status can be used as a generic informative alert without semantic meaning or colour association.
     /// Suitable for a wide range of contexts — such as tips, general information, or descriptive labels — where
     /// no specific feedback or urgency is required. Appropriate for help sections, dashboards, or onboarding flows.
@@ -34,6 +35,7 @@ import SwiftUI
     /// - Parameter icon: Optional `OUDSImage`  to be displayed in the alert. Pass `nil` if no icon is needed.
     case neutral(icon: OUDSImage? = nil)
 
+    // TODO: For v3, rename the "icon" parameter to "image" to be aligned with other enums
     /// Accent status uses brand colours to draw attention to promotional or highlighted information while remaining non-critical. Ideal for marketing content,
     /// announcements, or feature highlights, where you want to subtly engage users without introducing functional semantics. Ideal for promotional banners,
     /// product updates, or customer engagement moments.

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSInlineAlert.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/OUDSInlineAlert.swift
@@ -31,8 +31,8 @@ import SwiftUI
 ///     OUDSInlineAlert(label: "Warning", status: .warning)
 ///
 ///     // Add a custom icon for accent and neutral status
-///     OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-///     OUDSInlineAlert(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"))))
+///     OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_heart"))))
+///     OUDSInlineAlert(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_heart"))))
 /// ```
 ///
 /// ## Design documentation

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
@@ -32,11 +32,11 @@ struct BadgeIcon: View {
             case .warning:
                 if isEnabled {
                     ZStack {
-                        OUDSIcon(assetName: "ic_badge_warning_internal_shape", color: theme.icon.colorContentStatusWarningInternalShape)
-                        OUDSIcon(assetName: "ic_badge_warning_external_shape", color: theme.icon.colorContentStatusWarningExternalShape)
+                        OUDSImage(assetName: "ic_badge_warning_internal_shape", color: theme.icon.colorContentStatusWarningInternalShape)
+                        OUDSImage(assetName: "ic_badge_warning_external_shape", color: theme.icon.colorContentStatusWarningExternalShape)
                     }
                 } else {
-                    OUDSIcon(assetName: "ic_badge_warning_external_shape", color: theme.colors.actionDisabled)
+                    OUDSImage(assetName: "ic_badge_warning_external_shape", color: theme.colors.actionDisabled)
                 }
             default:
                 icon

--- a/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/Internal/BadgeIcon.swift
@@ -20,6 +20,7 @@ struct BadgeIcon: View {
     // MARK: Properties
 
     let configuration: BadgeIconConfiguration
+
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
 
@@ -40,7 +41,7 @@ struct BadgeIcon: View {
             default:
                 icon
                     .resizable()
-                    .renderingMode(.template)
+                    .renderingMode(renderingMode)
                     .toFlip(flipped)
             }
         }
@@ -70,7 +71,7 @@ struct BadgeIcon: View {
 
     private var icon: Image {
         switch configuration.status {
-        case let .neutral(icon, _), let .accent(icon, _):
+        case let .neutral(icon, _, _), let .accent(icon, _, _):
             icon
         case .warning:
             Image(decorative: "ic_badge_warning_external_shape", bundle: theme.resourcesBundle)
@@ -85,10 +86,19 @@ struct BadgeIcon: View {
 
     private var flipped: Bool {
         switch configuration.status {
-        case let .neutral(_, flipped), let .accent(_, flipped):
+        case let .neutral(_, flipped, _), let .accent(_, flipped, _):
             flipped
         default:
             false
+        }
+    }
+
+    private var renderingMode: Image.TemplateRenderingMode {
+        switch configuration.status {
+        case let .neutral(_, _, renderingMode), let .accent(_, _, renderingMode):
+            renderingMode
+        default:
+            .template
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -212,7 +212,7 @@ public struct OUDSBadge: View {
     }
 
     /// Creates a badge which displays numerical value (e.g., unread messages, notifications).
-    /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99, "+99" is displayed.
+    /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99,OUDSB "+99" is displayed.
     /// Negative values are not allowed by design.
     /// The background color of the badge and the number color are based on the given `status`.
     ///

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadge.swift
@@ -212,7 +212,7 @@ public struct OUDSBadge: View {
     }
 
     /// Creates a badge which displays numerical value (e.g., unread messages, notifications).
-    /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99,OUDSB "+99" is displayed.
+    /// Minimum and maximum values are 0 and 99 respectively. If value is greater than 99, "+99" is displayed.
     /// Negative values are not allowed by design.
     /// The background color of the badge and the number color are based on the given `status`.
     ///

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadgeIcon.swift
@@ -82,11 +82,21 @@ public struct OUDSBadgeIcon: View {
     /// - Since: 2.2.0
     @frozen public enum Status {
 
-        /// Used for general labels without specific emphasis
-        case neutral(icon: Image, flipped: Bool = false)
+        /// Used for general labels without specific emphasis.
+        ///
+        /// - Parameters:
+        ///    - icon: The `Image` to display in the badge
+        ///    - flipped: Default set to `false`, set to `true` to mirror the image (e.g. in RTL cases if relevant)
+        ///    - renderingMode: Default set to `.template`, set to `.original` if the image of the badge should not be tinted
+        case neutral(icon: Image, flipped: Bool = false, renderingMode: Image.TemplateRenderingMode = .template)
 
         /// Employed to highlight discovery or exploration-related content
-        case accent(icon: Image, flipped: Bool = false)
+        ///
+        /// - Parameters:
+        ///    - icon: The `Image` to display in the badge
+        ///    - flipped: Default set to `false`, set to `true` to mirror the image (e.g. in RTL cases if relevant)
+        ///    - renderingMode: Default set to `.template`, set to `.original` if the image of the badge should not be tinted
+        case accent(icon: Image, flipped: Bool = false, renderingMode: Image.TemplateRenderingMode = .template)
 
         /// Indicates success, completion, or approval
         case positive

--- a/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadgeIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Badge/OUDSBadgeIcon.swift
@@ -82,6 +82,8 @@ public struct OUDSBadgeIcon: View {
     /// - Since: 2.2.0
     @frozen public enum Status {
 
+        // TODO: For version v3, use OUDSImage instead of icon, accessibilityLabel and renderingMode
+        // Not done yet to not break public API
         /// Used for general labels without specific emphasis.
         ///
         /// - Parameters:
@@ -90,6 +92,8 @@ public struct OUDSBadgeIcon: View {
         ///    - renderingMode: Default set to `.template`, set to `.original` if the image of the badge should not be tinted
         case neutral(icon: Image, flipped: Bool = false, renderingMode: Image.TemplateRenderingMode = .template)
 
+        // TODO: For version v3, use OUDSImage instead of icon, accessibilityLabel and renderingMode
+        // Not done yet to not break public API
         /// Employed to highlight discovery or exploration-related content
         ///
         /// - Parameters:

--- a/OUDS/Core/Components/Sources/Indicators/Tag/Internal/InputTag/InputTagContent.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/Internal/InputTag/InputTagContent.swift
@@ -25,7 +25,8 @@ struct InputTagContent: View {
         HStack(alignment: .center, spacing: theme.tag.spaceColumnGapDefault) {
             Text(label)
                 .labelModerateMedium(theme)
-            ScaledIcon(icon: Image(decorative: "ic_tag_close", bundle: theme.resourcesBundle).renderingMode(.template),
+            ScaledIcon(image: OUDSImage(asset: Image(decorative: "ic_tag_close", bundle: theme.resourcesBundle),
+                                        renderingMode: .template),
                        size: theme.tag.sizeAssetDefault)
                 .aspectRatio(contentMode: .fit)
         }

--- a/OUDS/Core/Components/Sources/Indicators/Tag/Internal/Tag/TagLabelStyle+TagIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/Internal/Tag/TagLabelStyle+TagIcon.swift
@@ -88,7 +88,7 @@ struct TagAsset: View {
                 iconFromAsset?
                     .renderingMode(appliedRenderingMode)
                     .resizable()
-                    .toFlip(status.flipIcon)
+                    .toFlip(status.customIcon?.flipped ?? false)
                     .foregroundColor(color)
             }
         }
@@ -104,16 +104,16 @@ struct TagAsset: View {
         case .bullet:
             return Image(decorative: "ic_tag_bullet", bundle: theme.resourcesBundle)
         case .icon:
-            if let alternativeIcon = status.customIcon {
-                return alternativeIcon
+            if let oudsImage = status.customIcon {
+                return oudsImage.asset
             }
             return defaultLeadingIcon
         }
     }
 
     private var appliedRenderingMode: Image.TemplateRenderingMode {
-        if status.leading == .icon, status.customIcon != nil {
-            status.renderingMode
+        if status.leading == .icon, let oudsImage = status.customIcon {
+            oudsImage.renderingMode
         } else {
             .template
         }

--- a/OUDS/Core/Components/Sources/Indicators/Tag/Internal/Tag/TagLabelStyle+TagIcon.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/Internal/Tag/TagLabelStyle+TagIcon.swift
@@ -86,7 +86,7 @@ struct TagAsset: View {
                 }
             } else {
                 iconFromAsset?
-                    .renderingMode(.template)
+                    .renderingMode(appliedRenderingMode)
                     .resizable()
                     .toFlip(status.flipIcon)
                     .foregroundColor(color)
@@ -108,6 +108,14 @@ struct TagAsset: View {
                 return alternativeIcon
             }
             return defaultLeadingIcon
+        }
+    }
+
+    private var appliedRenderingMode: Image.TemplateRenderingMode {
+        if status.leading == .icon, status.customIcon != nil {
+            status.renderingMode
+        } else {
+            .template
         }
     }
 

--- a/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
@@ -105,12 +105,12 @@ import SwiftUI
 ///     OUDSTag(label: "Label", status: .neutral(leading: .bullet)
 ///
 ///     // Tag with neutral status with a custom decorative icon
-///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"))))
 ///     // If your layout is in RTL mode but your tag has an icon with another meaning because of bad orientation,
 ///     // you can flip the icon using OUDSImage.flipped
-///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
 ///     // If you want to display a raw image (not tinted), use renderingMode: .original
-///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
 ///
 ///     // Text with neutral status with bullet
 ///     OUDSTag(label: "Label", status: .neutral(bullet: true))
@@ -250,26 +250,26 @@ public struct OUDSTag: View {
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
         ///    - renderingMode: The rendering mode to apply on the icon
-        @available(*, deprecated, message: "Use OUDSTag.Status.neutral(icon: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
+        @available(*, deprecated, message: "Use OUDSTag.Status.neutral(image: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
         public static func neutral(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
-            .neutral(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
+            .neutral(image: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
         }
 
         /// Used to create a tag with a neutral status with a leading ``OUDSImage`` icon.
         ///
         /// ```swift
-        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+        ///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"))))
         ///
         ///     // Raw (non-tinted) image:
-        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+        ///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
         ///
         ///     // Flip for RTL:
-        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+        ///     OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
         /// ```
         ///
-        /// - Parameter icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
-        public static func neutral(icon: OUDSImage) -> Status {
-            Status(leading: .icon, category: .neutral, alternativeIcon: icon)
+        /// - Parameter image: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        public static func neutral(image: OUDSImage) -> Status {
+            Status(leading: .icon, category: .neutral, alternativeIcon: image)
         }
 
         /// Used to create a tag with a neutral status with leading bullet or not.
@@ -285,23 +285,23 @@ public struct OUDSTag: View {
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
         ///    - renderingMode: The rendering mode to apply on the icon
-        @available(*, deprecated, message: "Use OUDSTag.Status.accent(icon: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
+        @available(*, deprecated, message: "Use OUDSTag.Status.accent(image: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
         public static func accent(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
-            .accent(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
+            .accent(image: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
         }
 
         /// Used to create a tag with an accent status with a leading ``OUDSImage`` icon.
         ///
         /// ```swift
-        ///     OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+        ///     OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image(decorative: "ic_heart"))))
         ///
         ///     // Raw (non-tinted) image:
-        ///     OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+        ///     OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
         /// ```
         ///
-        /// - Parameter icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
-        public static func accent(icon: OUDSImage) -> Status {
-            Status(leading: .icon, category: .accent, alternativeIcon: icon)
+        /// - Parameter image: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        public static func accent(image: OUDSImage) -> Status {
+            Status(leading: .icon, category: .accent, alternativeIcon: image)
         }
 
         /// Used to create a tag with an accent status with leading bullet or not.

--- a/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
@@ -105,12 +105,12 @@ import SwiftUI
 ///     OUDSTag(label: "Label", status: .neutral(leading: .bullet)
 ///
 ///     // Tag with neutral status with a custom decorative icon
-///     OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
+///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
 ///     // If your layout is in RTL mode but your tag has an icon with another meaning because of bad orientation,
-///     // you can flip the icon
-///     OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+///     // you can flip the icon using OUDSImage.flipped
+///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
 ///     // If you want to display a raw image (not tinted), use renderingMode: .original
-///     OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
+///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
 ///
 ///     // Text with neutral status with bullet
 ///     OUDSTag(label: "Label", status: .neutral(bullet: true))
@@ -179,9 +179,7 @@ public struct OUDSTag: View {
 
         let leading: Self.Leading
         let category: Self.Category
-        let customIcon: Image?
-        let flipIcon: Bool
-        let renderingMode: Image.TemplateRenderingMode
+        let customIcon: OUDSImage?
 
         /// The leading element of the tag
         /// - Since: 0.18.0
@@ -251,9 +249,27 @@ public struct OUDSTag: View {
         /// - Parameters:
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-        ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+        ///    - renderingMode: The rendering mode to apply on the icon
+        @available(*, deprecated, message: "Use OUDSTag.Status.neutral(icon: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
         public static func neutral(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
-            Status(leading: .icon, category: .neutral, alternativeIcon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
+            .neutral(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
+        }
+
+        /// Used to create a tag with a neutral status with a leading ``OUDSImage`` icon.
+        ///
+        /// ```swift
+        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+        ///
+        ///     // Raw (non-tinted) image:
+        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+        ///
+        ///     // Flip for RTL:
+        ///     OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+        /// ```
+        ///
+        /// - Parameter icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        public static func neutral(icon: OUDSImage) -> Status {
+            Status(leading: .icon, category: .neutral, alternativeIcon: icon)
         }
 
         /// Used to create a tag with a neutral status with leading bullet or not.
@@ -263,17 +279,32 @@ public struct OUDSTag: View {
             Status(leading: bullet ? .bullet : .none, category: .neutral)
         }
 
-        /// Used to create a tag with a accent status with leading icon.
+        /// Used to create a tag with an accent status with leading icon.
         ///
         /// - Parameters:
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-        ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+        ///    - renderingMode: The rendering mode to apply on the icon
+        @available(*, deprecated, message: "Use OUDSTag.Status.accent(icon: OUDSImage) instead. Pass OUDSImage(asset:flipped:renderingMode:) to encapsulate image configuration.")
         public static func accent(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
-            Status(leading: .icon, category: .accent, alternativeIcon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
+            .accent(icon: OUDSImage(asset: icon, flipped: flipIcon, renderingMode: renderingMode))
         }
 
-        /// Used to create a tag with a accent status with leading bullet or not.
+        /// Used to create a tag with an accent status with a leading ``OUDSImage`` icon.
+        ///
+        /// ```swift
+        ///     OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+        ///
+        ///     // Raw (non-tinted) image:
+        ///     OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+        /// ```
+        ///
+        /// - Parameter icon: An ``OUDSImage`` encapsulating the asset, its flip flag and its rendering mode
+        public static func accent(icon: OUDSImage) -> Status {
+            Status(leading: .icon, category: .accent, alternativeIcon: icon)
+        }
+
+        /// Used to create a tag with an accent status with leading bullet or not.
         ///
         /// - Parameter bullet: Default set to `false`, set to true to add bullet.
         public static func accent(bullet: Bool = false) -> Status {
@@ -285,15 +316,11 @@ public struct OUDSTag: View {
         /// - Parameters:
         ///    - leading: The leading element
         ///    - category: The category of the status
-        ///    - alternativeIcon: The optional leading icon
-        ///    - flipIcon: Flag to flip icon
-        ///    - renderingMode: The rendering mode to apply on the icon (only used when `leading == .icon` and an `alternativeIcon` is provided)
-        private init(leading: Leading, category: Self.Category, alternativeIcon: Image? = nil, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) {
+        ///    - alternativeIcon: The optional leading ``OUDSImage`` (asset, flip and rendering mode encapsulated)
+        private init(leading: Leading, category: Self.Category, alternativeIcon: OUDSImage? = nil) {
             self.leading = leading
             self.category = category
             customIcon = alternativeIcon
-            self.flipIcon = flipIcon
-            self.renderingMode = renderingMode
         }
     }
 

--- a/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
+++ b/OUDS/Core/Components/Sources/Indicators/Tag/OUDSTag.swift
@@ -109,6 +109,8 @@ import SwiftUI
 ///     // If your layout is in RTL mode but your tag has an icon with another meaning because of bad orientation,
 ///     // you can flip the icon
 ///     OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+///     // If you want to display a raw image (not tinted), use renderingMode: .original
+///     OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
 ///
 ///     // Text with neutral status with bullet
 ///     OUDSTag(label: "Label", status: .neutral(bullet: true))
@@ -179,6 +181,7 @@ public struct OUDSTag: View {
         let category: Self.Category
         let customIcon: Image?
         let flipIcon: Bool
+        let renderingMode: Image.TemplateRenderingMode
 
         /// The leading element of the tag
         /// - Since: 0.18.0
@@ -248,8 +251,9 @@ public struct OUDSTag: View {
         /// - Parameters:
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-        public static func neutral(icon: Image, flipIcon: Bool = false) -> Status {
-            Status(leading: .icon, category: .neutral, alternativeIcon: icon, flipIcon: flipIcon)
+        ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+        public static func neutral(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
+            Status(leading: .icon, category: .neutral, alternativeIcon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
         }
 
         /// Used to create a tag with a neutral status with leading bullet or not.
@@ -264,8 +268,9 @@ public struct OUDSTag: View {
         /// - Parameters:
         ///    - icon: The icon to set as leading element in the tag
         ///    - flipIcon: Default set to `false`, set to true to reverse the image (i.e. flip vertically)
-        public static func accent(icon: Image, flipIcon: Bool = false) -> Status {
-            Status(leading: .icon, category: .accent, alternativeIcon: icon, flipIcon: flipIcon)
+        ///    - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+        public static func accent(icon: Image, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) -> Status {
+            Status(leading: .icon, category: .accent, alternativeIcon: icon, flipIcon: flipIcon, renderingMode: renderingMode)
         }
 
         /// Used to create a tag with a accent status with leading bullet or not.
@@ -282,11 +287,13 @@ public struct OUDSTag: View {
         ///    - category: The category of the status
         ///    - alternativeIcon: The optional leading icon
         ///    - flipIcon: Flag to flip icon
-        private init(leading: Leading, category: Self.Category, alternativeIcon: Image? = nil, flipIcon: Bool = false) {
+        ///    - renderingMode: The rendering mode to apply on the icon (only used when `leading == .icon` and an `alternativeIcon` is provided)
+        private init(leading: Leading, category: Self.Category, alternativeIcon: Image? = nil, flipIcon: Bool = false, renderingMode: Image.TemplateRenderingMode = .template) {
             self.leading = leading
             self.category = category
             customIcon = alternativeIcon
             self.flipIcon = flipIcon
+            self.renderingMode = renderingMode
         }
     }
 

--- a/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
+++ b/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///
 /// ```swift
 ///   OUDSColoredSurface(color: theme.colorModes.onBrandPrimary) {
-///      OUDSButton(image: OUDSImage(asset: "ic_heart")), appearance: .strong) {}
+///      OUDSButton(image: OUDSImage(asset: Image("ic_heart")), appearance: .strong) {}
 ///   }
 /// ```
 ///

--- a/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
+++ b/OUDS/Core/Components/Sources/Layouts/ColoredSurface/OUDSColoredSurface.swift
@@ -23,7 +23,7 @@ import SwiftUI
 ///
 /// ```swift
 ///   OUDSColoredSurface(color: theme.colorModes.onBrandPrimary) {
-///      OUDSButton(icon: Image("ic_heart"), appearance: .strong) {}
+///      OUDSButton(image: OUDSImage(asset: "ic_heart")), appearance: .strong) {}
 ///   }
 /// ```
 ///

--- a/OUDS/Core/Components/Sources/Layouts/OUDSIcon.swift
+++ b/OUDS/Core/Components/Sources/Layouts/OUDSIcon.swift
@@ -69,7 +69,7 @@ public struct OUDSIcon: View {
                 renderingMode: Image.TemplateRenderingMode = .template)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
-        self.init(asset: asset, flipped: flipped, accessibilityLabel: resolvedText)
+        self.init(asset: asset, flipped: flipped, accessibilityLabel: resolvedText, renderingMode: renderingMode)
     }
 
     // swiftlint:enable function_default_parameter_at_end

--- a/OUDS/Core/Components/Sources/Layouts/OUDSIcon.swift
+++ b/OUDS/Core/Components/Sources/Layouts/OUDSIcon.swift
@@ -21,6 +21,16 @@ import SwiftUI
 /// The icon can be flipped for RTL consideration and an associated `acessibilityLabel`must be provided
 /// if the icon is not decorative.
 ///
+/// ## Code Samples
+///
+/// ```swift
+///     // Display an image with a label loaded from a given module (default in rendering mode)
+///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+///
+///     // Display an image but without tints and in original mode
+///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+/// ```
+///
 /// - Since: 1.3.0
 public struct OUDSIcon: View {
 
@@ -31,6 +41,7 @@ public struct OUDSIcon: View {
     private let flipped: Bool
     private let accessibilityLabel: String?
     private let color: MultipleColorSemanticToken?
+    private let renderingMode: Image.TemplateRenderingMode
 
     @Environment(\.theme) private var theme
 
@@ -49,11 +60,13 @@ public struct OUDSIcon: View {
     ///    - key: The text to vocalize with *Voice Over* the component must have, as as `LocalizedStringKey` for the given `Bundle`
     ///    - tableName: The name of the `.strings` file, or `nil` for the default
     ///    - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///    - renderingMode: By default set to `.template`, allows to apply colors on given `asset` or not
     public init(asset: Image,
                 flipped: Bool = false,
                 accessibilityLabel key: LocalizedStringKey,
                 tableName: String? = nil,
-                bundle: Bundle = .main)
+                bundle: Bundle = .main,
+                renderingMode: Image.TemplateRenderingMode = .template)
     {
         let resolvedText = key.resolved(tableName: tableName, bundle: bundle)
         self.init(asset: asset, flipped: flipped, accessibilityLabel: resolvedText)
@@ -71,12 +84,18 @@ public struct OUDSIcon: View {
     ///    - asset: The asset
     ///    - flipped: If asset must be flipped, default set to `false`
     ///    - accessibilityLabel:The label to be vocalized to describe the icon, default set to `nil`
-    public init(asset: Image, flipped: Bool = false, accessibilityLabel: String? = nil) {
+    ///    - renderingMode: By default set to `.template`, allows to apply colors on given `asset` or not
+    public init(asset: Image,
+                flipped: Bool = false,
+                accessibilityLabel: String? = nil,
+                renderingMode: Image.TemplateRenderingMode = .template)
+    {
         self.asset = asset
         assetName = nil
         self.flipped = flipped
         self.accessibilityLabel = accessibilityLabel
         color = nil
+        self.renderingMode = renderingMode
     }
 
     /// Create the icon from its name.
@@ -93,6 +112,7 @@ public struct OUDSIcon: View {
         self.flipped = flipped
         self.accessibilityLabel = accessibilityLabel
         self.color = color
+        renderingMode = .template
     }
 
     // MARK: Body
@@ -100,7 +120,7 @@ public struct OUDSIcon: View {
     public var body: some View {
         image?
             .resizable()
-            .renderingMode(.template)
+            .renderingMode(renderingMode)
             .toFlip(flipped)
             .update(with: color)
             .accessibility(label: Text(accessibilityLabel ?? ""))

--- a/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
+++ b/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
@@ -15,7 +15,11 @@ import OUDSFoundations
 import OUDSTokensSemantic
 import SwiftUI
 
-// MARK: - OUDS Icon
+// MARK: - OUDS Image
+
+/// Old name of ``OUDSImage``
+@available(*, deprecated, message: "Use OUDSImage type instead of OUDSIcon.")
+public typealias OUDSIcon = OUDSImage // To not break public API where OUDSIcon were used before
 
 /// Use to provide an asset to ouds in order to be added in some components.
 /// The icon can be flipped for RTL consideration and an associated `acessibilityLabel`must be provided
@@ -25,14 +29,14 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Display an image with a label loaded from a given module (default in rendering mode)
-///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+///     OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
 ///
 ///     // Display an image but without tints and in original mode
-///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+///     OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
 /// ```
 ///
 /// - Since: 1.3.0
-public struct OUDSIcon: View {
+public struct OUDSImage: View {
 
     // MARK: Properties
 
@@ -51,7 +55,7 @@ public struct OUDSIcon: View {
     /// Create the icon with asset.
     ///
     /// ```swift
-    ///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+    ///     OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
     /// ```
     ///
     /// - Parameters:
@@ -77,7 +81,7 @@ public struct OUDSIcon: View {
     /// Create the icon with asset.
     ///
     /// ```swift
-    ///     OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like")
+    ///     OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like")
     /// ```
     ///
     /// - Parameters:

--- a/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
+++ b/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
@@ -17,7 +17,7 @@ import SwiftUI
 
 // MARK: - OUDS Image
 
-/// Old name of ``OUDSImage``
+/// Old name of ``OUDSImage`` (before v2.3.0)
 @available(*, deprecated, message: "Use OUDSImage type instead of OUDSIcon.")
 public typealias OUDSIcon = OUDSImage // To not break public API where OUDSIcon were used before
 
@@ -40,12 +40,12 @@ public struct OUDSImage: View {
 
     // MARK: Properties
 
-    private let asset: Image?
-    private let assetName: String?
-    private let flipped: Bool
-    private let accessibilityLabel: String?
-    private let color: MultipleColorSemanticToken?
-    private let renderingMode: Image.TemplateRenderingMode
+    public let asset: Image?
+    public let assetName: String?
+    public let flipped: Bool
+    public let accessibilityLabel: String?
+    public let color: MultipleColorSemanticToken?
+    public let renderingMode: Image.TemplateRenderingMode
 
     @Environment(\.theme) private var theme
 

--- a/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
+++ b/OUDS/Core/Components/Sources/Layouts/OUDSImage.swift
@@ -47,6 +47,14 @@ public struct OUDSImage: View {
     public let color: MultipleColorSemanticToken?
     public let renderingMode: Image.TemplateRenderingMode
 
+    public var image: Image? {
+        if let assetName {
+            return Image(decorative: assetName, bundle: theme.resourcesBundle)
+        }
+
+        return asset
+    }
+
     @Environment(\.theme) private var theme
 
     // MARK: Initializers
@@ -131,14 +139,6 @@ public struct OUDSImage: View {
     }
 
     // MARK: Helpers
-
-    private var image: Image? {
-        if let assetName {
-            return Image(decorative: assetName, bundle: theme.resourcesBundle)
-        }
-
-        return asset
-    }
 
     // NOTE: Seen as unused by Periphery 3.4.0  (warning: Unused function 'update(with:)')
     private func update(with color: MultipleColorSemanticToken) -> some View {

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -32,10 +32,10 @@ import SwiftUI
 ///     OUDSLink(LocalizedStringKey("feedback_link"), bundle: Bundle.module, size: .small) { }
 ///
 ///     // Text and icon in default size
-///     OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .default) { /* the action to process */ }
+///     OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_heart")), size: .default) { }
 ///
 ///     // Text and icon with raw image (not tinted)
-///     OUDSLink(text: "Feedback", icon: Image("ic_brand"), renderingMode: .original, size: .default) { /* the action to process */ }
+///     OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) { }
 /// ```
 ///
 /// ## Navigation layout
@@ -81,7 +81,7 @@ import SwiftUI
 @available(iOS 15, macOS 13, visionOS 1, watchOS 11, tvOS 16, *)
 public struct OUDSLink: View {
 
-    // MARK: Stored Properties
+    // MARK: - Stored Properties
 
     private let layout: Layout
     private let text: String
@@ -106,53 +106,73 @@ public struct OUDSLink: View {
     enum Layout {
         case indicator(OUDSLink.Indicator)
         case textOnly
-        case textAndIcon(Image, Image.TemplateRenderingMode)
+        case textAndIcon(OUDSImage)
     }
 
-    // MARK: Initializers
+    // MARK: - Initializers — String label + optional icon
 
     /// Create a link with text and icon.
     ///
-    /// ```swift
-    ///     OUDSLink(text: "Learn more", icon: Image(systemName: "arrow.right")) { }
-    /// ```
-    ///
     /// - Parameters:
     ///   - text: Text displayed in the link
-    ///   - icon: Icon displayed in the link
-    ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///   - icon: An optional icon image
+    ///   - renderingMode: The rendering mode to apply on the icon
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
+    @available(*, deprecated, message: "Use OUDSLink(text:icon:OUDSImage:size:action:) instead.")
     public init(text: String,
                 icon: Image? = nil,
                 renderingMode: Image.TemplateRenderingMode = .template,
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
-        if let icon {
-            layout = .textAndIcon(icon, renderingMode)
-        } else {
-            layout = .textOnly
-        }
+        self.init(text: text,
+                  icon: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
+                  size: size,
+                  action: action)
+    }
+
+    /// Create a link with text and an optional icon.
+    ///
+    /// ```swift
+    ///     OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image(systemName: "arrow.right")), size: .default) {}
+    ///
+    ///     // Raw (non-tinted) image:
+    ///     OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+    ///
+    ///     // Text only — omit icon or pass nil:
+    ///     OUDSLink(text: "Feedback", size: .small) {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - text: Text displayed in the link
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
+    ///   - size: Size of the link
+    ///   - action: The action to perform when the user triggers the link
+    public init(text: String,
+                icon: OUDSImage? = nil,
+                size: Size = .default,
+                action: @escaping () -> Void)
+    {
+        layout = icon.map { .textAndIcon($0) } ?? .textOnly
         self.text = text
         self.size = size
         self.action = action
     }
 
-    /// Creates a link with a localized text and optional icon, looking up the key in the given bundle.
-    ///
-    /// ```swift
-    ///     OUDSLink(LocalizedStringKey("feedback_link"), bundle: Bundle.module, size: .default) { }
-    /// ```
+    // MARK: - Initializers — LocalizedStringKey + optional icon
+
+    /// Creates a link with a localized text and optional icon.
     ///
     /// - Parameters:
     ///   - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///   - tableName: The name of the `.strings` file, or `nil` for the default
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
-    ///   - icon: Icon displayed in the link
-    ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
+    ///   - icon: An optional icon image
+    ///   - renderingMode: The rendering mode to apply on the icon
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
+    @available(*, deprecated, message: "Use OUDSLink(_:tableName:bundle:icon:OUDSImage:size:action:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -161,17 +181,48 @@ public struct OUDSLink: View {
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
-        if let icon {
-            layout = .textAndIcon(icon, renderingMode)
-        } else {
-            layout = .textOnly
-        }
-        text = key.resolved(tableName: tableName, bundle: bundle)
-        self.size = size
-        self.action = action
+        self.init(key.resolved(tableName: tableName, bundle: bundle),
+                  icon: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
+                  size: size,
+                  action: action)
     }
 
-    /// Create a link with a "before `Indicator`" (`OUDSLink.Indicator.back`) or "after  indicator" (`OUDSLink.Indicator.next`) beside the text.
+    /// Creates a link with a localized text and optional icon, looking up the key in the given bundle.
+    ///
+    /// ```swift
+    ///     OUDSLink(LocalizedStringKey("feedback_link"), bundle: Bundle.module, size: .default) {}
+    ///
+    ///     OUDSLink(LocalizedStringKey("learn_more"),
+    ///              bundle: Bundle.module,
+    ///              icon: OUDSImage(asset: Image("ic_heart")),
+    ///              size: .default) {}
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - key: A `LocalizedStringKey` used to look up the text in the given bundle
+    ///   - tableName: The name of the `.strings` file, or `nil` for the default
+    ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
+    ///   - icon: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
+    ///   - size: Size of the link
+    ///   - action: The action to perform when the user triggers the link
+    public init(_ key: LocalizedStringKey,
+                tableName: String? = nil,
+                bundle: Bundle = .main,
+                icon: OUDSImage? = nil,
+                size: Size = .default,
+                action: @escaping () -> Void)
+    {
+        self.init(text: key.resolved(tableName: tableName, bundle: bundle),
+                  icon: icon,
+                  size: size,
+                  action: action)
+    }
+
+    // MARK: - Initializers — indicator (unchanged)
+
+    // swiftlint:disable function_default_parameter_at_end
+
+    /// Create a link with a "before `Indicator`" (`OUDSLink.Indicator.back`) or "after indicator" (`OUDSLink.Indicator.next`) beside the text.
     ///
     /// ```swift
     ///     OUDSLink(text: "Back", indicator: .back) { }
@@ -179,9 +230,9 @@ public struct OUDSLink: View {
     ///
     /// - Parameters:
     ///   - text: Text displayed in the link
-    ///   - indicator: Indicator displayed in the link
-    ///   When `OUDSLink.Indicator.back`, the indicator is displayed before the text
-    ///   When `OudsLink.Indicator.next`, the indicator is displayed after the text
+    ///   - indicator: Indicator displayed in the link.
+    ///   When `OUDSLink.Indicator.back`, the indicator is displayed before the text.
+    ///   When `OUDSLink.Indicator.next`, the indicator is displayed after the text.
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
     public init(text: String, indicator: Indicator, size: Size = .default, action: @escaping () -> Void) {
@@ -191,7 +242,6 @@ public struct OUDSLink: View {
         self.action = action
     }
 
-    // swiftlint:disable function_default_parameter_at_end
     /// Creates a link with a localized text and a navigation indicator, looking up the key in the given bundle.
     ///
     /// ```swift
@@ -220,7 +270,7 @@ public struct OUDSLink: View {
 
     // swiftlint:enable function_default_parameter_at_end
 
-    // MARK: Body
+    // MARK: - Body
 
     public var body: some View {
         Button(action: action) {
@@ -240,13 +290,15 @@ public struct OUDSLink: View {
                 } icon: {
                     EmptyView()
                 }
-            case let .textAndIcon(icon, renderingMode):
+            case let .textAndIcon(oudsImage):
                 Label {
                     Text(LocalizedStringKey(text))
                 } icon: {
-                    icon
-                        .renderingMode(renderingMode)
-                        .resizable()
+                    if let asset = oudsImage.asset {
+                        asset
+                            .renderingMode(oudsImage.renderingMode)
+                            .resizable()
+                    }
                 }
             }
         }

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -33,6 +33,9 @@ import SwiftUI
 ///
 ///     // Text and icon in default size
 ///     OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .default) { /* the action to process */ }
+///
+///     // Text and icon with raw image (not tinted)
+///     OUDSLink(text: "Feedback", icon: Image("ic_brand"), renderingMode: .original, size: .default) { /* the action to process */ }
 /// ```
 ///
 /// ## Navigation layout
@@ -103,7 +106,7 @@ public struct OUDSLink: View {
     enum Layout {
         case indicator(OUDSLink.Indicator)
         case textOnly
-        case textAndIcon(Image)
+        case textAndIcon(Image, Image.TemplateRenderingMode)
     }
 
     // MARK: Initializers
@@ -117,11 +120,17 @@ public struct OUDSLink: View {
     /// - Parameters:
     ///   - text: Text displayed in the link
     ///   - icon: Icon displayed in the link
+    ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
-    public init(text: String, icon: Image? = nil, size: Size = .default, action: @escaping () -> Void) {
+    public init(text: String,
+                icon: Image? = nil,
+                renderingMode: Image.TemplateRenderingMode = .template,
+                size: Size = .default,
+                action: @escaping () -> Void)
+    {
         if let icon {
-            layout = .textAndIcon(icon)
+            layout = .textAndIcon(icon, renderingMode)
         } else {
             layout = .textOnly
         }
@@ -141,17 +150,19 @@ public struct OUDSLink: View {
     ///   - tableName: The name of the `.strings` file, or `nil` for the default
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - icon: Icon displayed in the link
+    ///   - renderingMode: The rendering mode to apply on the icon. Use `.template` (default) to tint the icon, or `.original` to display the image as-is.
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 icon: Image? = nil,
+                renderingMode: Image.TemplateRenderingMode = .template,
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
         if let icon {
-            layout = .textAndIcon(icon)
+            layout = .textAndIcon(icon, renderingMode)
         } else {
             layout = .textOnly
         }
@@ -229,12 +240,12 @@ public struct OUDSLink: View {
                 } icon: {
                     EmptyView()
                 }
-            case let .textAndIcon(icon):
+            case let .textAndIcon(icon, renderingMode):
                 Label {
                     Text(LocalizedStringKey(text))
                 } icon: {
                     icon
-                        .renderingMode(.template)
+                        .renderingMode(renderingMode)
                         .resizable()
                 }
             }

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -119,7 +119,7 @@ public struct OUDSLink: View {
     ///   - renderingMode: The rendering mode to apply on the icon
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
-    @available(*, deprecated, message: "Use OUDSLink(text:icon:OUDSImage:size:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSLink(text:image:size:action:) instead.")
     public init(text: String,
                 icon: Image? = nil,
                 renderingMode: Image.TemplateRenderingMode = .template,
@@ -127,7 +127,7 @@ public struct OUDSLink: View {
                 action: @escaping () -> Void)
     {
         self.init(text: text,
-                  icon: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
+                  image: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
                   size: size,
                   action: action)
     }
@@ -135,26 +135,26 @@ public struct OUDSLink: View {
     /// Create a link with text and an optional icon.
     ///
     /// ```swift
-    ///     OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image(systemName: "arrow.right")), size: .default) {}
+    ///     OUDSLink(text: "Learn more", image: OUDSImage(asset: Image(systemName: "arrow.right")), size: .default) {}
     ///
     ///     // Raw (non-tinted) image:
-    ///     OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+    ///     OUDSLink(text: "Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
     ///
-    ///     // Text only — omit icon or pass nil:
+    ///     // Text only — omit image or pass nil:
     ///     OUDSLink(text: "Feedback", size: .small) {}
     /// ```
     ///
     /// - Parameters:
     ///   - text: Text displayed in the link
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
     public init(text: String,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
-        layout = icon.map { .textAndIcon($0) } ?? .textOnly
+        layout = image.map { .textAndIcon($0) } ?? .textOnly
         self.text = text
         self.size = size
         self.action = action
@@ -172,7 +172,7 @@ public struct OUDSLink: View {
     ///   - renderingMode: The rendering mode to apply on the icon
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
-    @available(*, deprecated, message: "Use OUDSLink(_:tableName:bundle:icon:OUDSImage:size:action:) instead.")
+    @available(*, deprecated, message: "Use OUDSLink(_:tableName:bundle:image:size:action:) instead.")
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
@@ -182,7 +182,7 @@ public struct OUDSLink: View {
                 action: @escaping () -> Void)
     {
         self.init(text: key.resolved(tableName: tableName, bundle: bundle),
-                  icon: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
+                  image: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
                   size: size,
                   action: action)
     }
@@ -194,7 +194,7 @@ public struct OUDSLink: View {
     ///
     ///     OUDSLink(LocalizedStringKey("learn_more"),
     ///              bundle: Bundle.module,
-    ///              icon: OUDSImage(asset: Image("ic_heart")),
+    ///              image: OUDSImage(asset: Image("ic_heart")),
     ///              size: .default) {}
     /// ```
     ///
@@ -202,18 +202,18 @@ public struct OUDSLink: View {
     ///   - key: A `LocalizedStringKey` used to look up the text in the given bundle
     ///   - tableName: The name of the `.strings` file, or `nil` for the default
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
-    ///   - icon: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
+    ///   - image: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
     ///   - size: Size of the link
     ///   - action: The action to perform when the user triggers the link
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
-                icon: OUDSImage? = nil,
+                image: OUDSImage? = nil,
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
         self.init(text: key.resolved(tableName: tableName, bundle: bundle),
-                  icon: icon,
+                  image: image,
                   size: size,
                   action: action)
     }

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -181,7 +181,7 @@ public struct OUDSLink: View {
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
-        self.init(key.resolved(tableName: tableName, bundle: bundle),
+        self.init(text: key.resolved(tableName: tableName, bundle: bundle),
                   icon: icon.map { OUDSImage(asset: $0, renderingMode: renderingMode) },
                   size: size,
                   action: action)

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -32,10 +32,10 @@ import SwiftUI
 ///     OUDSLink(LocalizedStringKey("feedback_link"), bundle: Bundle.module, size: .small) { }
 ///
 ///     // Text and icon in default size
-///     OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_heart")), size: .default) { }
+///     OUDSLink(text: "Feedback", image: OUDSImage(asset: Image("ic_heart")), size: .default) { }
 ///
 ///     // Text and icon with raw image (not tinted)
-///     OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) { }
+///     OUDSLink(text: "Feedback", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) { }
 /// ```
 ///
 /// ## Navigation layout

--- a/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
@@ -45,7 +45,7 @@ struct ControlItemIconContainer: View {
     private var icon: some View {
         if layoutData.isError {
             Image(decorative: "ic_alert_important_fill", bundle: theme.resourcesBundle)
-                .renderingMode(.template)
+                .renderingMode(layoutData.renderingMode)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .accessibilityHidden(true)
@@ -56,7 +56,7 @@ struct ControlItemIconContainer: View {
             if let icon = layoutData.icon {
                 icon
                     .resizable()
-                    .renderingMode(.template)
+                    .renderingMode(layoutData.renderingMode)
                     .accessibilityHidden(true)
                     .foregroundStyle(color)
                     .frame(width: theme.controlItem.sizeAssetSmall, height: theme.controlItem.sizeAssetSmall)

--- a/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
@@ -45,7 +45,7 @@ struct ControlItemIconContainer: View {
     private var icon: some View {
         if layoutData.isError {
             Image(decorative: "ic_alert_important_fill", bundle: theme.resourcesBundle)
-                .renderingMode(layoutData.renderingMode)
+                .renderingMode(.template)
                 .resizable()
                 .aspectRatio(contentMode: .fill)
                 .accessibilityHidden(true)

--- a/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemIconContainer.swift
@@ -53,14 +53,14 @@ struct ControlItemIconContainer: View {
                 .frame(width: theme.controlItem.sizeErrorIcon, height: theme.controlItem.sizeErrorIcon)
                 .padding(.horizontal, theme.controlItem.spacePaddingInlineErrorIcon)
         } else {
-            if let icon = layoutData.icon {
-                icon
+            if let asset = layoutData.icon?.asset {
+                asset
                     .resizable()
-                    .renderingMode(layoutData.renderingMode)
+                    .renderingMode(layoutData.icon?.renderingMode ?? .template)
                     .accessibilityHidden(true)
                     .foregroundStyle(color)
                     .frame(width: theme.controlItem.sizeAssetSmall, height: theme.controlItem.sizeAssetSmall)
-                    .toFlip(layoutData.flipIcon)
+                    .toFlip(layoutData.icon?.flipped ?? false)
             }
         }
     }

--- a/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemLabel.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemLabel.swift
@@ -36,6 +36,7 @@ struct ControlItemLabel: View {
         let description: String?
         let icon: Image?
         let flipIcon: Bool
+        let renderingMode: Image.TemplateRenderingMode
         let isOutlined: Bool
         let isError: Bool
         let errorText: TextualContent?

--- a/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemLabel.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ControlItem/ControlItemLabel.swift
@@ -34,9 +34,7 @@ struct ControlItemLabel: View {
         let label: String
         let extraLabel: String?
         let description: String?
-        let icon: Image?
-        let flipIcon: Bool
-        let renderingMode: Image.TemplateRenderingMode
+        let icon: OUDSImage?
         let isOutlined: Bool
         let isError: Bool
         let errorText: TextualContent?

--- a/OUDS/Core/Components/Sources/_/Internal/Icons.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/Icons.swift
@@ -17,20 +17,12 @@ import SwiftUI
 
 struct FixedIcon: View {
 
-    let icon: Image
-    let flipped: Bool
+    let image: OUDSImage
     let size: CGFloat
 
-    init(icon: Image, size: CGFloat, flipped: Bool = false) {
-        self.icon = icon
-        self.size = size
-        self.flipped = flipped
-    }
-
     var body: some View {
-        icon.resizable()
+        image
             .frame(width: size, height: size, alignment: .center)
-            .toFlip(flipped)
     }
 }
 
@@ -38,19 +30,16 @@ struct FixedIcon: View {
 
 struct ScaledIcon: View {
 
-    let icon: Image
-    let flipped: Bool
+    let image: OUDSImage
     @ScaledMetric var size: CGFloat
 
-    init(icon: Image, size: CGFloat, flipped: Bool = false) {
-        self.icon = icon
-        self.flipped = flipped
+    init(image: OUDSImage, size: CGFloat) {
+        self.image = image
         _size = ScaledMetric(wrappedValue: size)
     }
 
     var body: some View {
-        icon.resizable()
+        image
             .frame(width: size, height: size, alignment: .center)
-            .toFlip(flipped)
     }
 }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Actions.md
@@ -34,7 +34,7 @@ A button with `OUDSButton.Appearance.Negative` appearance is not allowed as a di
 
 ```swift
     // Icon only with default appearance
-    OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) { /* the action to process */ }
+    OUDSButton(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Like", appearance: .default) { /* the action to process */ }
 
     // Text only with negative appearance
     OUDSButton(text: "Delete", appearance: .negative) {}

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -647,17 +647,22 @@ OUDSTextInput(label: "Email", text: $text)
 OUDSTextInput(label: "Email", text: $text, prefix: "Distance", suffix: "km")
 
 // Add a leading icon for more context
-OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com", leadingIcon: Image(systemName: "envelope"))
+OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com",
+              leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
 
 // Add a leading raw image (not tinted)
-OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+OUDSTextInput(label: "Brand", text: $text,
+              leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
 
-// Add a trailing button with local image named "ic_cross" for additional action
-let trailingAction = OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
+// Add a trailing button for additional action
+let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")),
+                                                   actionHint: "Delete") { text = "" }
 OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
 
 // Add a trailing button with raw image (not tinted)
-let trailingActionRaw = OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", renderingMode: .original) { /* action */ }
+let trailingActionRaw = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"),
+                                                                      renderingMode: .original),
+                                                      actionHint: "Brand") { /* action */ }
 OUDSTextInput(label: "Brand", text: $text, trailingAction: trailingActionRaw)
 
 // With helper text

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -79,7 +79,7 @@ OUDSCheckboxItemIndeterminate("Dead Robot Zombie Cop",
 OUDSCheckboxItem("We live in a fabled world",
                  isOn: $isOn,
                  description: "Of dreaming boys and wide-eyed girls",
-                 icon: Image(decorative: "ic_heart"),
+                 icon: OUDSImage(asset: Image(decorative: "ic_heart")),
                  isReversed: true,
                  isError: true,
                  hasDivider: true)
@@ -113,16 +113,16 @@ var someDataToPopulate: [OUDSCheckboxPickerData<String>] {
          OUDSCheckboxPickerData<String>(tag: "Choice_1",
                                         label: "Virgin Holy Lava",
                                         description: "No alcohol, only tasty flavors",
-                                        icon: Image(systemName: "flame")),
+                                        icon: OUDSImage(asset: Image(systemName: "flame"))),
 
          OUDSCheckboxPickerData<String>(tag: "Choice_2",
                                         label: "IPA beer",
                                         description: "From Brewdog company",
-                                        icon: Image(systemName: "dog.fill")),
+                                        icon: OUDSImage(asset: Image(systemName: "dog.fill"))),
 
          OUDSCheckboxPickerData<String>(tag: "Choice_3",
                                         label: "Mineral water",
-                                        icon: Image(systemName: "waterbottle.fill")),
+                                        icon: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
     ]
 }
 
@@ -200,16 +200,23 @@ The indicator can be leading or trailing.
 // A leading radio with a label
 OUDSRadioItem("Lucy in the Sky with Diamonds", isOn: $isOn)
 
-// A trailing radio with a label, an additional label, a descrption, an icon, a divider and is about an
-// error with a reversed layout
+// A trailing radio with a label, an additional label, a description, a tinted icon,
+// a divider and is about an error with a reversed layout
 OUDSRadioItem("Lucy in the Sky with Diamonds",
               isOn: $isOn,
-              extraLabel: "The Beatles"
+              extraLabel: "The Beatles",
               description: "1967",
-              icon: Image(decorative: "ic_heart"),
+              icon: OUDSImage(asset: Image(decorative: "ic_heart")),
               isReversed: true,
               isError: true,
               hasDivider: true)
+
+// A radio with a raw (non-tinted) image and RTL flip support
+OUDSRadioItem("Lucy in the Sky with Diamonds",
+              isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "il_someImage"),
+                              flipped: layoutDirection == .rightToLeft,
+                              renderingMode: .original))
 ```
 
 #### Radio picker
@@ -241,16 +248,16 @@ var someDataToPopulate: [OUDSRadioPickerData<String>] {
                                         label: "Virgin Holy Lava",
                                         extraLabel: "Very spicy",
                                         description: "No alcohol, only tasty flavors",
-                                        icon: Image(systemName: "flame")),
+                                        icon: OUDSImage(asset: Image(systemName: "flame"))),
 
             OUDSRadioPickerData<String>(tag: "Choice_2",
                                         label: "IPA beer",
                                         description: "From Brewdog company",
-                                        icon: Image(systemName: "dog.fill")),
+                                        icon: OUDSImage(asset: Image(systemName: "dog.fill"))),
 
             OUDSRadioPickerData<String>(tag: "Choice_3",
                                         label: "Mineral water",
-                                        icon: Image(systemName: "waterbottle.fill")),
+                                        icon: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
     ]
 }
 
@@ -322,15 +329,22 @@ OUDSSwitchItem("Dead Robot Zombie Cop",
                isOn: $isOn,
                description: "from Outer Space II")
 
-// A trailing switch with a label, a description, an icon, a divider and is about an error
+// A trailing switch with a label, a description, a tinted icon, a divider and is about an error
 // with an inverse layout
 OUDSSwitchItem("We live in a fabled world",
                 isOn: $isOn,
                 description: "Of dreaming boys and wide-eyed girls",
-                icon: Image(decorative: "ic_heart"),
+                icon: OUDSImage(asset: Image(decorative: "ic_heart")),
                 isReversed: true,
                 isError: true,
                 hasDivider: true)
+
+// A trailing switch with a raw (non-tinted) image and RTL flip support
+OUDSSwitchItem("We live in a fabled world",
+                isOn: $isOn,
+                icon: OUDSImage(asset: Image(decorative: "il_someImage"),
+                                flipped: layoutDirection == .rightToLeft,
+                                renderingMode: .original))
 ```
 
 ### Chips

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -358,11 +358,17 @@ The library proposes suggestion (``OUDSSuggestionChip``) chip component to make 
 // Suggestion chip with icon only
 OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { /* the action to process */ }
 
+// Suggestion chip with raw icon (not tinted)
+OUDSSuggestionChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) { /* the action to process */ }
+
 // Layout with text only
 OUDSSuggestionChip(text: "Heart") { /* the action to process */ }
 
 // Layout with text and icon
 OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") { /* the action to process */ }
+
+// Layout with text and raw icon (not tinted)
+OUDSSuggestionChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) { /* the action to process */ }
 ```
 
 #### Filter
@@ -388,11 +394,17 @@ The library proposes filter chip component (``OUDSFilterChip``) to make some fil
 // Filter chip with icon only as selected
 OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) { /* the action to process */ }
 
+// Filter chip with raw icon (not tinted)
+OUDSFilterChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) { /* the action to process */ }
+
 // Filter chip with text only as not selected
 OUDSFilterChip(text: "Heart") { /* the action to process */ }
 
 // Filter chip with text and icon layout an in selected state
 OUDSFilterChip(icon: Image("ic_heart"), text: "Heart", selected: true) { /* the action to process */ }
+
+// Filter chip with text and raw icon (not tinted)
+OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) { /* the action to process */ }
 ```
 
 
@@ -620,9 +632,16 @@ OUDSTextInput(label: "Email", text: $text, prefix: "Distance", suffix: "km")
 // Add a leading icon for more context
 OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com", leadingIcon: Image(systemName: "envelope"))
 
+// Add a leading raw image (not tinted)
+OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+
 // Add a trailing button with local image named "ic_cross" for additional action
 let trailingAction = OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
 OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
+
+// Add a trailing button with raw image (not tinted)
+let trailingActionRaw = OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", renderingMode: .original) { /* action */ }
+OUDSTextInput(label: "Brand", text: $text, trailingAction: trailingActionRaw)
 
 // With helper text
 OUDSTextInput(label: "Email",

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -655,12 +655,12 @@ OUDSTextInput(label: "Brand", text: $text,
               leadingImage: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
 
 // Add a trailing button for additional action
-let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")),
+let trailingAction = OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_cross")),
                                                    actionHint: "Delete") { text = "" }
 OUDSTextInput(label: "Email", text: $text, trailingAction: trailingAction)
 
 // Add a trailing button with raw image (not tinted)
-let trailingActionRaw = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"),
+let trailingActionRaw = OUDSTextInput.TrailingAction(image: OUDSImage(asset: Image("ic_brand"),
                                                                       renderingMode: .original),
                                                       actionHint: "Brand") { /* action */ }
 OUDSTextInput(label: "Brand", text: $text, trailingAction: trailingActionRaw)

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -79,7 +79,7 @@ OUDSCheckboxItemIndeterminate("Dead Robot Zombie Cop",
 OUDSCheckboxItem("We live in a fabled world",
                  isOn: $isOn,
                  description: "Of dreaming boys and wide-eyed girls",
-                 icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+                 image: OUDSImage(asset: Image(decorative: "ic_heart")),
                  isReversed: true,
                  isError: true,
                  hasDivider: true)
@@ -113,16 +113,16 @@ var someDataToPopulate: [OUDSCheckboxPickerData<String>] {
          OUDSCheckboxPickerData<String>(tag: "Choice_1",
                                         label: "Virgin Holy Lava",
                                         description: "No alcohol, only tasty flavors",
-                                        icon: OUDSImage(asset: Image(systemName: "flame"))),
+                                        image: OUDSImage(asset: Image(systemName: "flame"))),
 
          OUDSCheckboxPickerData<String>(tag: "Choice_2",
                                         label: "IPA beer",
                                         description: "From Brewdog company",
-                                        icon: OUDSImage(asset: Image(systemName: "dog.fill"))),
+                                        image: OUDSImage(asset: Image(systemName: "dog.fill"))),
 
          OUDSCheckboxPickerData<String>(tag: "Choice_3",
                                         label: "Mineral water",
-                                        icon: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
+                                        image: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
     ]
 }
 
@@ -206,7 +206,7 @@ OUDSRadioItem("Lucy in the Sky with Diamonds",
               isOn: $isOn,
               extraLabel: "The Beatles",
               description: "1967",
-              icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+              image: OUDSImage(asset: Image(decorative: "ic_heart")),
               isReversed: true,
               isError: true,
               hasDivider: true)
@@ -214,9 +214,9 @@ OUDSRadioItem("Lucy in the Sky with Diamonds",
 // A radio with a raw (non-tinted) image and RTL flip support
 OUDSRadioItem("Lucy in the Sky with Diamonds",
               isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "il_someImage"),
-                              flipped: layoutDirection == .rightToLeft,
-                              renderingMode: .original))
+              image: OUDSImage(asset: Image(decorative: "il_someImage"),
+                               flipped: layoutDirection == .rightToLeft,
+                               renderingMode: .original))
 ```
 
 #### Radio picker
@@ -248,16 +248,16 @@ var someDataToPopulate: [OUDSRadioPickerData<String>] {
                                         label: "Virgin Holy Lava",
                                         extraLabel: "Very spicy",
                                         description: "No alcohol, only tasty flavors",
-                                        icon: OUDSImage(asset: Image(systemName: "flame"))),
+                                        image: OUDSImage(asset: Image(systemName: "flame"))),
 
             OUDSRadioPickerData<String>(tag: "Choice_2",
                                         label: "IPA beer",
                                         description: "From Brewdog company",
-                                        icon: OUDSImage(asset: Image(systemName: "dog.fill"))),
+                                        image: OUDSImage(asset: Image(systemName: "dog.fill"))),
 
             OUDSRadioPickerData<String>(tag: "Choice_3",
                                         label: "Mineral water",
-                                        icon: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
+                                        image: OUDSImage(asset: Image(systemName: "waterbottle.fill"))),
     ]
 }
 
@@ -334,7 +334,7 @@ OUDSSwitchItem("Dead Robot Zombie Cop",
 OUDSSwitchItem("We live in a fabled world",
                 isOn: $isOn,
                 description: "Of dreaming boys and wide-eyed girls",
-                icon: OUDSImage(asset: Image(decorative: "ic_heart")),
+                image: OUDSImage(asset: Image(decorative: "ic_heart")),
                 isReversed: true,
                 isError: true,
                 hasDivider: true)
@@ -342,9 +342,9 @@ OUDSSwitchItem("We live in a fabled world",
 // A trailing switch with a raw (non-tinted) image and RTL flip support
 OUDSSwitchItem("We live in a fabled world",
                 isOn: $isOn,
-                icon: OUDSImage(asset: Image(decorative: "il_someImage"),
-                                flipped: layoutDirection == .rightToLeft,
-                                renderingMode: .original))
+                image: OUDSImage(asset: Image(decorative: "il_someImage"),
+                                 flipped: layoutDirection == .rightToLeft,
+                                 renderingMode: .original))
 ```
 
 ### Chips
@@ -370,19 +370,19 @@ The library proposes suggestion (``OUDSSuggestionChip``) chip component to make 
 
 ```swift
 // Suggestion chip with icon only
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
 
 // Suggestion chip with raw icon (not tinted)
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
 
 // Layout with text only
 OUDSSuggestionChip(text: "Heart") {}
 
 // Layout with text and icon
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
 
 // Layout with text and raw icon (not tinted)
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 ```
 
 #### Filter
@@ -406,19 +406,19 @@ The library proposes filter chip component (``OUDSFilterChip``) to make some fil
 
 ```swift
 // Filter chip with icon only as selected
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
 
 // Filter chip with raw icon (not tinted)
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
 
 // Filter chip with text only as not selected
 OUDSFilterChip(text: "Heart") {}
 
 // Filter chip with text and icon in selected state
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
 
 // Filter chip with text and raw icon (not tinted)
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 ```
 
 
@@ -648,11 +648,11 @@ OUDSTextInput(label: "Email", text: $text, prefix: "Distance", suffix: "km")
 
 // Add a leading icon for more context
 OUDSTextInput(label: "Email", text: $text, placeholder: "firstName.lastName", suffix: "@orange.com",
-              leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+              leadingImage: OUDSImage(asset: Image(systemName: "envelope")))
 
 // Add a leading raw image (not tinted)
 OUDSTextInput(label: "Brand", text: $text,
-              leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+              leadingImage: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
 
 // Add a trailing button for additional action
 let trailingAction = OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")),

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Controls.md
@@ -370,19 +370,19 @@ The library proposes suggestion (``OUDSSuggestionChip``) chip component to make 
 
 ```swift
 // Suggestion chip with icon only
-OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") { /* the action to process */ }
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
 
 // Suggestion chip with raw icon (not tinted)
-OUDSSuggestionChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) { /* the action to process */ }
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
 
 // Layout with text only
-OUDSSuggestionChip(text: "Heart") { /* the action to process */ }
+OUDSSuggestionChip(text: "Heart") {}
 
 // Layout with text and icon
-OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") { /* the action to process */ }
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
 
 // Layout with text and raw icon (not tinted)
-OUDSSuggestionChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) { /* the action to process */ }
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 ```
 
 #### Filter
@@ -406,19 +406,19 @@ The library proposes filter chip component (``OUDSFilterChip``) to make some fil
 
 ```swift
 // Filter chip with icon only as selected
-OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) { /* the action to process */ }
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
 
 // Filter chip with raw icon (not tinted)
-OUDSFilterChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) { /* the action to process */ }
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
 
 // Filter chip with text only as not selected
-OUDSFilterChip(text: "Heart") { /* the action to process */ }
+OUDSFilterChip(text: "Heart") {}
 
-// Filter chip with text and icon layout an in selected state
-OUDSFilterChip(icon: Image("ic_heart"), text: "Heart", selected: true) { /* the action to process */ }
+// Filter chip with text and icon in selected state
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
 
 // Filter chip with text and raw icon (not tinted)
-OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) { /* the action to process */ }
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
 ```
 
 
@@ -453,13 +453,16 @@ enum Drink: String, CaseIterable {
 var someDataToPopulate: [OUDSChipPickerData<Drink>] {
     [
         OUDSChipPickerData(tag: Drink.virginHolyLava,
-                          layout: .textAndIcon("Virgin Holy Lava", icon: Image(systemName: "flame"))),
+                          layout: .textAndIcon("Virgin Holy Lava",
+                                               image: OUDSImage(asset: Image(systemName: "flame")))),
 
-        OUDSChipPickerData(tag: Dring.ipaBeer,
-                           layout: .textAndIcon("IPA Beer", icon: Image(systemName: "dog.fill"))),
+        OUDSChipPickerData(tag: Drink.ipaBeer,
+                           layout: .textAndIcon("IPA Beer",
+                                                image: OUDSImage(asset: Image(systemName: "dog.fill")))),
 
         OUDSChipPickerData(tag: Drink.mineralWater,
-                           layout: .textAndIcon("Mineral water", icon: Image(systemName: "waterbottle.fill")),
+                           layout: .textAndIcon("Mineral water",
+                                                image: OUDSImage(asset: Image(systemName: "waterbottle.fill")))),
     ]
 }
 

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Dialogs.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Dialogs.md
@@ -43,8 +43,10 @@ Dialogs components are UI elements that display information, system feedback or 
     }
         
     // Add a custom icon for accent and neutral status
+    // with original rendering mode (to avoid tints) or not.
+    // By default, tinted, template mode.
     OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-    OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"))))
+    OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)))
 ```
 
 ### Inline Alert

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Dialogs.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Dialogs.md
@@ -45,8 +45,8 @@ Dialogs components are UI elements that display information, system feedback or 
     // Add a custom icon for accent and neutral status
     // with original rendering mode (to avoid tints) or not.
     // By default, tinted, template mode.
-    OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-    OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)))
+    OUDSAlertMessage(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_heart"))))
+    OUDSAlertMessage(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original)))
 ```
 
 ### Inline Alert
@@ -79,6 +79,6 @@ Inline alert does not disappear and remains visible.
     OUDSInlineAlert(label: "Warning", status: .warning)
 
     // Add a custom icon for accent and neutral status
-    OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
-    OUDSInlineAlert(label: "Label", status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"))))
+    OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_heart"))))
+    OUDSInlineAlert(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_heart"))))
 ```

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
@@ -114,16 +114,15 @@ OUDSTag(label: "Label")
 OUDSTag(label: "Label", status: .negative(leading: .bullet)
             
 // Tag with neutral status with a custom decorative icon
-OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
-// If your layout is in RTL mode but your tag has an icon with another meaning because of bad orientation,
-// you can flip the icon
-OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+// Flip the icon for RTL layouts using OUDSImage.flipped
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
 
 // Tag with neutral status with a raw image (not tinted)
-OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
 
 // Tag with accent status with a raw image (not tinted)
-OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: .original))
+OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
             
 // Text with neutral status with bullet
 OUDSTag(label: "Label", status: .neutral(bullet: true))

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
@@ -114,15 +114,15 @@ OUDSTag(label: "Label")
 OUDSTag(label: "Label", status: .negative(leading: .bullet)
             
 // Tag with neutral status with a custom decorative icon
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"))))
 // Flip the icon for RTL layouts using OUDSImage.flipped
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
 
 // Tag with neutral status with a raw image (not tinted)
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
 
 // Tag with accent status with a raw image (not tinted)
-OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
             
 // Text with neutral status with bullet
 OUDSTag(label: "Label", status: .neutral(bullet: true))

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Indicators.md
@@ -118,6 +118,12 @@ OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
 // If your layout is in RTL mode but your tag has an icon with another meaning because of bad orientation,
 // you can flip the icon
 OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+
+// Tag with neutral status with a raw image (not tinted)
+OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
+
+// Tag with accent status with a raw image (not tinted)
+OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: .original))
             
 // Text with neutral status with bullet
 OUDSTag(label: "Label", status: .neutral(bullet: true))

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -37,6 +37,9 @@ OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
 // Text and icon in default size
 OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .default) { /* the action to process */ }
 
+// Text and raw icon (not tinted)
+OUDSLink(text: "Brand", icon: Image("ic_brand"), renderingMode: .original, size: .default) { /* the action to process */ }
+
 // Navigate to previous page with link in a default size
 OUDSLink(text: "Back", indicator: .back, size: .default) { /* the action to process */ }
 ```

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -35,10 +35,10 @@ The link can be displayed in `small` or `default` size.
 OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
 
 // Text and icon in default size
-OUDSLink(text: "Feedback", icon: Image("ic_heart"), size: .default) { /* the action to process */ }
+OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
 
 // Text and raw icon (not tinted)
-OUDSLink(text: "Brand", icon: Image("ic_brand"), renderingMode: .original, size: .default) { /* the action to process */ }
+OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
 
 // Navigate to previous page with link in a default size
 OUDSLink(text: "Back", indicator: .back, size: .default) { /* the action to process */ }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -35,10 +35,10 @@ The link can be displayed in `small` or `default` size.
 OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
 
 // Text and icon in default size
-OUDSLink(text: "Feedback", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+OUDSLink(text: "Feedback", image: OUDSImage(asset: Image("ic_heart")), size: .default) {}
 
 // Text and raw icon (not tinted)
-OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+OUDSLink(text: "Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
 
 // Navigate to previous page with link in a default size
 OUDSLink(text: "Back", indicator: .back, size: .default) { /* the action to process */ }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -183,8 +183,8 @@ The `flipped` property of ``OUDSImage`` can be used when passing an icon to a co
 // For example in a checkbox item — wrap the asset in OUDSImage and set flipped:
 OUDSCheckboxItem("Label",
                  isOn: $isOn,
-                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-                                 flipped: layoutDirection == .rightToLeft),
+                 image: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                  flipped: layoutDirection == .rightToLeft),
                  isReversed: layoutDirection == .rightToLeft)
 ```
 

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/_OUDSComponents.md
@@ -170,7 +170,8 @@ Images bring meanings, and are used in components. But sometimes, depending to y
 of your app changes, the images in use can loose meanings or have another one (except if they are asymetric).
 Even if some assets can be defined in a project with specific RTL/LTR variants, images can be loaded outside and in some case, in the end, must not be mirrored.
 
-If your application manages several languages with RTL and LTR, here is a simple trick to flip the icons depending to the layout for the cases you want. The `flipIcon` flag available in components can be used.
+If your application manages several languages with RTL and LTR, here is a simple trick to flip the icons depending to the layout for the cases you want.
+The `flipped` property of ``OUDSImage`` can be used when passing an icon to a component.
 
 ```swift
 // Get the layout direction in your View
@@ -179,10 +180,12 @@ If your application manages several languages with RTL and LTR, here is a simple
 // Because by default icons are not flipped, i.e. more LTR flavoured, use a simple comparison
 // (layoutDirection == .rightToLeft)
 
-// For example in a checkbox item
-OUDSCheckboxItem(...,
-                 flipIcon: (layoutDirection == .rightToLeft),
-                 )
+// For example in a checkbox item — wrap the asset in OUDSImage and set flipped:
+OUDSCheckboxItem("Label",
+                 isOn: $isOn,
+                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                 flipped: layoutDirection == .rightToLeft),
+                 isReversed: layoutDirection == .rightToLeft)
 ```
 
 ## Change font family according to locale or preferred language

--- a/OUDS/Core/Components/Tests/Dialog/Alert/OUDSInlineAlertTests.swift
+++ b/OUDS/Core/Components/Tests/Dialog/Alert/OUDSInlineAlertTests.swift
@@ -22,7 +22,7 @@ struct OUDSInlineAlertTests {
 
     @Test("Inline alert default status must be neutral with an icon")
     func defaultStatusIsNeutralWithIcon() {
-        let neutralWithIcon = OUDSAlertStatus.neutral(icon: OUDSIcon(assetName: "ic_heart"))
+        let neutralWithIcon = OUDSAlertStatus.neutral(icon: OUDSImage(assetName: "ic_heart"))
         #expect(neutralWithIcon.hasIcon, "Neutral status with a non-nil icon must report hasIcon as true")
     }
 
@@ -58,7 +58,7 @@ struct OUDSInlineAlertTests {
 
     @MainActor @Test("Neutral status with icon must render a leading icon")
     func neutralStatusWithIconHasIcon() {
-        let status = OUDSAlertStatus.neutral(icon: OUDSIcon(assetName: "ic_heart"))
+        let status = OUDSAlertStatus.neutral(icon: OUDSImage(assetName: "ic_heart"))
         #expect(status.hasIcon, "Neutral status with non-nil icon must report hasIcon as true, allowing icon rendering")
     }
 
@@ -70,7 +70,7 @@ struct OUDSInlineAlertTests {
 
     @MainActor @Test("Accent status with icon must render a leading icon")
     func accentStatusWithIconHasIcon() {
-        let status = OUDSAlertStatus.accent(icon: OUDSIcon(assetName: "ic_heart"))
+        let status = OUDSAlertStatus.accent(icon: OUDSImage(assetName: "ic_heart"))
         #expect(status.hasIcon, "Accent status with non-nil icon must report hasIcon as true, allowing icon rendering")
     }
 }

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -7,7 +7,8 @@
       "skills": [
         "ouds-ios-vocabulary",
         "ouds-ios-framework-usage",
-        "ouds-ios-figma-to-swift"
+        "ouds-ios-figma-to-swift",
+        "ouds-ios-migration"
       ]
     }
   ]

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -121,17 +121,17 @@ OUDSButton(
 
 OUDSLink(
     text: "Back",
-    icon: Image(systemName: "chevron.left").accessibilityHidden(true), // ❌ same error
+    icon: OUDSImage(asset: Image(systemName: "chevron.left").accessibilityHidden(true)), // ❌ compile error: Image modifier → some View
     size: .default) {}
 ```
 
-**Always do this — swiftlint comment on the line before the component call:**
+**Always do this — pass a bare `Image` inside `OUDSImage`, swiftlint comment on the line before:**
 ```swift
 // swiftlint:disable:next accessibility_label_for_image
 OUDSButton(text: "Add", icon: Image(systemName: "plus"), appearance: .default) {}
 
 // swiftlint:disable:next accessibility_label_for_image
-OUDSLink(text: "Back", icon: Image(systemName: "chevron.left"), size: .default) {}
+OUDSLink(text: "Back", icon: OUDSImage(asset: Image(systemName: "chevron.left")), size: .default) {}
 
 // swiftlint:disable:next accessibility_label_for_image
 OUDSToolBarItem(icon: Image("ic_share"), accessibilityLabel: "Share") {}
@@ -471,8 +471,8 @@ OUDSVerticalDivider(color: .brandPrimary)
 ```swift
 OUDSLink(text: "Text", size: .default) {}
 OUDSLink(text: "Text", indicator: .back, size: .default) {}
-OUDSLink(text: "Text", icon: Image("ic"), size: .default) {}
-OUDSLink(text: "Text", icon: Image("ic"), renderingMode: .original, size: .default) {} // raw image (not tinted)
+OUDSLink(text: "Text", icon: OUDSImage(asset: Image("ic")), size: .default) {}
+OUDSLink(text: "Text", icon: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
 ```
 
 ---

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -324,20 +324,20 @@ OUDSPasswordInput(label: "Password", password: $password, isHiddenPassword: $isH
 
 ```swift
 OUDSSuggestionChip(text: "Label") {}
-OUDSSuggestionChip(icon: Image("ic"), text: "Label") {}
-OUDSSuggestionChip(icon: Image("ic"), text: "Label", renderingMode: .original) {} // raw image (not tinted)
-OUDSSuggestionChip(icon: Image("ic"), accessibilityLabel: "Label") {}
-OUDSSuggestionChip(icon: Image("ic"), accessibilityLabel: "Label", renderingMode: .original) {} // raw image (not tinted)
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic")), text: "Label") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
 OUDSFilterChip(text: "Label") {}
-OUDSFilterChip(icon: Image("ic"), text: "Label") {}
-OUDSFilterChip(icon: Image("ic"), text: "Label", renderingMode: .original) {} // raw image (not tinted)
-OUDSFilterChip(icon: Image("ic"), accessibilityLabel: "Label") {}
-OUDSFilterChip(icon: Image("ic"), accessibilityLabel: "Label", renderingMode: .original) {} // raw image (not tinted)
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic")), text: "Label") {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
 OUDSChipPicker(title: "Title", selection: $selection, chips: [
-    .init(tag: .value1, layout: .textAndIcon("Label", icon: Image("ic"))),
-    .init(tag: .value2, layout: .textAndIcon("Brand", icon: Image("ic_brand"), renderingMode: .original)), // raw image
-    .init(tag: .value3, layout: .icon(icon: Image("ic"), accessibilityLabel: "Label")),
-    .init(tag: .value4, layout: .icon(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original)), // raw image
+    .init(tag: .value1, layout: .textAndIcon("Label", image: OUDSImage(asset: Image("ic")))),
+    .init(tag: .value2, layout: .textAndIcon("Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))), // raw image
+    .init(tag: .value3, layout: .icon(OUDSImage(asset: Image("ic")), accessibilityLabel: "Label")),
+    .init(tag: .value4, layout: .icon(OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand")), // raw image
 ])
 ```
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -429,10 +429,11 @@ OUDSBadgeIcon(status: .neutral(icon: Image("ic")), accessibilityLabel: "Label", 
 
 ```swift
 OUDSTag(label: "Label")
-OUDSTag(label: "Label", status: .neutral(icon: Image("ic")))
-OUDSTag(label: "Label", status: .neutral(icon: Image("ic"), renderingMode: .original)) // raw image (not tinted)
-OUDSTag(label: "Label", status: .accent(icon: Image("ic")))
-OUDSTag(label: "Label", status: .accent(icon: Image("ic"), renderingMode: .original)) // raw image (not tinted)
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"))))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"), flipped: true))) // flipped for RTL
+OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic"))))
+OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
 OUDSTag(label: "Label", status: .neutral(bullet: true))
 ```
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -116,22 +116,19 @@ OUDS components accept `Image` — the bare SwiftUI type. Calling any modifier o
 ```swift
 OUDSButton(
     text: "Add",
-    icon: Image(systemName: "plus").accessibilityHidden(true), // ❌ compile error: Image → some View
+    image: Image(systemName: "plus").accessibilityHidden(true), // ❌ compile error: Image → some View
     appearance: .default) {}
 
 OUDSLink(
     text: "Back",
-    icon: OUDSImage(asset: Image(systemName: "chevron.left").accessibilityHidden(true)), // ❌ compile error: Image modifier → some View
+    image: OUDSImage(asset: Image(systemName: "chevron.left").accessibilityHidden(true)), // ❌ compile error: Image modifier → some View
     size: .default) {}
 ```
 
 **Always do this — pass a bare `Image` inside `OUDSImage`, swiftlint comment on the line before:**
 ```swift
 // swiftlint:disable:next accessibility_label_for_image
-OUDSButton(text: "Add", icon: Image(systemName: "plus"), appearance: .default) {}
-
-// swiftlint:disable:next accessibility_label_for_image
-OUDSLink(text: "Back", icon: OUDSImage(asset: Image(systemName: "chevron.left")), size: .default) {}
+OUDSLink(text: "Back", image: OUDSImage(asset: Image(systemName: "chevron.left")), size: .default) {}
 
 // swiftlint:disable:next accessibility_label_for_image
 OUDSToolBarItem(icon: Image("ic_share"), accessibilityLabel: "Share") {}
@@ -200,7 +197,7 @@ These patterns apply to Checkbox, Radio, Switch, TextInput, TextArea, PinCodeInp
 OUDSButton(text: "Label", appearance: .default) {}
 OUDSButton(text: "Label", appearance: .default, style: .loading) {}
 OUDSButton(text: "Label", icon: Image("ic"), appearance: .default) {}
-OUDSButton(icon: Image("ic"), accessibilityLabel: "Label") {}
+OUDSButton(image: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
 ```
 
 ---
@@ -350,10 +347,10 @@ OUDSPasswordInput(label: "Password", password: $password, isHiddenPassword: $isH
 
 ```swift
 OUDSSuggestionChip(text: "Label") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic")), text: "Label") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic")), text: "Label") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
+OUDSSuggestionChip(image: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
 OUDSFilterChip(text: "Label") {}
 OUDSFilterChip(image: OUDSImage(asset: Image("ic")), text: "Label") {}
 OUDSFilterChip(image: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
@@ -380,9 +377,9 @@ OUDSTextInput(label: "Label", text: $text,
 OUDSTextInput(label: "Label", text: $text,
               leadingImage: OUDSImage(asset: Image("ic"), flipped: layoutDirection == .rightToLeft)) // flip for RTL
 OUDSTextInput(label: "Label", text: $text,
-              trailingAction: .init(icon: OUDSImage(asset: Image("ic")), actionHint: "Hint") {})
+              trailingAction: .init(image: OUDSImage(asset: Image("ic")), actionHint: "Hint") {})
 OUDSTextInput(label: "Label", text: $text,
-              trailingAction: .init(icon: OUDSImage(asset: Image("ic"), renderingMode: .original),
+              trailingAction: .init(image: OUDSImage(asset: Image("ic"), renderingMode: .original),
                                     actionHint: "Hint") {}) // raw image
 // Helper / error status → see §6 Common patterns
 ```
@@ -459,11 +456,11 @@ OUDSBadgeIcon(status: .neutral(icon: Image("ic")), accessibilityLabel: "Label", 
 
 ```swift
 OUDSTag(label: "Label")
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"))))
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic"), flipped: true))) // flipped for RTL
-OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic"))))
-OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic"))))
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
+OUDSTag(label: "Label", status: .neutral(image: OUDSImage(asset: Image("ic"), flipped: true))) // flipped for RTL
+OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image("ic"))))
+OUDSTag(label: "Label", status: .accent(image: OUDSImage(asset: Image("ic"), renderingMode: .original))) // raw image (not tinted)
 OUDSTag(label: "Label", status: .neutral(bullet: true))
 ```
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -348,12 +348,16 @@ OUDSChipPicker(title: "Title", selection: $selection, chips: [
 ```swift
 OUDSTextInput(label: "Label", text: $text)
 OUDSTextInput(label: "Label", text: $text, placeholder: "…", prefix: "Pre", suffix: "Suf")
-OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"))
-OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), leadingIconRenderingMode: .original) // raw image (not tinted)
+OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic")))
 OUDSTextInput(label: "Label", text: $text,
-              trailingAction: .init(icon: Image("ic"), actionHint: "Hint") {})
+              leadingIcon: OUDSImage(asset: Image("ic"), renderingMode: .original)) // raw image (not tinted)
 OUDSTextInput(label: "Label", text: $text,
-              trailingAction: .init(icon: Image("ic"), actionHint: "Hint", renderingMode: .original) {}) // raw image
+              leadingIcon: OUDSImage(asset: Image("ic"), flipped: layoutDirection == .rightToLeft)) // flip for RTL
+OUDSTextInput(label: "Label", text: $text,
+              trailingAction: .init(icon: OUDSImage(asset: Image("ic")), actionHint: "Hint") {})
+OUDSTextInput(label: "Label", text: $text,
+              trailingAction: .init(icon: OUDSImage(asset: Image("ic"), renderingMode: .original),
+                                    actionHint: "Hint") {}) // raw image
 // Helper / error status → see §6 Common patterns
 ```
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -343,7 +343,7 @@ Statuses: `neutral`, `accent`, `positive`, `info`, `warning`, `negative`
 OUDSAlertMessage(label: "Label")
 OUDSAlertMessage(label: "Label", status: .warning, description: "Details") { /* dismiss */ }
 OUDSAlertMessage(label: "Label",
-                 status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)), // .original to avoid to have tinted images
+                 status: .neutral(icon: OUDSImage(asset: Image("ic_heart"), renderingMode: .original)), // .original to avoid to have tinted images
                  bulletList: ["A", "B"],
                  link: .init(text: "More", position: .bottom) {},
                  onClose: {})
@@ -359,7 +359,7 @@ Statuses: `neutral`, `accent`, `positive`, `info`, `warning`, `negative`
 ```swift
 OUDSInlineAlert(label: "Label")
 OUDSInlineAlert(label: "Label", status: .warning)
-OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSIcon(asset: Image("ic_heart"))))
+OUDSInlineAlert(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_heart"))))
 ```
 
 ---

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -200,18 +200,38 @@ OUDSBulletList { OUDSBulletList.Item(AttributedString(…)) }
 OUDSCheckbox(isOn: $isOn, accessibilityLabel: "Label")
 OUDSCheckboxIndeterminate(selection: $selection, accessibilityLabel: "Label")
 OUDSCheckboxItem("Label", isOn: $isOn)
-OUDSCheckboxItem("Label", isOn: $isOn, description: "Helper", icon: Image(decorative: "ic"))
-OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "ic"), isReversed: true)
+OUDSCheckboxItem("Label", isOn: $isOn, description: "Helper",
+                 icon: OUDSImage(asset: Image(decorative: "ic")))
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "ic")), isReversed: true)
+// Raw (non-tinted) image:
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+// Flip icon for RTL:
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                 flipped: layoutDirection == .rightToLeft))
+// LocalizedStringKey:
+OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "ic")))
+// Indeterminate (three states) — also accepts LocalizedStringKey:
+OUDSCheckboxItemIndeterminate("Label", selection: $selection,
+                               icon: OUDSImage(asset: Image(decorative: "ic")))
+OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module,
+                               selection: $selection)
 // Error / helper / disabled → see §6 Common patterns
 ```
 
-> Parameter order: `(_ label:, isOn:, description:, icon:, flipIcon:, isReversed:, isError:, errorText:, isReadOnly:, hasDivider:, constrainedMaxWidth:, action:)`
+> Parameter order: `(_ label:, isOn:, description:, icon:, isReversed:, isError:, errorText:, isReadOnly:, hasDivider:, constrainedMaxWidth:, action:)`
 
 ```swift
-// Picker
+// Picker — icon is OUDSImage?
 OUDSCheckboxPicker(selections: $selections, checkboxes: [
     .init(tag: "a", label: "Option A"),
     .init(tag: "b", label: "Option B", description: "Details", isReversed: true),
+    .init(tag: "c", label: "Option C", icon: OUDSImage(asset: Image(systemName: "flame"))),
+    .init(tag: "d", label: "Option D",
+          icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original)),
 ])
 OUDSCheckboxPicker(selections: $selections, checkboxes: data,
                    placement: .verticalRooted("All options", .textAndCount))
@@ -226,10 +246,27 @@ OUDSCheckboxPicker(selections: $selections, checkboxes: data,
 ```swift
 OUDSRadio(isOn: $isOn, accessibilityLabel: "Label")
 OUDSRadioItem("Label", isOn: $isOn)
-OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "ic"))
+OUDSRadioItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic")))
+// Raw (non-tinted) image:
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+// Flip icon for RTL:
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
+                              flipped: layoutDirection == .rightToLeft))
+// LocalizedStringKey:
+OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "ic")))
 // Error / helper / disabled → see §6 Common patterns
 OUDSRadioPicker(selection: $selection,
-                radios: [.init(tag: "a", label: "Option A")],
+                radios: [
+                    .init(tag: "a", label: "Option A"),
+                    .init(tag: "b", label: "Option B",
+                          icon: OUDSImage(asset: Image(systemName: "flame"))),
+                    .init(tag: "c", label: "Option C",
+                          icon: OUDSImage(asset: Image(decorative: "il_brand"),
+                                         renderingMode: .original)),
+                ],
                 placement: .vertical)
 ```
 
@@ -240,7 +277,18 @@ OUDSRadioPicker(selection: $selection,
 ```swift
 OUDSSwitch(isOn: $isOn, accessibilityLabel: "Label")
 OUDSSwitchItem("Label", isOn: $isOn)
-OUDSSwitchItem("Label", isOn: $isOn, icon: Image(decorative: "ic"))
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "ic")))
+// Raw (non-tinted) image:
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+// Flip icon for RTL:
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(systemName: "figure.handball"),
+                               flipped: layoutDirection == .rightToLeft))
+// LocalizedStringKey:
+OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "ic")))
 // Error / helper / disabled → see §6 Common patterns
 ```
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -331,7 +331,7 @@ Statuses: `neutral`, `accent`, `positive`, `info`, `warning`, `negative`
 OUDSAlertMessage(label: "Label")
 OUDSAlertMessage(label: "Label", status: .warning, description: "Details") { /* dismiss */ }
 OUDSAlertMessage(label: "Label",
-                 status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"))),
+                 status: .neutral(icon: OUDSIcon(asset: Image("ic_heart"), renderingMode: .original)), // .original to avoid to have tinted images
                  bulletList: ["A", "B"],
                  link: .init(text: "More", position: .bottom) {},
                  onClose: {})

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -277,10 +277,19 @@ OUDSPasswordInput(label: "Password", password: $password, isHiddenPassword: $isH
 ```swift
 OUDSSuggestionChip(text: "Label") {}
 OUDSSuggestionChip(icon: Image("ic"), text: "Label") {}
+OUDSSuggestionChip(icon: Image("ic"), text: "Label", renderingMode: .original) {} // raw image (not tinted)
+OUDSSuggestionChip(icon: Image("ic"), accessibilityLabel: "Label") {}
+OUDSSuggestionChip(icon: Image("ic"), accessibilityLabel: "Label", renderingMode: .original) {} // raw image (not tinted)
 OUDSFilterChip(text: "Label") {}
 OUDSFilterChip(icon: Image("ic"), text: "Label") {}
+OUDSFilterChip(icon: Image("ic"), text: "Label", renderingMode: .original) {} // raw image (not tinted)
+OUDSFilterChip(icon: Image("ic"), accessibilityLabel: "Label") {}
+OUDSFilterChip(icon: Image("ic"), accessibilityLabel: "Label", renderingMode: .original) {} // raw image (not tinted)
 OUDSChipPicker(title: "Title", selection: $selection, chips: [
     .init(tag: .value1, layout: .textAndIcon("Label", icon: Image("ic"))),
+    .init(tag: .value2, layout: .textAndIcon("Brand", icon: Image("ic_brand"), renderingMode: .original)), // raw image
+    .init(tag: .value3, layout: .icon(icon: Image("ic"), accessibilityLabel: "Label")),
+    .init(tag: .value4, layout: .icon(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original)), // raw image
 ])
 ```
 
@@ -292,8 +301,11 @@ OUDSChipPicker(title: "Title", selection: $selection, chips: [
 OUDSTextInput(label: "Label", text: $text)
 OUDSTextInput(label: "Label", text: $text, placeholder: "…", prefix: "Pre", suffix: "Suf")
 OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"))
+OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), leadingIconRenderingMode: .original) // raw image (not tinted)
 OUDSTextInput(label: "Label", text: $text,
               trailingAction: .init(icon: Image("ic"), actionHint: "Hint") {})
+OUDSTextInput(label: "Label", text: $text,
+              trailingAction: .init(icon: Image("ic"), actionHint: "Hint", renderingMode: .original) {}) // raw image
 // Helper / error status → see §6 Common patterns
 ```
 
@@ -370,6 +382,9 @@ OUDSBadgeIcon(status: .neutral(icon: Image("ic")), accessibilityLabel: "Label", 
 ```swift
 OUDSTag(label: "Label")
 OUDSTag(label: "Label", status: .neutral(icon: Image("ic")))
+OUDSTag(label: "Label", status: .neutral(icon: Image("ic"), renderingMode: .original)) // raw image (not tinted)
+OUDSTag(label: "Label", status: .accent(icon: Image("ic")))
+OUDSTag(label: "Label", status: .accent(icon: Image("ic"), renderingMode: .original)) // raw image (not tinted)
 OUDSTag(label: "Label", status: .neutral(bullet: true))
 ```
 
@@ -408,6 +423,7 @@ OUDSVerticalDivider(color: .brandPrimary)
 OUDSLink(text: "Text", size: .default) {}
 OUDSLink(text: "Text", indicator: .back, size: .default) {}
 OUDSLink(text: "Text", icon: Image("ic"), size: .default) {}
+OUDSLink(text: "Text", icon: Image("ic"), renderingMode: .original, size: .default) {} // raw image (not tinted)
 ```
 
 ---

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -141,6 +141,32 @@ The `// swiftlint:disable:next accessibility_label_for_image` comment must appea
 
 Exception: `Image(decorative: "name")` suppresses the linter rule automatically and needs no comment.
 
+> **⚠ Init ambiguity warning (v2.3.0)**
+>
+> The following components have both a deprecated init (`icon: Image? = nil` or `leadingIcon: Image? = nil`) and an active init (`image: OUDSImage? = nil` or `leadingImage: OUDSImage? = nil`). When the image parameter is omitted entirely, Swift may fail with `error: ambiguous use of 'init(...)'` because both overloads match.
+>
+> **If this error occurs**, pass the image parameter explicitly as `nil` to disambiguate:
+>
+> | Component | Parameter to add |
+> |---|---|
+> | `OUDSCheckboxItem` | `image: nil` |
+> | `OUDSCheckboxItemIndeterminate` | `image: nil` |
+> | `OUDSCheckboxPickerData` | `image: nil` |
+> | `OUDSRadioItem` | `image: nil` |
+> | `OUDSSwitchItem` | `image: nil` |
+> | `OUDSLink` | `image: nil` |
+> | `OUDSTextInput` | `leadingImage: nil` |
+>
+> ```swift
+> // ❌ may be ambiguous while deprecated inits exist:
+> OUDSCheckboxItem("Label", isOn: $isOn)
+>
+> // ✅ unambiguous:
+> OUDSCheckboxItem("Label", isOn: $isOn, image: nil)
+> ```
+>
+> This is temporary — the ambiguity disappears once deprecated inits are removed in v3.
+
 ---
 
 ## 6. Common patterns (shared by multiple components)
@@ -201,37 +227,37 @@ OUDSCheckbox(isOn: $isOn, accessibilityLabel: "Label")
 OUDSCheckboxIndeterminate(selection: $selection, accessibilityLabel: "Label")
 OUDSCheckboxItem("Label", isOn: $isOn)
 OUDSCheckboxItem("Label", isOn: $isOn, description: "Helper",
-                 icon: OUDSImage(asset: Image(decorative: "ic")))
+                 image: OUDSImage(asset: Image(decorative: "ic")))
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "ic")), isReversed: true)
+                 image: OUDSImage(asset: Image(decorative: "ic")), isReversed: true)
 // Raw (non-tinted) image:
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+                 image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 // Flip icon for RTL:
 OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-                                 flipped: layoutDirection == .rightToLeft))
+                 image: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                  flipped: layoutDirection == .rightToLeft))
 // LocalizedStringKey:
 OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "ic")))
+                 image: OUDSImage(asset: Image(decorative: "ic")))
 // Indeterminate (three states) — also accepts LocalizedStringKey:
 OUDSCheckboxItemIndeterminate("Label", selection: $selection,
-                               icon: OUDSImage(asset: Image(decorative: "ic")))
+                               image: OUDSImage(asset: Image(decorative: "ic")))
 OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module,
                                selection: $selection)
 // Error / helper / disabled → see §6 Common patterns
 ```
 
-> Parameter order: `(_ label:, isOn:, description:, icon:, isReversed:, isError:, errorText:, isReadOnly:, hasDivider:, constrainedMaxWidth:, action:)`
+> Parameter order: `(_ label:, isOn:, description:, image:, isReversed:, isError:, errorText:, isReadOnly:, hasDivider:, constrainedMaxWidth:, action:)`
 
 ```swift
-// Picker — icon is OUDSImage?
+// Picker — image is OUDSImage?
 OUDSCheckboxPicker(selections: $selections, checkboxes: [
     .init(tag: "a", label: "Option A"),
     .init(tag: "b", label: "Option B", description: "Details", isReversed: true),
-    .init(tag: "c", label: "Option C", icon: OUDSImage(asset: Image(systemName: "flame"))),
+    .init(tag: "c", label: "Option C", image: OUDSImage(asset: Image(systemName: "flame"))),
     .init(tag: "d", label: "Option D",
-          icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original)),
+          image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original)),
 ])
 OUDSCheckboxPicker(selections: $selections, checkboxes: data,
                    placement: .verticalRooted("All options", .textAndCount))
@@ -246,26 +272,26 @@ OUDSCheckboxPicker(selections: $selections, checkboxes: data,
 ```swift
 OUDSRadio(isOn: $isOn, accessibilityLabel: "Label")
 OUDSRadioItem("Label", isOn: $isOn)
-OUDSRadioItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic")))
+OUDSRadioItem("Label", isOn: $isOn, image: OUDSImage(asset: Image(decorative: "ic")))
 // Raw (non-tinted) image:
 OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+              image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 // Flip icon for RTL:
 OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
-                              flipped: layoutDirection == .rightToLeft))
+              image: OUDSImage(asset: Image(systemName: "chevron.right"),
+                               flipped: layoutDirection == .rightToLeft))
 // LocalizedStringKey:
 OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "ic")))
+              image: OUDSImage(asset: Image(decorative: "ic")))
 // Error / helper / disabled → see §6 Common patterns
 OUDSRadioPicker(selection: $selection,
                 radios: [
                     .init(tag: "a", label: "Option A"),
                     .init(tag: "b", label: "Option B",
-                          icon: OUDSImage(asset: Image(systemName: "flame"))),
+                          image: OUDSImage(asset: Image(systemName: "flame"))),
                     .init(tag: "c", label: "Option C",
-                          icon: OUDSImage(asset: Image(decorative: "il_brand"),
-                                         renderingMode: .original)),
+                          image: OUDSImage(asset: Image(decorative: "il_brand"),
+                                          renderingMode: .original)),
                 ],
                 placement: .vertical)
 ```
@@ -278,17 +304,17 @@ OUDSRadioPicker(selection: $selection,
 OUDSSwitch(isOn: $isOn, accessibilityLabel: "Label")
 OUDSSwitchItem("Label", isOn: $isOn)
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "ic")))
+               image: OUDSImage(asset: Image(decorative: "ic")))
 // Raw (non-tinted) image:
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+               image: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
 // Flip icon for RTL:
 OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(systemName: "figure.handball"),
-                               flipped: layoutDirection == .rightToLeft))
+               image: OUDSImage(asset: Image(systemName: "figure.handball"),
+                                flipped: layoutDirection == .rightToLeft))
 // LocalizedStringKey:
 OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "ic")))
+               image: OUDSImage(asset: Image(decorative: "ic")))
 // Error / helper / disabled → see §6 Common patterns
 ```
 
@@ -329,10 +355,10 @@ OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original)
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
 OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
 OUDSFilterChip(text: "Label") {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic")), text: "Label") {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
+OUDSFilterChip(image: OUDSImage(asset: Image("ic")), text: "Label") {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic"), renderingMode: .original), text: "Label") {} // raw image (not tinted)
+OUDSFilterChip(image: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
+OUDSFilterChip(image: OUDSImage(asset: Image("ic"), renderingMode: .original), accessibilityLabel: "Label") {} // raw image (not tinted)
 OUDSChipPicker(title: "Title", selection: $selection, chips: [
     .init(tag: .value1, layout: .textAndIcon("Label", image: OUDSImage(asset: Image("ic")))),
     .init(tag: .value2, layout: .textAndIcon("Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))), // raw image
@@ -348,11 +374,11 @@ OUDSChipPicker(title: "Title", selection: $selection, chips: [
 ```swift
 OUDSTextInput(label: "Label", text: $text)
 OUDSTextInput(label: "Label", text: $text, placeholder: "…", prefix: "Pre", suffix: "Suf")
-OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic")))
+OUDSTextInput(label: "Label", text: $text, leadingImage: OUDSImage(asset: Image("ic")))
 OUDSTextInput(label: "Label", text: $text,
-              leadingIcon: OUDSImage(asset: Image("ic"), renderingMode: .original)) // raw image (not tinted)
+              leadingImage: OUDSImage(asset: Image("ic"), renderingMode: .original)) // raw image (not tinted)
 OUDSTextInput(label: "Label", text: $text,
-              leadingIcon: OUDSImage(asset: Image("ic"), flipped: layoutDirection == .rightToLeft)) // flip for RTL
+              leadingImage: OUDSImage(asset: Image("ic"), flipped: layoutDirection == .rightToLeft)) // flip for RTL
 OUDSTextInput(label: "Label", text: $text,
               trailingAction: .init(icon: OUDSImage(asset: Image("ic")), actionHint: "Hint") {})
 OUDSTextInput(label: "Label", text: $text,
@@ -475,8 +501,8 @@ OUDSVerticalDivider(color: .brandPrimary)
 ```swift
 OUDSLink(text: "Text", size: .default) {}
 OUDSLink(text: "Text", indicator: .back, size: .default) {}
-OUDSLink(text: "Text", icon: OUDSImage(asset: Image("ic")), size: .default) {}
-OUDSLink(text: "Text", icon: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
+OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic")), size: .default) {}
+OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
 ```
 
 ---

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -196,7 +196,7 @@ These patterns apply to Checkbox, Radio, Switch, TextInput, TextArea, PinCodeInp
 ```swift
 OUDSButton(text: "Label", appearance: .default) {}
 OUDSButton(text: "Label", appearance: .default, style: .loading) {}
-OUDSButton(text: "Label", icon: Image("ic"), appearance: .default) {}
+OUDSButton(text: "Label", image: OUDSImage(asset: Image("ic")), appearance: .default) {}
 OUDSButton(image: OUDSImage(asset: Image("ic")), accessibilityLabel: "Label") {}
 ```
 

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -22,7 +22,7 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip`, `OUDSLink` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip`, `OUDSLink`, `OUDSTextInput`, `OUDSTextInput.TrailingAction` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
 
 ---
 
@@ -850,6 +850,55 @@ OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
 1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
 2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
 3. Remove the now-unused `renderingMode` parameter from the call site.
+
+### 10. `OUDSTextInput` and `OUDSTextInput.TrailingAction` — `icon:` / `leadingIcon:` deprecated
+
+#### OUDSTextInput — leadingIcon
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `leadingIcon: Image(…)` | `leadingIcon: OUDSImage(asset: Image(…))` |
+| `flipLeadingIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` |
+| `leadingIconRenderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` |
+
+**Before (v2.2.0)**:
+```swift
+OUDSTextInput(label: "Email", text: $text, leadingIcon: Image(systemName: "envelope"))
+OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
+OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), flipLeadingIcon: true)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTextInput(label: "Email", text: $text, leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
+OUDSTextInput(label: "Brand", text: $text, leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
+OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic"), flipped: true))
+```
+
+#### OUDSTextInput.TrailingAction
+
+**Before (v2.2.0)**:
+```swift
+OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
+OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", renderingMode: .original) {}
+OUDSTextInput.TrailingAction(icon: Image("ic"), actionHint: "Hint", flipIcon: true) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
+OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), actionHint: "Brand") {}
+OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic"), flipped: true), actionHint: "Hint") {}
+```
+
+**Required action**:
+1. Replace `leadingIcon: Image(…)` with `leadingIcon: OUDSImage(asset: Image(…))`.
+2. Move `flipLeadingIcon:` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `leadingIconRenderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(icon: OUDSImage(asset: Image(…)), …)`.
+5. Move `flipIcon:` and `renderingMode:` inside the `OUDSImage` for `TrailingAction`.
 
 ---
 

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -22,7 +22,7 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; four `OUDSButton` initialisers with `icon:` deprecated |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData` and `OUDSSwitchItem` initialisers with `icon:` deprecated |
 
 ---
 
@@ -45,7 +45,7 @@ Run these from the project root to find all occurrences before starting:
 ```bash
 # All active deprecations (v2.x era)
 grep -rn \
-  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|spacePaddingBlockDensityCompactTopAlignmentTopText_container" \
+  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container" \
   --include="*.swift" .
 
 # Breaking changes removed in v2.0.0 (v1.x era)
@@ -528,6 +528,192 @@ OUDSButton(image: OUDSImage(asset: Image("ic_heart"),
 
 ---
 
+### 3. `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate` and `OUDSCheckboxPickerData` — initialisers with `icon:` deprecated
+
+Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
+
+**Parameter mapping** (applies to all three types):
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+#### OUDSCheckboxItem — String and LocalizedStringKey
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
+OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
+OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
+                 icon: Image(decorative: "ic_heart"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSCheckboxItem("Label", isOn: $isOn,
+                 icon: OUDSImage(asset: Image(systemName: "chevron.right"),
+                                 flipped: layoutDirection == .rightToLeft))
+OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
+                 icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+```
+
+#### OUDSCheckboxItemIndeterminate
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxItemIndeterminate("Label", selection: $state, icon: Image(decorative: "ic_heart"))
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: Image(decorative: "il_brand"), renderingMode: .original,
+                               flipIcon: true)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+OUDSCheckboxItemIndeterminate("Label", selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "il_brand"),
+                                               flipped: true, renderingMode: .original))
+// New in v2.3.0: LocalizedStringKey variant now available
+OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module,
+                               selection: $state,
+                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+```
+
+#### OUDSCheckboxPickerData
+
+**Before (v2.2.0)**:
+```swift
+OUDSCheckboxPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
+OUDSCheckboxPickerData(tag: "b", label: "Option B",
+                       icon: Image(decorative: "il_brand"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSCheckboxPickerData(tag: "a", label: "Option A",
+                       icon: OUDSImage(asset: Image(systemName: "flame")))
+OUDSCheckboxPickerData(tag: "b", label: "Option B",
+                       icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
+
+### 4. `OUDSRadioItem` and `OUDSRadioPickerData` — initialisers with `icon:` deprecated
+
+Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
+
+**Parameter mapping** (applies to both types):
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+#### OUDSRadioItem — String and LocalizedStringKey
+
+**Before (v2.2.0)**:
+```swift
+OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
+OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
+OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
+              icon: Image(decorative: "ic_heart"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSRadioItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSRadioItem("Label", isOn: $isOn,
+              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
+                              flipped: layoutDirection == .rightToLeft))
+OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
+              icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
+```
+
+#### OUDSRadioPickerData
+
+**Before (v2.2.0)**:
+```swift
+OUDSRadioPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
+OUDSRadioPickerData(tag: "b", label: "Option B", icon: Image(decorative: "il_brand"))
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSRadioPickerData(tag: "a", label: "Option A",
+                    icon: OUDSImage(asset: Image(systemName: "flame")))
+OUDSRadioPickerData(tag: "b", label: "Option B",
+                    icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
+
+### 5. `OUDSSwitchItem` — initialisers with `icon:` deprecated
+
+Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
+Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSSwitchItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: Image(decorative: "il_brand"), renderingMode: .original)
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
+OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
+               icon: Image(decorative: "ic_wifi"), renderingMode: .original)
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSSwitchItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
+OUDSSwitchItem("Label", isOn: $isOn,
+               icon: OUDSImage(asset: Image(systemName: "chevron.right"),
+                               flipped: layoutDirection == .rightToLeft))
+OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
+               icon: OUDSImage(asset: Image(decorative: "ic_wifi"), renderingMode: .original))
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
+
+---
+
 ## Verification checklist
 
 After completing all transformations, run:
@@ -541,7 +727,7 @@ swift build 2>&1 | grep -i "deprecated" | grep -iv "apple\|system\|swift\|founda
 
 # Residual deprecated or removed symbols — must return no results
 grep -rn \
-  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
+  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
   --include="*.swift" .
 
 # Tests — must pass

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -6,8 +6,8 @@ license: MIT
 
 # Skill: ouds-ios-migration
 
-This skill provides step-by-step guidance to migrate OUDS iOS code from **v1.0.0** up to **v2.3.0** (current).
-It covers all breaking changes, removed APIs and deprecated symbols introduced in each release.
+Migration guide from **v1.0.0** to **v2.3.0** (current). Covers all breaking changes and deprecated symbols.
+For full before/after examples, refer to `MIGRATION.md` in the project root.
 
 ---
 
@@ -15,40 +15,36 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 
 | From → To | Impact | Key changes |
 |---|---|---|
-| v1.0.0 → v1.1.0 | High | `Multiple*Tokens` (plural) → `Multiple*Token` (singular); button border tokens shortened |
+| v1.0.0 → v1.1.0 | High | `Multiple*Tokens` → `Multiple*Token`; button border tokens shortened |
 | v1.1.0 → v1.2.0 | High | Theme renamed: `OrangeBusinessTools` → `OrangeCompact` |
-| v1.2.0 → v1.3.0 | Low | `oudsVerticalSizeClass` removed; `OUDSBulletList.UnorderedIcon` → `UnorderedAsset` |
-| v1.3.0 → v1.4.0 | Low | `ouds`-prefixed `View` extension methods removed; `OUDSTabBar(selected:)` → `(selectedTab:)` |
+| v1.2.0 → v1.3.0 | Low | `oudsVerticalSizeClass` removed; `UnorderedIcon` → `UnorderedAsset` |
+| v1.3.0 → v1.4.0 | Low | `ouds`-prefixed `View` methods removed; `OUDSTabBar(selected:)` → `(selectedTab:)` |
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip`, `OUDSLink`, `OUDSTextInput`, `OUDSTextInput.TrailingAction` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; all `icon: Image` + `flipIcon` + `renderingMode` params replaced by `OUDSImage` |
 
 ---
 
 ## Migration workflow
 
-For each migration task, follow this sequence:
-
-1. **Detect** — grep the target codebase for deprecated or removed symbols (commands provided per section below).
-2. **Transform** — apply the before/after substitutions listed in the relevant section.
-3. **Build** — run `swift build` and confirm zero errors.
-4. **Check warnings** — run `swift build 2>&1 | grep -i deprecated` and confirm zero OUDS deprecation warnings.
-5. **Test** — run the test suite (`swift test`) to confirm no regressions.
+1. **Detect** — grep for deprecated symbols (commands below).
+2. **Transform** — apply the rules for the relevant version.
+3. **Build** — `swift build` must succeed with zero errors.
+4. **Check warnings** — `swift build 2>&1 | grep -i deprecated` must return nothing OUDS-related.
+5. **Test** — `swift test` must pass.
 
 ---
 
 ## Detection grep commands
 
-Run these from the project root to find all occurrences before starting:
-
 ```bash
-# All active deprecations (v2.x era)
+# Active deprecations (v2.x)
 grep -rn \
   "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container" \
   --include="*.swift" .
 
-# Breaking changes removed in v2.0.0 (v1.x era)
+# Removed symbols (v1.x era)
 grep -rn \
   "oudsVerticalSizeClass\|UnorderedIcon\|\.free(\|OUDSTabBar(selected:\|\.ouds[A-Z]\|Multiple.*Tokens\b\|OrangeBusinessTools\|buttonBorderRadius\|buttonBorderWidth" \
   --include="*.swift" .
@@ -56,127 +52,41 @@ grep -rn \
 
 ---
 
-## v1.0.0 → v1.1.0 — Breaking changes
+## v1.0.0 → v1.1.0
 
-### 1. `Multiple*Tokens` (plural) → `Multiple*Token` (singular)
-
-**Before (v1.0.0)**:
-```swift
-MultipleElevationCompositeRawTokens
-MultipleColorSemanticTokens
-MultipleFontCompositeSemanticTokens
-MultipleFontLetterSpacingSemanticTokens
-MultipleFontLineHeightSemanticTokens
-MultipleFontSizeSemanticTokens
-MultipleSizeSemanticTokens
-MultipleSpaceSemanticTokens
-```
-
-**After (v1.1.0)**:
-```swift
-MultipleElevationCompositeRawToken
-MultipleColorSemanticToken
-MultipleFontCompositeSemanticToken
-MultipleFontLetterSpacingSemanticToken
-MultipleFontLineHeightSemanticToken
-MultipleFontSizeSemanticToken
-MultipleSizeSemanticToken
-MultipleSpaceSemanticToken
-```
-
-**Action**: Global rename — remove the trailing `s` from each type name.
-
-### 2. Button border component tokens shortened
-
-**Before (v1.0.0)**:
-```swift
-theme.button.buttonBorderRadiusDefault
-theme.button.buttonBorderRadiusRounded
-theme.button.buttonBorderRadiusSocial
-theme.button.buttonBorderWidthDefault
-theme.button.buttonBorderWidthDefaultInteraction
-theme.button.buttonBorderWidthDefaultInteractionMono
-```
-
-**After (v1.1.0)**:
-```swift
-theme.button.borderRadiusDefault
-theme.button.borderRadiusRounded
-theme.button.borderRadiusSocial
-theme.button.borderWidthDefault
-theme.button.borderWidthDefaultInteraction
-theme.button.borderWidthDefaultInteractionMono
-```
-
-**Action**: Remove the `button` prefix from each token name.
+| Old | New |
+|---|---|
+| `MultipleElevationCompositeRawTokens` | `MultipleElevationCompositeRawToken` |
+| `MultipleColorSemanticTokens` | `MultipleColorSemanticToken` |
+| `MultipleFontCompositeSemanticTokens` | `MultipleFontCompositeSemanticToken` |
+| `MultipleFontLetterSpacingSemanticTokens` | `MultipleFontLetterSpacingSemanticToken` |
+| `MultipleFontLineHeightSemanticTokens` | `MultipleFontLineHeightSemanticToken` |
+| `MultipleFontSizeSemanticTokens` | `MultipleFontSizeSemanticToken` |
+| `MultipleSizeSemanticTokens` | `MultipleSizeSemanticToken` |
+| `MultipleSpaceSemanticTokens` | `MultipleSpaceSemanticToken` |
+| `theme.button.buttonBorderRadiusDefault` | `theme.button.borderRadiusDefault` |
+| `theme.button.buttonBorderRadiusRounded` | `theme.button.borderRadiusRounded` |
+| `theme.button.buttonBorderRadiusSocial` | `theme.button.borderRadiusSocial` |
+| `theme.button.buttonBorderWidthDefault` | `theme.button.borderWidthDefault` |
+| `theme.button.buttonBorderWidthDefaultInteraction` | `theme.button.borderWidthDefaultInteraction` |
+| `theme.button.buttonBorderWidthDefaultInteractionMono` | `theme.button.borderWidthDefaultInteractionMono` |
 
 ---
 
-## v1.1.0 → v1.2.0 — Breaking changes
+## v1.1.0 → v1.2.0
 
-### Theme renamed: OrangeBusinessTools → OrangeCompact
-
-**Before (v1.1.0)**:
-```swift
-import OUDSThemeOrangeBusinessTools
-// …
-OUDSThemeableView(theme: OrangeBusinessToolsTheme()) { … }
-```
-
-**After (v1.2.0)**:
-```swift
-import OUDSThemeOrangeCompact
-// …
-OUDSThemeableView(theme: OrangeCompactTheme()) { … }
-```
-
-**Action**:
-1. Replace import `OUDSThemeOrangeBusinessTools` → `OUDSThemeOrangeCompact`.
-2. Replace all occurrences of `OrangeBusinessToolsTheme` → `OrangeCompactTheme`.
-3. Replace any string or identifier containing `OrangeBusinessTools` → `OrangeCompact` (documentation, test names, etc.).
+Replace everywhere: `OUDSThemeOrangeBusinessTools` → `OUDSThemeOrangeCompact`, `OrangeBusinessToolsTheme` → `OrangeCompactTheme`, `OrangeBusinessTools` → `OrangeCompact`.
 
 ---
 
-## v1.2.0 → v1.3.0 — Breaking changes
+## v1.2.0 → v1.3.0
 
-### 1. `oudsVerticalSizeClass` removed
-
-**Before (v1.2.0)**:
-```swift
-@Environment(\.oudsVerticalSizeClass) var sizeClass
-```
-
-**After (v1.3.0)**:
-```swift
-// Remove entirely — the property no longer exists.
-// Note: reintroduced in v1.4.0; wait for that version if you need it.
-```
-
-**Action**: Remove all uses of `oudsVerticalSizeClass`.
-
-### 2. `OUDSBulletList.UnorderedIcon` → `OUDSBulletList.UnorderedAsset`; `.free` → `.icon`
-
-**Before (v1.2.0)**:
-```swift
-var bullet: OUDSBulletList.UnorderedIcon { .free(someImage) }
-```
-
-**After (v1.3.0)**:
-```swift
-var bullet: OUDSBulletList.UnorderedAsset { .icon(someImage) }
-```
-
-**Action**:
-1. Rename `OUDSBulletList.UnorderedIcon` → `OUDSBulletList.UnorderedAsset`.
-2. Rename case `.free(…)` → `.icon(…)`.
+- Remove all uses of `@Environment(\.oudsVerticalSizeClass)`.
+- Rename `OUDSBulletList.UnorderedIcon` → `OUDSBulletList.UnorderedAsset`; case `.free(…)` → `.icon(…)`.
 
 ---
 
-## v1.3.0 → v1.4.0 — Breaking changes
-
-### 1. `ouds`-prefixed `View` extension methods removed
-
-All `ouds`-prefixed methods were removed. Replace each with its unprefixed counterpart:
+## v1.3.0 → v1.4.0
 
 | Removed | Replacement |
 |---|---|
@@ -192,732 +102,100 @@ All `ouds`-prefixed methods were removed. Replace each with its unprefixed count
 | `.oudsRequestAccessibleFocus(_:for:)` | `.requestAccessibleFocus(_:for:)` |
 | `.oudsHorizontalDivider(dividerColor:)` | `.horizontal(color:)` |
 | `.oudsVerticalDivider(color:)` | `.vertical(color:)` |
-
-**Action**: Replace each `ouds`-prefixed call with its unprefixed counterpart.
-
-### 2. `OUDSTabBar(selected:count:content:)` → `OUDSTabBar(selectedTab:count:content:)`
-
-**Before (v1.3.x)**:
-```swift
-OUDSTabBar(selected: 0, count: 3) {
-    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
-}
-```
-
-**After (v1.4.0)**:
-```swift
-@State private var selectedTab = 0
-
-OUDSTabBar(selectedTab: $selectedTab, count: 3) {
-    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
-}
-```
-
-**Action**:
-1. Rename parameter label `selected:` → `selectedTab:`.
-2. Declare `@State private var selectedTab: Int` and pass it as `$selectedTab`.
+| `OUDSTabBar(selected: 0, count: 3) { … }` | `@State var selectedTab = 0; OUDSTabBar(selectedTab: $selectedTab, count: 3) { … }` |
 
 ---
 
-## v1.4.0 → v2.0.0 — Breaking changes
+## v1.4.0 → v2.0.0
 
-### 1. Renamed semantic tokens — colors
+### Renamed semantic tokens
 
-| Old name | New name |
+| Old | New |
 |---|---|
 | `repositorySecondaryHigher` | `repositorySecondaryHigherHigh` |
-| `overlayModalLight` | `overlayModalSheetLight` |
-| `overlayModalDark` | `overlayModalSheetDark` |
-| `overlayModal` | `overlayModalSheet` |
+| `overlayModalLight/Dark/` | `overlayModalSheetLight/Dark/` (drop `Modal`, add `Sheet`) |
+| `xDefault`, `yDefault`, `blurDefault`, `spreadDefault` | `xElevated`, `yElevated`, `blurElevated`, `spreadElevated` |
+| `colorDefaultLight/Dark` | `colorElevatedLight/Dark` |
+| All `maxWidthType*` sizes | `maxWidth*` (remove `Type`) |
+| Badge `spaceInset` | `spaceInsetMediumLarge` |
+| Bar `colorActiveIndicator*` | `colorCurrentIndicator*` |
+| Bar `opacityActiveIndicator*`, `borderRadiusActiveIndicator*`, `sizeWidthActiveIndicator*` | same with `Current` |
 
-### 2. Renamed semantic tokens — elevations
+### Removed tokens
 
-| Old name | New name |
-|---|---|
-| `xDefault` | `xElevated` |
-| `yDefault` | `yElevated` |
-| `blurDefault` | `blurElevated` |
-| `spreadDefault` | `spreadElevated` |
-| `colorDefaultLight` | `colorElevatedLight` |
-| `colorDefaultDark` | `colorElevatedDark` |
+Remove: `blur160`, `opacityGrayLight80800`, `actionAccentLight/Dark/` (use `colorAccent` bar tokens), radio/checkbox `sizeIndicator` (use `controlItem.sizeControlIndicator`), control item tokens: `sizeMaxHeihtAssetsContainer`, `sizeLoader`, `sizeErrorIcon`, `borderRadiusItemOnly`, `colorBgHover/Focus/Pressed/Loading*`, `colorContentLoader*`, `spacePaddingInlineErrorIcon*`.
 
-### 3. Renamed semantic tokens — sizes (remove "Type")
+### Other changes
 
-Pattern: `maxWidthType` → `maxWidth` for all typography size tokens.
-
-| Old name | New name |
-|---|---|
-| `maxWidthTypeDisplayLargeMobile` | `maxWidthDisplayLargeMobile` |
-| `maxWidthTypeDisplayLargeTablet` | `maxWidthDisplayLargeTablet` |
-| `maxWidthTypeDisplayMediumMobile` | `maxWidthDisplayMediumMobile` |
-| `maxWidthTypeDisplayMediumTablet` | `maxWidthDisplayMediumTablet` |
-| `maxWidthTypeDisplaySmallMobile` | `maxWidthDisplaySmallMobile` |
-| `maxWidthTypeDisplaySmallTablet` | `maxWidthDisplaySmallTablet` |
-| `maxWidthTypeHeadingXlargeMobile` | `maxWidthHeadingXlargeMobile` |
-| `maxWidthTypeHeadingXlargeTablet` | `maxWidthHeadingXlargeTablet` |
-| `maxWidthTypeHeadingLargeMobile` | `maxWidthHeadingLargeMobile` |
-| `maxWidthTypeHeadingLargeTablet` | `maxWidthHeadingLargeTablet` |
-| `maxWidthTypeHeadingMediumMobile` | `maxWidthHeadingMediumMobile` |
-| `maxWidthTypeHeadingMediumTablet` | `maxWidthHeadingMediumTablet` |
-| `maxWidthTypeHeadingSmallMobile` | `maxWidthHeadingSmallMobile` |
-| `maxWidthTypeHeadingSmallTablet` | `maxWidthHeadingSmallTablet` |
-| `maxWidthTypeBodyLargeMobile` | `maxWidthBodyLargeMobile` |
-| `maxWidthTypeBodyLargeTablet` | `maxWidthBodyLargeTablet` |
-| `maxWidthTypeBodyMediumMobile` | `maxWidthBodyMediumMobile` |
-| `maxWidthTypeBodyMediumTablet` | `maxWidthBodyMediumTablet` |
-| `maxWidthTypeBodySmallMobile` | `maxWidthBodySmallMobile` |
-| `maxWidthTypeBodySmallTablet` | `maxWidthBodySmallTablet` |
-| `maxWidthTypeLabelXlargeMobile` | `maxWidthLabelXlargeMobile` |
-| `maxWidthTypeLabelXlargeTablet` | `maxWidthLabelXlargeTablet` |
-| `maxWidthTypeLabelLargeMobile` | `maxWidthLabelLargeMobile` |
-| `maxWidthTypeLabelLargeTablet` | `maxWidthLabelLargeTablet` |
-| `maxWidthTypeLabelMediumMobile` | `maxWidthLabelMediumMobile` |
-| `maxWidthTypeLabelMediumTablet` | `maxWidthLabelMediumTablet` |
-| `maxWidthTypeLabelSmallMobile` | `maxWidthLabelSmallMobile` |
-| `maxWidthTypeLabelSmallTablet` | `maxWidthLabelSmallTablet` |
-
-### 4. Renamed component tokens — badge
-
-| Old name | New name |
-|---|---|
-| `spaceInset` | `spaceInsetMediumLarge` |
-
-### 5. Renamed component tokens — bar (ActiveIndicator → CurrentIndicator)
-
-| Old name | New name |
-|---|---|
-| `colorActiveIndicatorCustomSelectedEnabled` | `colorCurrentIndicatorCustomSelectedEnabled` |
-| `colorActiveIndicatorCustomSelectedHover` | `colorCurrentIndicatorCustomSelectedHover` |
-| `colorActiveIndicatorCustomSelectedPressed` | `colorCurrentIndicatorCustomSelectedPressed` |
-| `colorActiveIndicatorCustomSelectedFocus` | `colorCurrentIndicatorCustomSelectedFocus` |
-| `opacityActiveIndicatorCustom` | `opacityCurrentIndicatorCustom` |
-| `borderRadiusActiveIndicatorCustomTop` | `borderRadiusCurrentIndicatorCustomTop` |
-| `borderRadiusActiveIndicatorCustomBottom` | `borderRadiusCurrentIndicatorCustomBottom` |
-| `sizeWidthActiveIndicatorCustomTop` | `sizeWidthCurrentIndicatorCustomTop` |
-| `sizeWidthActiveIndicatorCustomBottom` | `sizeWidthCurrentIndicatorCustomBottom` |
-
-### 6. Removed tokens
-
-| Removed symbol | Action |
-|---|---|
-| Raw token `blur160` | Remove all uses |
-| Raw token `opacityGrayLight80800` | Remove all uses |
-| Semantic tokens `actionAccentLight`, `actionAccentDark`, `actionAccent` | Remove; use `colorAccent` bar component tokens if relevant |
-| Radio component token `sizeIndicator` | Use `controlItem.sizeControlIndicator` instead |
-| Checkbox component token `sizeIndicator` | Use `controlItem.sizeControlIndicator` instead |
-| Control item tokens: `sizeMaxHeihtAssetsContainer`, `sizeLoader`, `sizeErrorIcon`, `borderRadiusItemOnly`, `colorBgHover*`, `colorBgFocus*`, `colorBgPressed*`, `colorBgLoading*`, `colorContentLoader*`, `spacePaddingInlineErrorIcon*` | Remove all uses |
-
-### 7. Charts color token provider renamed
-
-**Before (v1.4.x)**:
-```swift
-theme.charts.someColorToken
-```
-
-**After (v2.0.0)**:
-```swift
-theme.colorsCharts.someColorToken
-```
-
-**Action**: Replace `theme.charts.` → `theme.colorsCharts.`.
-
-### 8. `OUDSToolBarItem.ActionType` — new `badgeType` parameter in `icon` case
-
-If you pattern-match on the `.icon` case, add a slot for `badgeType`:
-
-**Before (v1.4.x)**:
-```swift
-case .icon(let asset, let accessibilityLabel):
-    …
-```
-
-**After (v2.0.0)**:
-```swift
-case .icon(let asset, let accessibilityLabel, let badgeType):
-    …
-```
+- `theme.charts.*` → `theme.colorsCharts.*`
+- `OUDSToolBarItem.ActionType` `.icon` case: add new `badgeType` slot in pattern matching.
 
 ---
 
-## v2.0.0 → v2.1.0 — Deprecated symbols
+## v2.0.0 → v2.1.0
 
-### Component token renamed (ControlItem)
-
-**Before (v2.0.0)**:
-```swift
-theme.controlItem.spacePaddingBlockDensityCompactTopAlignmentTopText_container
-```
-
-**After (v2.1.0)**:
-```swift
-theme.controlItem.spacePaddingBlockDensityCompactTopAlignmentTopTextContainer
-```
-
-**Action**: Replace the underscore form with the camelCase form.
+`theme.controlItem.spacePaddingBlockDensityCompactTopAlignmentTopText_container` → `spacePaddingBlockDensityCompactTopAlignmentTopTextContainer`
 
 ---
 
-## v2.0.0 → v2.2.0 — Deprecated symbols
+## v2.0.0 → v2.2.0 — OUDSBadge split
 
-### `OUDSBadge` split into three dedicated components
+`OUDSBadge` is deprecated. Identify the variant and replace:
 
-`OUDSBadge` is deprecated. Identify which variant you are using from the call site and replace it.
-
-**Detection**: search for `OUDSBadge(` in your Swift files.
-
-**Identification rule**:
-- Call has `count:` parameter → use `OUDSBadgeCount`
-- Call has a `status:` whose associated value carries an `icon:` (i.e. `StatusWithIcon`) → use `OUDSBadgeIcon`
-- Otherwise → use `OUDSBadgeStandard`
-
-#### Standard badge (no count, no icon in status)
-
-**Before (v2.0.0)**:
-```swift
-OUDSBadge(accessibilityLabel: "New", status: .accent, size: .small)
-OUDSBadge(accessibilityLabel: LocalizedStringKey("new_badge"), bundle: Bundle.module, status: .neutral, size: .medium)
-```
-
-**After (v2.2.0)**:
-```swift
-OUDSBadgeStandard(accessibilityLabel: "New", status: .accent, size: .small)
-OUDSBadgeStandard(accessibilityLabel: LocalizedStringKey("new_badge"), bundle: Bundle.module, status: .neutral, size: .medium)
-```
-
-#### Count badge
-
-**Before (v2.0.0)**:
-```swift
-OUDSBadge(count: 9, accessibilityLabel: "9 messages", status: .negative, size: .large)
-OUDSBadge(count: 3, accessibilityLabel: LocalizedStringKey("badge_count"), bundle: Bundle.module, status: .neutral, size: .medium)
-```
-
-**After (v2.2.0)**:
-```swift
-// count becomes the first unlabelled argument
-OUDSBadgeCount(9, accessibilityLabel: "9 messages", status: .negative, size: .large)
-OUDSBadgeCount(3, accessibilityLabel: LocalizedStringKey("badge_count"), bundle: Bundle.module, status: .neutral, size: .medium)
-```
-
-> `count` must be of type `UInt8`.
-
-#### Icon badge
-
-**Before (v2.0.0)**:
-```swift
-OUDSBadge(status: .info(icon: Image("ic_info")), accessibilityLabel: "Info", size: .medium)
-OUDSBadge(status: .warning(icon: Image("ic_warn")), accessibilityLabel: LocalizedStringKey("badge_warn"), bundle: Bundle.module, size: .small)
-```
-
-**After (v2.2.0)**:
-```swift
-OUDSBadgeIcon(status: .info(icon: Image("ic_info")), accessibilityLabel: "Info", size: .medium)
-OUDSBadgeIcon(status: .warning(icon: Image("ic_warn")), accessibilityLabel: LocalizedStringKey("badge_warn"), bundle: Bundle.module, size: .small)
-```
+| If the call has… | Use |
+|---|---|
+| `count:` parameter | `OUDSBadgeCount(count, accessibilityLabel:status:size:)` — count is first unlabelled arg, type `UInt8` |
+| `status:` of type `StatusWithIcon` (carries an icon) | `OUDSBadgeIcon(status:accessibilityLabel:size:)` |
+| Neither | `OUDSBadgeStandard(accessibilityLabel:status:size:)` |
 
 ---
 
-## v2.2.0 → v2.3.0 — Deprecated symbols
+## v2.2.0 → v2.3.0 — OUDSImage migration
 
-### 1. `OUDSIcon` → `OUDSImage`
+### Universal rule
 
-`OUDSIcon` is a deprecated typealias for `OUDSImage`. The initialiser signature is identical.
+All components that used `icon: Image`, `flipIcon: Bool`, `renderingMode:` as separate parameters now use `OUDSImage`:
 
-**Before (v2.2.0)**:
-```swift
-OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like")
-OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
-OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
-OUDSIcon(asset: Image("ic_heart"), flipped: true, accessibilityLabel: "Back")
+```
+icon: Image("x")                  →  OUDSImage(asset: Image("x"))
+flipIcon: true                    →  OUDSImage(asset:, flipped: true)          [omit if false]
+renderingMode: .original          →  OUDSImage(asset:, renderingMode: .original) [omit if .template]
 ```
 
-**After (v2.3.0)**:
-```swift
-OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like")
-OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
-OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
-OUDSImage(asset: Image("ic_heart"), flipped: true, accessibilityLabel: "Back")
-```
-
-**Action**: Global find-and-replace `OUDSIcon(` → `OUDSImage(`.
-
-### 2. `OUDSButton` — initialisers with `icon:` deprecated
-
-Four `OUDSButton` initialisers that accepted a bare `Image` with separate `flipIcon`, `renderingMode` and `accessibilityLabel` parameters are deprecated.
-Migrate by wrapping the image and its configuration into a single `OUDSImage` value.
-
-**Parameter mapping**:
-
-| Old parameter on `OUDSButton` | New location |
-|---|---|
-| `icon: Image("ic_x")` | `image: OUDSImage(asset: Image("ic_x"))` |
-| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit entirely if `false` (default) |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit entirely if `.template` (default) |
-| `accessibilityLabel: "Label"` | `OUDSImage(asset:, accessibilityLabel: "Label")` |
-| `accessibilityLabel: LocalizedStringKey("key"), bundle: B` | `OUDSImage(asset:, accessibilityLabel: LocalizedStringKey("key"), bundle: B)` |
-
-#### Case A — text + icon, String label
-
-**Before (v2.2.0)**:
-```swift
-OUDSButton(text: "Like", icon: Image("ic_heart"), appearance: .default) {}
-OUDSButton(text: "Back", icon: Image("ic_chevron"), flipIcon: true, renderingMode: .original, appearance: .strong) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSButton(text: "Like", image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
-OUDSButton(text: "Back", image: OUDSImage(asset: Image("ic_chevron"), flipped: true, renderingMode: .original), appearance: .strong) {}
-```
-
-#### Case B — text + icon, LocalizedStringKey
-
-**Before (v2.2.0)**:
-```swift
-OUDSButton(LocalizedStringKey("action_like"), icon: Image("ic_heart"), appearance: .default) {}
-OUDSButton(LocalizedStringKey("go_back"), tableName: "Nav", bundle: Bundle.module,
-           icon: Image("ic_chevron"), flipIcon: true, appearance: .minimal) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSButton(LocalizedStringKey("action_like"), image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
-OUDSButton(LocalizedStringKey("go_back"), tableName: "Nav", bundle: Bundle.module,
-           image: OUDSImage(asset: Image("ic_chevron"), flipped: true), appearance: .minimal) {}
-```
-
-#### Case C — icon only, String accessibility label
-
-**Before (v2.2.0)**:
-```swift
-OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) {}
-OUDSButton(icon: Image("ic_share"), accessibilityLabel: "Share", renderingMode: .original, appearance: .strong) {}
-```
-
-**After (v2.3.0)**:
-```swift
-// accessibilityLabel moves into OUDSImage
-OUDSButton(image: OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like"), appearance: .default) {}
-OUDSButton(image: OUDSImage(asset: Image("ic_share"), accessibilityLabel: "Share", renderingMode: .original), appearance: .strong) {}
-```
-
-#### Case D — icon only, LocalizedStringKey accessibility label
-
-**Before (v2.2.0)**:
-```swift
-OUDSButton(icon: Image("ic_heart"),
-           accessibilityLabel: LocalizedStringKey("like_icon"),
-           bundle: Bundle.module,
-           appearance: .default) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSButton(image: OUDSImage(asset: Image("ic_heart"),
-                            accessibilityLabel: LocalizedStringKey("like_icon"),
-                            bundle: Bundle.module),
-           appearance: .default) {}
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `image: OUDSImage(asset: Image(…))`.
-2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Move `accessibilityLabel:` (String or LocalizedStringKey) and optional `bundle:` into `OUDSImage`.
-5. Remove the now-unused `flipIcon`, `renderingMode` and `accessibilityLabel` parameters from the `OUDSButton` call site.
-
----
-
-### 3. `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate` and `OUDSCheckboxPickerData` — initialisers with `icon:` deprecated
-
-Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
-Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
-
-**Parameter mapping** (applies to all three types):
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
-| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-#### OUDSCheckboxItem — String and LocalizedStringKey
-
-**Before (v2.2.0)**:
-```swift
-OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
-OUDSCheckboxItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
-OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
-OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
-                 icon: Image(decorative: "ic_heart"), renderingMode: .original)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSCheckboxItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
-OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
-OUDSCheckboxItem("Label", isOn: $isOn,
-                 icon: OUDSImage(asset: Image(systemName: "chevron.right"),
-                                 flipped: layoutDirection == .rightToLeft))
-OUDSCheckboxItem(LocalizedStringKey("agree_terms"), bundle: Bundle.module, isOn: $isOn,
-                 icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
-```
-
-#### OUDSCheckboxItemIndeterminate
-
-**Before (v2.2.0)**:
-```swift
-OUDSCheckboxItemIndeterminate("Label", selection: $state, icon: Image(decorative: "ic_heart"))
-OUDSCheckboxItemIndeterminate("Label", selection: $state,
-                               icon: Image(decorative: "il_brand"), renderingMode: .original,
-                               flipIcon: true)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSCheckboxItemIndeterminate("Label", selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
-OUDSCheckboxItemIndeterminate("Label", selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "il_brand"),
-                                               flipped: true, renderingMode: .original))
-// New in v2.3.0: LocalizedStringKey variant now available
-OUDSCheckboxItemIndeterminate(LocalizedStringKey("select_all"), bundle: Bundle.module,
-                               selection: $state,
-                               icon: OUDSImage(asset: Image(decorative: "ic_heart")))
-```
-
-#### OUDSCheckboxPickerData
-
-**Before (v2.2.0)**:
-```swift
-OUDSCheckboxPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
-OUDSCheckboxPickerData(tag: "b", label: "Option B",
-                       icon: Image(decorative: "il_brand"), renderingMode: .original)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSCheckboxPickerData(tag: "a", label: "Option A",
-                       icon: OUDSImage(asset: Image(systemName: "flame")))
-OUDSCheckboxPickerData(tag: "b", label: "Option B",
-                       icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
-
-### 4. `OUDSRadioItem` and `OUDSRadioPickerData` — initialisers with `icon:` deprecated
-
-Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
-Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
-
-**Parameter mapping** (applies to both types):
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
-| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-#### OUDSRadioItem — String and LocalizedStringKey
-
-**Before (v2.2.0)**:
-```swift
-OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
-OUDSRadioItem("Label", isOn: $isOn, icon: Image(decorative: "il_brand"), renderingMode: .original)
-OUDSRadioItem("Label", isOn: $isOn,
-              icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
-OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
-              icon: Image(decorative: "ic_heart"), renderingMode: .original)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSRadioItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
-OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
-OUDSRadioItem("Label", isOn: $isOn,
-              icon: OUDSImage(asset: Image(systemName: "chevron.right"),
-                              flipped: layoutDirection == .rightToLeft))
-OUDSRadioItem(LocalizedStringKey("option_label"), bundle: Bundle.module, isOn: $isOn,
-              icon: OUDSImage(asset: Image(decorative: "ic_heart"), renderingMode: .original))
-```
-
-#### OUDSRadioPickerData
-
-**Before (v2.2.0)**:
-```swift
-OUDSRadioPickerData(tag: "a", label: "Option A", icon: Image(systemName: "flame"))
-OUDSRadioPickerData(tag: "b", label: "Option B", icon: Image(decorative: "il_brand"))
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSRadioPickerData(tag: "a", label: "Option A",
-                    icon: OUDSImage(asset: Image(systemName: "flame")))
-OUDSRadioPickerData(tag: "b", label: "Option B",
-                    icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
-
-### 5. `OUDSSwitchItem` — initialisers with `icon:` deprecated
-
-Initialisers that accepted a bare `Image` with separate `flipIcon` and `renderingMode` parameters are deprecated.
-Migrate by wrapping the image and its configuration into a single `OUDSImage?` value.
-
-**Parameter mapping**:
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image("ic_x")` | `icon: OUDSImage(asset: Image("ic_x"))` |
-| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-**Before (v2.2.0)**:
-```swift
-OUDSSwitchItem("Label", isOn: $isOn, icon: Image(decorative: "ic_heart"))
-OUDSSwitchItem("Label", isOn: $isOn,
-               icon: Image(decorative: "il_brand"), renderingMode: .original)
-OUDSSwitchItem("Label", isOn: $isOn,
-               icon: Image(systemName: "chevron.right"), flipIcon: layoutDirection == .rightToLeft)
-OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
-               icon: Image(decorative: "ic_wifi"), renderingMode: .original)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSSwitchItem("Label", isOn: $isOn, icon: OUDSImage(asset: Image(decorative: "ic_heart")))
-OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "il_brand"), renderingMode: .original))
-OUDSSwitchItem("Label", isOn: $isOn,
-               icon: OUDSImage(asset: Image(systemName: "chevron.right"),
-                               flipped: layoutDirection == .rightToLeft))
-OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: $isOn,
-               icon: OUDSImage(asset: Image(decorative: "ic_wifi"), renderingMode: .original))
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
-
-### 6. `OUDSFilterChip` and `OUDSSuggestionChip` — initialisers with `icon: Image` deprecated
-
-Initialisers accepting a bare `Image` with a separate `renderingMode` are deprecated.
-
-> **Note**: Unlike other components, chips do **not** support `flipIcon`. The `accessibilityLabel` parameter stays on the chip itself — do not move it into `OUDSImage`.
-
-**Parameter mapping**:
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-**Before (v2.2.0)**:
-```swift
-OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") {}
-OUDSSuggestionChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
-OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") {}
-OUDSSuggestionChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
-
-OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) {}
-OUDSFilterChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
-OUDSFilterChip(icon: Image("ic_heart"), text: "Heart", selected: true) {}
-OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
-OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
-
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
-OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-3. Remove the now-unused `renderingMode` parameter from the chip call site.
-4. Leave `accessibilityLabel` as a separate parameter on the chip — do not set it on `OUDSImage`.
-
-### 7. `OUDSChipPickerData.Layout` — new static factories for OUDSImage
-
-`@frozen` is preserved. Two static factory methods have been added to accept `OUDSImage` directly.
-The existing cases still compile and remain valid.
-
-**Before (v2.2.0)** — case-based form:
-```swift
-OUDSChipPickerData(tag: .x, layout: .icon(icon: Image("ic_heart"), accessibilityLabel: "Heart"))
-OUDSChipPickerData(tag: .y, layout: .icon(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original))
-OUDSChipPickerData(tag: .z, layout: .textAndIcon("Label", icon: Image("ic_heart")))
-OUDSChipPickerData(tag: .w, layout: .textAndIcon("Brand", icon: Image("ic_brand"), renderingMode: .original))
-```
-
-**After (v2.3.0)** — preferred form using static factories:
-```swift
-OUDSChipPickerData(tag: .x, layout: .icon(OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart"))
-OUDSChipPickerData(tag: .y, layout: .icon(OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand"))
-OUDSChipPickerData(tag: .z, layout: .textAndIcon("Label", image: OUDSImage(asset: Image("ic_heart"))))
-OUDSChipPickerData(tag: .w, layout: .textAndIcon("Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
-```
-
-**Required action**: Migrate to the static factory form when convenient. The old form still compiles.
-
-### 8. `OUDSTag.Status` — factories with `icon: Image` deprecated
-
-The static factories `OUDSTag.Status.neutral(icon:flipIcon:renderingMode:)` and `OUDSTag.Status.accent(icon:flipIcon:renderingMode:)` are deprecated.
-
-> Only these two factories are affected. All others (`.positive`, `.negative`, `.warning`, `.info`, `.neutral(bullet:)`, `.accent(bullet:)`) are unchanged.
-
-**Parameter mapping**:
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image(…)` | `OUDSImage(asset: Image(…))` |
-| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-**Before (v2.2.0)**:
-```swift
-OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
-OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
-OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
-OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: .original))
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
-OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
-OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the factory call.
-
-### 9. `OUDSLink` — initialisers with `icon: Image` deprecated
-
-The two `OUDSLink` initialisers that accepted a bare `Image` with a separate `renderingMode` are deprecated.
-
-> Navigation initialisers (`init(text:indicator:…)` and `init(_:…:indicator:…)`) are **unchanged**.
-> `OUDSLink` does not support `flipIcon` for custom icons — only back/next indicators flip automatically for RTL.
-
-**Parameter mapping**:
-
-| Old parameter | New location |
-|---|---|
-| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
-| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
-
-**Before (v2.2.0)**:
-```swift
-OUDSLink(text: "Learn more", icon: Image("ic_heart"), size: .default) {}
-OUDSLink(text: "Brand", icon: Image("ic_brand"), renderingMode: .original, size: .default) {}
-OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
-         icon: Image("ic_heart"), size: .default) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
-OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
-OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
-         icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
-```
-
-**Required action**:
-1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
-2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-3. Remove the now-unused `renderingMode` parameter from the call site.
-
-### 10. `OUDSTextInput` and `OUDSTextInput.TrailingAction` — `icon:` / `leadingIcon:` deprecated
-
-#### OUDSTextInput — leadingIcon
-
-**Parameter mapping**:
-
-| Old parameter | New location |
-|---|---|
-| `leadingIcon: Image(…)` | `leadingIcon: OUDSImage(asset: Image(…))` |
-| `flipLeadingIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` |
-| `leadingIconRenderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` |
-
-**Before (v2.2.0)**:
-```swift
-OUDSTextInput(label: "Email", text: $text, leadingIcon: Image(systemName: "envelope"))
-OUDSTextInput(label: "Brand", text: $text, leadingIcon: Image("ic_brand"), leadingIconRenderingMode: .original)
-OUDSTextInput(label: "Label", text: $text, leadingIcon: Image("ic"), flipLeadingIcon: true)
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSTextInput(label: "Email", text: $text, leadingIcon: OUDSImage(asset: Image(systemName: "envelope")))
-OUDSTextInput(label: "Brand", text: $text, leadingIcon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original))
-OUDSTextInput(label: "Label", text: $text, leadingIcon: OUDSImage(asset: Image("ic"), flipped: true))
-```
-
-#### OUDSTextInput.TrailingAction
-
-**Before (v2.2.0)**:
-```swift
-OUDSTextInput.TrailingAction(icon: Image("ic_cross"), actionHint: "Delete") { text = "" }
-OUDSTextInput.TrailingAction(icon: Image("ic_brand"), actionHint: "Brand", renderingMode: .original) {}
-OUDSTextInput.TrailingAction(icon: Image("ic"), actionHint: "Hint", flipIcon: true) {}
-```
-
-**After (v2.3.0)**:
-```swift
-OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_cross")), actionHint: "Delete") { text = "" }
-OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), actionHint: "Brand") {}
-OUDSTextInput.TrailingAction(icon: OUDSImage(asset: Image("ic"), flipped: true), actionHint: "Hint") {}
-```
-
-**Required action**:
-1. Replace `leadingIcon: Image(…)` with `leadingIcon: OUDSImage(asset: Image(…))`.
-2. Move `flipLeadingIcon:` → `OUDSImage(asset:, flipped:)` (omit if `false`).
-3. Move `leadingIconRenderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
-4. Replace `TrailingAction(icon: Image(…), …)` with `TrailingAction(icon: OUDSImage(asset: Image(…)), …)`.
-5. Move `flipIcon:` and `renderingMode:` inside the `OUDSImage` for `TrailingAction`.
+### OUDSIcon → OUDSImage
+
+`OUDSIcon` is a deprecated typealias. Global find-and-replace: `OUDSIcon(` → `OUDSImage(`.
+
+### Components index
+
+| Component | Old params removed | New param | Notes |
+|---|---|---|---|
+| `OUDSButton` | `icon:`, `flipIcon:`, `renderingMode:`, `accessibilityLabel:` | `image: OUDSImage` | `accessibilityLabel` moves **into** `OUDSImage` |
+| `OUDSCheckboxItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | — |
+| `OUDSCheckboxItemIndeterminate` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | New `LocalizedStringKey` init added |
+| `OUDSCheckboxPickerData` | `icon: Image?`, `renderingMode:` | `icon: OUDSImage?` | — |
+| `OUDSRadioItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | — |
+| `OUDSRadioPickerData` | `icon: Image?` | `icon: OUDSImage?` | — |
+| `OUDSSwitchItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | `isReversed` defaults to `true` |
+| `OUDSFilterChip` / `OUDSSuggestionChip` | `icon: Image`, `renderingMode:` | `icon: OUDSImage` | No `flipIcon`; `accessibilityLabel` **stays on chip** |
+| `OUDSChipPickerData.Layout` | cases `.icon(icon: Image, …)` / `.textAndIcon(icon: Image, …)` | static factories `.icon(OUDSImage, accessibilityLabel:)` / `.textAndIcon(_, image: OUDSImage)` | Old cases still compile |
+| `OUDSTag.Status` | `neutral/accent(icon: Image, flipIcon:, renderingMode:)` | `neutral/accent(icon: OUDSImage)` | Deprecated static factories; other status unchanged |
+| `OUDSLink` | `icon: Image?`, `renderingMode:` | `icon: OUDSImage?` | No `flipIcon`; navigation inits unchanged |
+| `OUDSTextInput` | `leadingIcon: Image?`, `flipLeadingIcon:`, `leadingIconRenderingMode:` | `leadingIcon: OUDSImage?` | — |
+| `OUDSTextInput.TrailingAction` | `icon: Image`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage` | — |
 
 ---
 
 ## Verification checklist
 
-After completing all transformations, run:
-
 ```bash
-# Build — must succeed with zero errors
 swift build
 
-# Deprecation warnings — must return no OUDS-related lines
 swift build 2>&1 | grep -i "deprecated" | grep -iv "apple\|system\|swift\|foundation"
 
-# Residual deprecated or removed symbols — must return no results
 grep -rn \
   "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
   --include="*.swift" .
 
-# Tests — must pass
 swift test
 ```

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -171,18 +171,55 @@ renderingMode: .original          →  OUDSImage(asset:, renderingMode: .origina
 | Component | Old params removed | New param | Notes |
 |---|---|---|---|
 | `OUDSButton` | `icon:`, `flipIcon:`, `renderingMode:`, `accessibilityLabel:` | `image: OUDSImage` | `accessibilityLabel` moves **into** `OUDSImage` |
-| `OUDSCheckboxItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | — |
-| `OUDSCheckboxItemIndeterminate` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | New `LocalizedStringKey` init added |
-| `OUDSCheckboxPickerData` | `icon: Image?`, `renderingMode:` | `icon: OUDSImage?` | — |
-| `OUDSRadioItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | — |
-| `OUDSRadioPickerData` | `icon: Image?` | `icon: OUDSImage?` | — |
-| `OUDSSwitchItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage?` | `isReversed` defaults to `true` |
-| `OUDSFilterChip` / `OUDSSuggestionChip` | `icon: Image`, `renderingMode:` | `icon: OUDSImage` | No `flipIcon`; `accessibilityLabel` **stays on chip** |
-| `OUDSChipPickerData.Layout` | cases `.icon(icon: Image, …)` / `.textAndIcon(icon: Image, …)` | static factories `.icon(OUDSImage, accessibilityLabel:)` / `.textAndIcon(_, image: OUDSImage)` | Old cases still compile |
+| `OUDSCheckboxItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `image: OUDSImage?` | Renamed `icon:` → `image:` to resolve init ambiguity |
+| `OUDSCheckboxItemIndeterminate` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `image: OUDSImage?` | New `LocalizedStringKey` init added; renamed `icon:` → `image:` |
+| `OUDSCheckboxPickerData` | `icon: Image?`, `renderingMode:` | `image: OUDSImage?` | Renamed `icon:` → `image:` to resolve init ambiguity |
+| `OUDSRadioItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `image: OUDSImage?` | Renamed `icon:` → `image:` to resolve init ambiguity |
+| `OUDSRadioPickerData` | `icon: Image?` | `image: OUDSImage?` | Renamed `icon:` → `image:`; active init uses positional `_ tag` (no label), deprecated uses named `tag:` |
+| `OUDSSwitchItem` | `icon: Image?`, `flipIcon:`, `renderingMode:` | `image: OUDSImage?` | `isReversed` defaults to `true`; renamed `icon:` → `image:` |
+| `OUDSFilterChip` | `icon: Image`, `renderingMode:` | `image: OUDSImage` | Renamed `icon:` → `image:`; no `flipIcon`; `accessibilityLabel` **stays on chip** |
+| `OUDSSuggestionChip` | `icon: Image`, `renderingMode:` | `image: OUDSImage` (LocalizedStringKey text variant) / `icon: OUDSImage` (3 other variants) | No `flipIcon`; `icon:` label kept where `OUDSImage`/`Image` distinction prevents ambiguity |
+| `OUDSChipPickerData.Layout` | cases `.icon(icon: Image, …)` / `.textAndIcon(icon: Image, …)` — still available | static factories `.icon(OUDSImage, accessibilityLabel:)` / `.textAndIcon(_, image: OUDSImage)` | — |
 | `OUDSTag.Status` | `neutral/accent(icon: Image, flipIcon:, renderingMode:)` | `neutral/accent(icon: OUDSImage)` | Deprecated static factories; other status unchanged |
-| `OUDSLink` | `icon: Image?`, `renderingMode:` | `icon: OUDSImage?` | No `flipIcon`; navigation inits unchanged |
-| `OUDSTextInput` | `leadingIcon: Image?`, `flipLeadingIcon:`, `leadingIconRenderingMode:` | `leadingIcon: OUDSImage?` | — |
-| `OUDSTextInput.TrailingAction` | `icon: Image`, `flipIcon:`, `renderingMode:` | `icon: OUDSImage` | — |
+| `OUDSLink` | `icon: Image?`, `renderingMode:` | `image: OUDSImage?` | Renamed `icon:` → `image:` to resolve init ambiguity; navigation inits unchanged |
+| `OUDSTextInput` | `leadingIcon: Image?`, `flipLeadingIcon:`, `leadingIconRenderingMode:` | `leadingImage: OUDSImage?` | Renamed `leadingIcon:` → `leadingImage:` to resolve init ambiguity |
+| `OUDSTextInput.TrailingAction` | `icon: Image`, `flipIcon:`, `renderingMode:` | `image: OUDSImage` | — |
+
+### ⚠ Residual init ambiguity — workaround
+
+Even after the `icon:` → `image:` / `leadingIcon:` → `leadingImage:` rename, a call site that omits the image parameter entirely can still trigger a Swift compile-time ambiguity error, because the deprecated initialisers (`icon: Image? = nil`) and the active initialisers (`image: OUDSImage? = nil`) both match a call with no image argument at all.
+
+**Symptom**: `error: ambiguous use of 'init(...)'` on a component call with no image argument.
+
+**Fix**: Pass the image parameter explicitly as `nil` to force resolution toward the active init:
+
+| Component | Add this to the call site |
+|---|---|
+| `OUDSCheckboxItem` | `image: nil` |
+| `OUDSCheckboxItemIndeterminate` | `image: nil` |
+| `OUDSCheckboxPickerData` | `image: nil` |
+| `OUDSRadioItem` | `image: nil` |
+| `OUDSSwitchItem` | `image: nil` |
+| `OUDSLink` | `image: nil` |
+| `OUDSTextInput` | `leadingImage: nil` |
+
+```swift
+// ❌ ambiguous while deprecated inits coexist:
+OUDSCheckboxItem("Label", isOn: $isOn)
+OUDSRadioItem("Label", isOn: $isOn)
+OUDSSwitchItem("Label", isOn: $isOn)
+OUDSLink(text: "Learn more", size: .default) {}
+OUDSTextInput(label: "Email", text: $text)
+
+// ✅ unambiguous — active init selected:
+OUDSCheckboxItem("Label", isOn: $isOn, image: nil)
+OUDSRadioItem("Label", isOn: $isOn, image: nil)
+OUDSSwitchItem("Label", isOn: $isOn, image: nil)
+OUDSLink(text: "Learn more", image: nil, size: .default) {}
+OUDSTextInput(label: "Email", text: $text, leadingImage: nil)
+```
+
+This workaround is only needed until the deprecated initialisers are removed in v3.
 
 ---
 
@@ -194,8 +231,15 @@ swift build
 swift build 2>&1 | grep -i "deprecated" | grep -iv "apple\|system\|swift\|foundation"
 
 grep -rn \
-  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
+  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|leadingIcon: Image\|flipIcon\|renderingMode:\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
   --include="*.swift" .
+
+# Detect old active-init parameter labels that were renamed (v2.3.0 disambiguation).
+# Note: OUDSSuggestionChip and OUDSTag.Status legitimately use icon: OUDSImage — filter them out:
+grep -rn \
+  "icon: OUDSImage\|leadingIcon: OUDSImage" \
+  --include="*.swift" . \
+  | grep -v "OUDSSuggestionChip\|OUDSTag"
 
 swift test
 ```

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -22,7 +22,7 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData` and `OUDSSwitchItem` initialisers with `icon:` deprecated |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip` and `OUDSSuggestionChip` initialisers with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
 
 ---
 
@@ -711,6 +711,74 @@ OUDSSwitchItem(LocalizedStringKey("wifi_setting"), bundle: Bundle.module, isOn: 
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the call site.
+
+### 6. `OUDSFilterChip` and `OUDSSuggestionChip` — initialisers with `icon: Image` deprecated
+
+Initialisers accepting a bare `Image` with a separate `renderingMode` are deprecated.
+
+> **Note**: Unlike other components, chips do **not** support `flipIcon`. The `accessibilityLabel` parameter stays on the chip itself — do not move it into `OUDSImage`.
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSSuggestionChip(icon: Image("ic_heart"), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
+OUDSSuggestionChip(icon: Image("ic_heart"), text: "Heart") {}
+OUDSSuggestionChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
+
+OUDSFilterChip(icon: Image("ic_heart"), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original) {}
+OUDSFilterChip(icon: Image("ic_heart"), text: "Heart", selected: true) {}
+OUDSFilterChip(icon: Image("ic_brand"), text: "Brand", renderingMode: .original) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart") {}
+OUDSSuggestionChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart", selected: true) {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand") {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_heart")), text: "Heart", selected: true) {}
+OUDSFilterChip(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), text: "Brand") {}
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+3. Remove the now-unused `renderingMode` parameter from the chip call site.
+4. Leave `accessibilityLabel` as a separate parameter on the chip — do not set it on `OUDSImage`.
+
+### 7. `OUDSChipPickerData.Layout` — new static factories for OUDSImage
+
+`@frozen` is preserved. Two static factory methods have been added to accept `OUDSImage` directly.
+The existing cases still compile and remain valid.
+
+**Before (v2.2.0)** — case-based form:
+```swift
+OUDSChipPickerData(tag: .x, layout: .icon(icon: Image("ic_heart"), accessibilityLabel: "Heart"))
+OUDSChipPickerData(tag: .y, layout: .icon(icon: Image("ic_brand"), accessibilityLabel: "Brand", renderingMode: .original))
+OUDSChipPickerData(tag: .z, layout: .textAndIcon("Label", icon: Image("ic_heart")))
+OUDSChipPickerData(tag: .w, layout: .textAndIcon("Brand", icon: Image("ic_brand"), renderingMode: .original))
+```
+
+**After (v2.3.0)** — preferred form using static factories:
+```swift
+OUDSChipPickerData(tag: .x, layout: .icon(OUDSImage(asset: Image("ic_heart")), accessibilityLabel: "Heart"))
+OUDSChipPickerData(tag: .y, layout: .icon(OUDSImage(asset: Image("ic_brand"), renderingMode: .original), accessibilityLabel: "Brand"))
+OUDSChipPickerData(tag: .z, layout: .textAndIcon("Label", image: OUDSImage(asset: Image("ic_heart"))))
+OUDSChipPickerData(tag: .w, layout: .textAndIcon("Brand", image: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+```
+
+**Required action**: Migrate to the static factory form when convenient. The old form still compiles.
 
 ---
 

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -22,7 +22,7 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip` and `OUDSSuggestionChip` initialisers with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
 
 ---
 
@@ -779,6 +779,42 @@ OUDSChipPickerData(tag: .w, layout: .textAndIcon("Brand", image: OUDSImage(asset
 ```
 
 **Required action**: Migrate to the static factory form when convenient. The old form still compiles.
+
+### 8. `OUDSTag.Status` — factories with `icon: Image` deprecated
+
+The static factories `OUDSTag.Status.neutral(icon:flipIcon:renderingMode:)` and `OUDSTag.Status.accent(icon:flipIcon:renderingMode:)` are deprecated.
+
+> Only these two factories are affected. All others (`.positive`, `.negative`, `.warning`, `.info`, `.neutral(bullet:)`, `.accent(bullet:)`) are unchanged.
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `OUDSImage(asset: Image(…))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart")))
+OUDSTag(label: "Label", status: .neutral(icon: Image(decorative: "ic_heart"), flipIcon: true))
+OUDSTag(label: "Label", status: .neutral(icon: Image("ic_brand"), renderingMode: .original))
+OUDSTag(label: "Label", status: .accent(icon: Image("ic_brand"), renderingMode: .original))
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"))))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image(decorative: "ic_heart"), flipped: true)))
+OUDSTag(label: "Label", status: .neutral(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original)))
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the factory call.
 
 ---
 

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -22,7 +22,7 @@ It covers all breaking changes, removed APIs and deprecated symbols introduced i
 | v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
-| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; `OUDSButton`, `OUDSCheckboxItem`, `OUDSCheckboxItemIndeterminate`, `OUDSCheckboxPickerData`, `OUDSRadioItem`, `OUDSRadioPickerData`, `OUDSSwitchItem`, `OUDSFilterChip`, `OUDSSuggestionChip`, `OUDSLink` initialisers and `OUDSTag.Status` factories with `icon:` deprecated; `OUDSChipPickerData.Layout` new static factories |
 
 ---
 
@@ -815,6 +815,41 @@ OUDSTag(label: "Label", status: .accent(icon: OUDSImage(asset: Image("ic_brand")
 2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
 3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
 4. Remove the now-unused `flipIcon` and `renderingMode` parameters from the factory call.
+
+### 9. `OUDSLink` — initialisers with `icon: Image` deprecated
+
+The two `OUDSLink` initialisers that accepted a bare `Image` with a separate `renderingMode` are deprecated.
+
+> Navigation initialisers (`init(text:indicator:…)` and `init(_:…:indicator:…)`) are **unchanged**.
+> `OUDSLink` does not support `flipIcon` for custom icons — only back/next indicators flip automatically for RTL.
+
+**Parameter mapping**:
+
+| Old parameter | New location |
+|---|---|
+| `icon: Image(…)` | `icon: OUDSImage(asset: Image(…))` |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit if `.template` (default) |
+
+**Before (v2.2.0)**:
+```swift
+OUDSLink(text: "Learn more", icon: Image("ic_heart"), size: .default) {}
+OUDSLink(text: "Brand", icon: Image("ic_brand"), renderingMode: .original, size: .default) {}
+OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
+         icon: Image("ic_heart"), size: .default) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSLink(text: "Learn more", icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+OUDSLink(text: "Brand", icon: OUDSImage(asset: Image("ic_brand"), renderingMode: .original), size: .default) {}
+OUDSLink(LocalizedStringKey("learn_more"), bundle: Bundle.module,
+         icon: OUDSImage(asset: Image("ic_heart")), size: .default) {}
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `icon: OUDSImage(asset: Image(…))`.
+2. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+3. Remove the now-unused `renderingMode` parameter from the call site.
 
 ---
 

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -1,0 +1,549 @@
+---
+name: ouds-ios-migration
+description: Use when the user wants to migrate OUDS iOS code from an older version (1.0.0 or later) to the current version (2.3.0 or higher), or when deprecated or removed OUDS APIs are detected in the codebase
+license: MIT
+---
+
+# Skill: ouds-ios-migration
+
+This skill provides step-by-step guidance to migrate OUDS iOS code from **v1.0.0** up to **v2.3.0** (current).
+It covers all breaking changes, removed APIs and deprecated symbols introduced in each release.
+
+---
+
+## Quick-reference: what changed, when
+
+| From → To | Impact | Key changes |
+|---|---|---|
+| v1.0.0 → v1.1.0 | High | `Multiple*Tokens` (plural) → `Multiple*Token` (singular); button border tokens shortened |
+| v1.1.0 → v1.2.0 | High | Theme renamed: `OrangeBusinessTools` → `OrangeCompact` |
+| v1.2.0 → v1.3.0 | Low | `oudsVerticalSizeClass` removed; `OUDSBulletList.UnorderedIcon` → `UnorderedAsset` |
+| v1.3.0 → v1.4.0 | Low | `ouds`-prefixed `View` extension methods removed; `OUDSTabBar(selected:)` → `(selectedTab:)` |
+| v1.4.0 → v2.0.0 | High | Token renames (colors, elevations, sizes, badge, bar); charts provider renamed; toolbar action type enriched |
+| v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
+| v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
+| v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; four `OUDSButton` initialisers with `icon:` deprecated |
+
+---
+
+## Migration workflow
+
+For each migration task, follow this sequence:
+
+1. **Detect** — grep the target codebase for deprecated or removed symbols (commands provided per section below).
+2. **Transform** — apply the before/after substitutions listed in the relevant section.
+3. **Build** — run `swift build` and confirm zero errors.
+4. **Check warnings** — run `swift build 2>&1 | grep -i deprecated` and confirm zero OUDS deprecation warnings.
+5. **Test** — run the test suite (`swift test`) to confirm no regressions.
+
+---
+
+## Detection grep commands
+
+Run these from the project root to find all occurrences before starting:
+
+```bash
+# All active deprecations (v2.x era)
+grep -rn \
+  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|spacePaddingBlockDensityCompactTopAlignmentTopText_container" \
+  --include="*.swift" .
+
+# Breaking changes removed in v2.0.0 (v1.x era)
+grep -rn \
+  "oudsVerticalSizeClass\|UnorderedIcon\|\.free(\|OUDSTabBar(selected:\|\.ouds[A-Z]\|Multiple.*Tokens\b\|OrangeBusinessTools\|buttonBorderRadius\|buttonBorderWidth" \
+  --include="*.swift" .
+```
+
+---
+
+## v1.0.0 → v1.1.0 — Breaking changes
+
+### 1. `Multiple*Tokens` (plural) → `Multiple*Token` (singular)
+
+**Before (v1.0.0)**:
+```swift
+MultipleElevationCompositeRawTokens
+MultipleColorSemanticTokens
+MultipleFontCompositeSemanticTokens
+MultipleFontLetterSpacingSemanticTokens
+MultipleFontLineHeightSemanticTokens
+MultipleFontSizeSemanticTokens
+MultipleSizeSemanticTokens
+MultipleSpaceSemanticTokens
+```
+
+**After (v1.1.0)**:
+```swift
+MultipleElevationCompositeRawToken
+MultipleColorSemanticToken
+MultipleFontCompositeSemanticToken
+MultipleFontLetterSpacingSemanticToken
+MultipleFontLineHeightSemanticToken
+MultipleFontSizeSemanticToken
+MultipleSizeSemanticToken
+MultipleSpaceSemanticToken
+```
+
+**Action**: Global rename — remove the trailing `s` from each type name.
+
+### 2. Button border component tokens shortened
+
+**Before (v1.0.0)**:
+```swift
+theme.button.buttonBorderRadiusDefault
+theme.button.buttonBorderRadiusRounded
+theme.button.buttonBorderRadiusSocial
+theme.button.buttonBorderWidthDefault
+theme.button.buttonBorderWidthDefaultInteraction
+theme.button.buttonBorderWidthDefaultInteractionMono
+```
+
+**After (v1.1.0)**:
+```swift
+theme.button.borderRadiusDefault
+theme.button.borderRadiusRounded
+theme.button.borderRadiusSocial
+theme.button.borderWidthDefault
+theme.button.borderWidthDefaultInteraction
+theme.button.borderWidthDefaultInteractionMono
+```
+
+**Action**: Remove the `button` prefix from each token name.
+
+---
+
+## v1.1.0 → v1.2.0 — Breaking changes
+
+### Theme renamed: OrangeBusinessTools → OrangeCompact
+
+**Before (v1.1.0)**:
+```swift
+import OUDSThemeOrangeBusinessTools
+// …
+OUDSThemeableView(theme: OrangeBusinessToolsTheme()) { … }
+```
+
+**After (v1.2.0)**:
+```swift
+import OUDSThemeOrangeCompact
+// …
+OUDSThemeableView(theme: OrangeCompactTheme()) { … }
+```
+
+**Action**:
+1. Replace import `OUDSThemeOrangeBusinessTools` → `OUDSThemeOrangeCompact`.
+2. Replace all occurrences of `OrangeBusinessToolsTheme` → `OrangeCompactTheme`.
+3. Replace any string or identifier containing `OrangeBusinessTools` → `OrangeCompact` (documentation, test names, etc.).
+
+---
+
+## v1.2.0 → v1.3.0 — Breaking changes
+
+### 1. `oudsVerticalSizeClass` removed
+
+**Before (v1.2.0)**:
+```swift
+@Environment(\.oudsVerticalSizeClass) var sizeClass
+```
+
+**After (v1.3.0)**:
+```swift
+// Remove entirely — the property no longer exists.
+// Note: reintroduced in v1.4.0; wait for that version if you need it.
+```
+
+**Action**: Remove all uses of `oudsVerticalSizeClass`.
+
+### 2. `OUDSBulletList.UnorderedIcon` → `OUDSBulletList.UnorderedAsset`; `.free` → `.icon`
+
+**Before (v1.2.0)**:
+```swift
+var bullet: OUDSBulletList.UnorderedIcon { .free(someImage) }
+```
+
+**After (v1.3.0)**:
+```swift
+var bullet: OUDSBulletList.UnorderedAsset { .icon(someImage) }
+```
+
+**Action**:
+1. Rename `OUDSBulletList.UnorderedIcon` → `OUDSBulletList.UnorderedAsset`.
+2. Rename case `.free(…)` → `.icon(…)`.
+
+---
+
+## v1.3.0 → v1.4.0 — Breaking changes
+
+### 1. `ouds`-prefixed `View` extension methods removed
+
+All `ouds`-prefixed methods were removed. Replace each with its unprefixed counterpart:
+
+| Removed | Replacement |
+|---|---|
+| `.oudsForegroundStyle(_:)` | `.foregroundStyle(_:)` |
+| `.oudsForegroundColor(_:)` | `.foregroundColor(_:)` |
+| `.oudsBackground(_:)` | `.background(_:)` |
+| `.oudsAccentColor(_:)` | `.accentColor(_:)` |
+| `.oudsShadow(_:)` | `.shadow(_:)` |
+| `.oudsBorder(style:width:radius:color:)` | `.border(style:width:radius:color:)` |
+| `.oudsColoredSurface(_:)` | `.coloredSurface(_:)` |
+| `.oudsGridMargin(_:)` | `.gridMargin(_:)` |
+| `.oudsRequestAccessibleFocus(_:)` | `.requestAccessibleFocus(_:)` |
+| `.oudsRequestAccessibleFocus(_:for:)` | `.requestAccessibleFocus(_:for:)` |
+| `.oudsHorizontalDivider(dividerColor:)` | `.horizontal(color:)` |
+| `.oudsVerticalDivider(color:)` | `.vertical(color:)` |
+
+**Action**: Replace each `ouds`-prefixed call with its unprefixed counterpart.
+
+### 2. `OUDSTabBar(selected:count:content:)` → `OUDSTabBar(selectedTab:count:content:)`
+
+**Before (v1.3.x)**:
+```swift
+OUDSTabBar(selected: 0, count: 3) {
+    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
+}
+```
+
+**After (v1.4.0)**:
+```swift
+@State private var selectedTab = 0
+
+OUDSTabBar(selectedTab: $selectedTab, count: 3) {
+    SomeView().tabItem { Label("Home", image: "ic_home") }.tag(0)
+}
+```
+
+**Action**:
+1. Rename parameter label `selected:` → `selectedTab:`.
+2. Declare `@State private var selectedTab: Int` and pass it as `$selectedTab`.
+
+---
+
+## v1.4.0 → v2.0.0 — Breaking changes
+
+### 1. Renamed semantic tokens — colors
+
+| Old name | New name |
+|---|---|
+| `repositorySecondaryHigher` | `repositorySecondaryHigherHigh` |
+| `overlayModalLight` | `overlayModalSheetLight` |
+| `overlayModalDark` | `overlayModalSheetDark` |
+| `overlayModal` | `overlayModalSheet` |
+
+### 2. Renamed semantic tokens — elevations
+
+| Old name | New name |
+|---|---|
+| `xDefault` | `xElevated` |
+| `yDefault` | `yElevated` |
+| `blurDefault` | `blurElevated` |
+| `spreadDefault` | `spreadElevated` |
+| `colorDefaultLight` | `colorElevatedLight` |
+| `colorDefaultDark` | `colorElevatedDark` |
+
+### 3. Renamed semantic tokens — sizes (remove "Type")
+
+Pattern: `maxWidthType` → `maxWidth` for all typography size tokens.
+
+| Old name | New name |
+|---|---|
+| `maxWidthTypeDisplayLargeMobile` | `maxWidthDisplayLargeMobile` |
+| `maxWidthTypeDisplayLargeTablet` | `maxWidthDisplayLargeTablet` |
+| `maxWidthTypeDisplayMediumMobile` | `maxWidthDisplayMediumMobile` |
+| `maxWidthTypeDisplayMediumTablet` | `maxWidthDisplayMediumTablet` |
+| `maxWidthTypeDisplaySmallMobile` | `maxWidthDisplaySmallMobile` |
+| `maxWidthTypeDisplaySmallTablet` | `maxWidthDisplaySmallTablet` |
+| `maxWidthTypeHeadingXlargeMobile` | `maxWidthHeadingXlargeMobile` |
+| `maxWidthTypeHeadingXlargeTablet` | `maxWidthHeadingXlargeTablet` |
+| `maxWidthTypeHeadingLargeMobile` | `maxWidthHeadingLargeMobile` |
+| `maxWidthTypeHeadingLargeTablet` | `maxWidthHeadingLargeTablet` |
+| `maxWidthTypeHeadingMediumMobile` | `maxWidthHeadingMediumMobile` |
+| `maxWidthTypeHeadingMediumTablet` | `maxWidthHeadingMediumTablet` |
+| `maxWidthTypeHeadingSmallMobile` | `maxWidthHeadingSmallMobile` |
+| `maxWidthTypeHeadingSmallTablet` | `maxWidthHeadingSmallTablet` |
+| `maxWidthTypeBodyLargeMobile` | `maxWidthBodyLargeMobile` |
+| `maxWidthTypeBodyLargeTablet` | `maxWidthBodyLargeTablet` |
+| `maxWidthTypeBodyMediumMobile` | `maxWidthBodyMediumMobile` |
+| `maxWidthTypeBodyMediumTablet` | `maxWidthBodyMediumTablet` |
+| `maxWidthTypeBodySmallMobile` | `maxWidthBodySmallMobile` |
+| `maxWidthTypeBodySmallTablet` | `maxWidthBodySmallTablet` |
+| `maxWidthTypeLabelXlargeMobile` | `maxWidthLabelXlargeMobile` |
+| `maxWidthTypeLabelXlargeTablet` | `maxWidthLabelXlargeTablet` |
+| `maxWidthTypeLabelLargeMobile` | `maxWidthLabelLargeMobile` |
+| `maxWidthTypeLabelLargeTablet` | `maxWidthLabelLargeTablet` |
+| `maxWidthTypeLabelMediumMobile` | `maxWidthLabelMediumMobile` |
+| `maxWidthTypeLabelMediumTablet` | `maxWidthLabelMediumTablet` |
+| `maxWidthTypeLabelSmallMobile` | `maxWidthLabelSmallMobile` |
+| `maxWidthTypeLabelSmallTablet` | `maxWidthLabelSmallTablet` |
+
+### 4. Renamed component tokens — badge
+
+| Old name | New name |
+|---|---|
+| `spaceInset` | `spaceInsetMediumLarge` |
+
+### 5. Renamed component tokens — bar (ActiveIndicator → CurrentIndicator)
+
+| Old name | New name |
+|---|---|
+| `colorActiveIndicatorCustomSelectedEnabled` | `colorCurrentIndicatorCustomSelectedEnabled` |
+| `colorActiveIndicatorCustomSelectedHover` | `colorCurrentIndicatorCustomSelectedHover` |
+| `colorActiveIndicatorCustomSelectedPressed` | `colorCurrentIndicatorCustomSelectedPressed` |
+| `colorActiveIndicatorCustomSelectedFocus` | `colorCurrentIndicatorCustomSelectedFocus` |
+| `opacityActiveIndicatorCustom` | `opacityCurrentIndicatorCustom` |
+| `borderRadiusActiveIndicatorCustomTop` | `borderRadiusCurrentIndicatorCustomTop` |
+| `borderRadiusActiveIndicatorCustomBottom` | `borderRadiusCurrentIndicatorCustomBottom` |
+| `sizeWidthActiveIndicatorCustomTop` | `sizeWidthCurrentIndicatorCustomTop` |
+| `sizeWidthActiveIndicatorCustomBottom` | `sizeWidthCurrentIndicatorCustomBottom` |
+
+### 6. Removed tokens
+
+| Removed symbol | Action |
+|---|---|
+| Raw token `blur160` | Remove all uses |
+| Raw token `opacityGrayLight80800` | Remove all uses |
+| Semantic tokens `actionAccentLight`, `actionAccentDark`, `actionAccent` | Remove; use `colorAccent` bar component tokens if relevant |
+| Radio component token `sizeIndicator` | Use `controlItem.sizeControlIndicator` instead |
+| Checkbox component token `sizeIndicator` | Use `controlItem.sizeControlIndicator` instead |
+| Control item tokens: `sizeMaxHeihtAssetsContainer`, `sizeLoader`, `sizeErrorIcon`, `borderRadiusItemOnly`, `colorBgHover*`, `colorBgFocus*`, `colorBgPressed*`, `colorBgLoading*`, `colorContentLoader*`, `spacePaddingInlineErrorIcon*` | Remove all uses |
+
+### 7. Charts color token provider renamed
+
+**Before (v1.4.x)**:
+```swift
+theme.charts.someColorToken
+```
+
+**After (v2.0.0)**:
+```swift
+theme.colorsCharts.someColorToken
+```
+
+**Action**: Replace `theme.charts.` → `theme.colorsCharts.`.
+
+### 8. `OUDSToolBarItem.ActionType` — new `badgeType` parameter in `icon` case
+
+If you pattern-match on the `.icon` case, add a slot for `badgeType`:
+
+**Before (v1.4.x)**:
+```swift
+case .icon(let asset, let accessibilityLabel):
+    …
+```
+
+**After (v2.0.0)**:
+```swift
+case .icon(let asset, let accessibilityLabel, let badgeType):
+    …
+```
+
+---
+
+## v2.0.0 → v2.1.0 — Deprecated symbols
+
+### Component token renamed (ControlItem)
+
+**Before (v2.0.0)**:
+```swift
+theme.controlItem.spacePaddingBlockDensityCompactTopAlignmentTopText_container
+```
+
+**After (v2.1.0)**:
+```swift
+theme.controlItem.spacePaddingBlockDensityCompactTopAlignmentTopTextContainer
+```
+
+**Action**: Replace the underscore form with the camelCase form.
+
+---
+
+## v2.0.0 → v2.2.0 — Deprecated symbols
+
+### `OUDSBadge` split into three dedicated components
+
+`OUDSBadge` is deprecated. Identify which variant you are using from the call site and replace it.
+
+**Detection**: search for `OUDSBadge(` in your Swift files.
+
+**Identification rule**:
+- Call has `count:` parameter → use `OUDSBadgeCount`
+- Call has a `status:` whose associated value carries an `icon:` (i.e. `StatusWithIcon`) → use `OUDSBadgeIcon`
+- Otherwise → use `OUDSBadgeStandard`
+
+#### Standard badge (no count, no icon in status)
+
+**Before (v2.0.0)**:
+```swift
+OUDSBadge(accessibilityLabel: "New", status: .accent, size: .small)
+OUDSBadge(accessibilityLabel: LocalizedStringKey("new_badge"), bundle: Bundle.module, status: .neutral, size: .medium)
+```
+
+**After (v2.2.0)**:
+```swift
+OUDSBadgeStandard(accessibilityLabel: "New", status: .accent, size: .small)
+OUDSBadgeStandard(accessibilityLabel: LocalizedStringKey("new_badge"), bundle: Bundle.module, status: .neutral, size: .medium)
+```
+
+#### Count badge
+
+**Before (v2.0.0)**:
+```swift
+OUDSBadge(count: 9, accessibilityLabel: "9 messages", status: .negative, size: .large)
+OUDSBadge(count: 3, accessibilityLabel: LocalizedStringKey("badge_count"), bundle: Bundle.module, status: .neutral, size: .medium)
+```
+
+**After (v2.2.0)**:
+```swift
+// count becomes the first unlabelled argument
+OUDSBadgeCount(9, accessibilityLabel: "9 messages", status: .negative, size: .large)
+OUDSBadgeCount(3, accessibilityLabel: LocalizedStringKey("badge_count"), bundle: Bundle.module, status: .neutral, size: .medium)
+```
+
+> `count` must be of type `UInt8`.
+
+#### Icon badge
+
+**Before (v2.0.0)**:
+```swift
+OUDSBadge(status: .info(icon: Image("ic_info")), accessibilityLabel: "Info", size: .medium)
+OUDSBadge(status: .warning(icon: Image("ic_warn")), accessibilityLabel: LocalizedStringKey("badge_warn"), bundle: Bundle.module, size: .small)
+```
+
+**After (v2.2.0)**:
+```swift
+OUDSBadgeIcon(status: .info(icon: Image("ic_info")), accessibilityLabel: "Info", size: .medium)
+OUDSBadgeIcon(status: .warning(icon: Image("ic_warn")), accessibilityLabel: LocalizedStringKey("badge_warn"), bundle: Bundle.module, size: .small)
+```
+
+---
+
+## v2.2.0 → v2.3.0 — Deprecated symbols
+
+### 1. `OUDSIcon` → `OUDSImage`
+
+`OUDSIcon` is a deprecated typealias for `OUDSImage`. The initialiser signature is identical.
+
+**Before (v2.2.0)**:
+```swift
+OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like")
+OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+OUDSIcon(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+OUDSIcon(asset: Image("ic_heart"), flipped: true, accessibilityLabel: "Back")
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like")
+OUDSImage(asset: Image("ic_heart"), accessibilityLabel: LocalizedStringKey("like_icon"), bundle: Bundle.module)
+OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like", renderingMode: .original)
+OUDSImage(asset: Image("ic_heart"), flipped: true, accessibilityLabel: "Back")
+```
+
+**Action**: Global find-and-replace `OUDSIcon(` → `OUDSImage(`.
+
+### 2. `OUDSButton` — initialisers with `icon:` deprecated
+
+Four `OUDSButton` initialisers that accepted a bare `Image` with separate `flipIcon`, `renderingMode` and `accessibilityLabel` parameters are deprecated.
+Migrate by wrapping the image and its configuration into a single `OUDSImage` value.
+
+**Parameter mapping**:
+
+| Old parameter on `OUDSButton` | New location |
+|---|---|
+| `icon: Image("ic_x")` | `image: OUDSImage(asset: Image("ic_x"))` |
+| `flipIcon: true` | `OUDSImage(asset:, flipped: true)` — omit entirely if `false` (default) |
+| `renderingMode: .original` | `OUDSImage(asset:, renderingMode: .original)` — omit entirely if `.template` (default) |
+| `accessibilityLabel: "Label"` | `OUDSImage(asset:, accessibilityLabel: "Label")` |
+| `accessibilityLabel: LocalizedStringKey("key"), bundle: B` | `OUDSImage(asset:, accessibilityLabel: LocalizedStringKey("key"), bundle: B)` |
+
+#### Case A — text + icon, String label
+
+**Before (v2.2.0)**:
+```swift
+OUDSButton(text: "Like", icon: Image("ic_heart"), appearance: .default) {}
+OUDSButton(text: "Back", icon: Image("ic_chevron"), flipIcon: true, renderingMode: .original, appearance: .strong) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSButton(text: "Like", image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
+OUDSButton(text: "Back", image: OUDSImage(asset: Image("ic_chevron"), flipped: true, renderingMode: .original), appearance: .strong) {}
+```
+
+#### Case B — text + icon, LocalizedStringKey
+
+**Before (v2.2.0)**:
+```swift
+OUDSButton(LocalizedStringKey("action_like"), icon: Image("ic_heart"), appearance: .default) {}
+OUDSButton(LocalizedStringKey("go_back"), tableName: "Nav", bundle: Bundle.module,
+           icon: Image("ic_chevron"), flipIcon: true, appearance: .minimal) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSButton(LocalizedStringKey("action_like"), image: OUDSImage(asset: Image("ic_heart")), appearance: .default) {}
+OUDSButton(LocalizedStringKey("go_back"), tableName: "Nav", bundle: Bundle.module,
+           image: OUDSImage(asset: Image("ic_chevron"), flipped: true), appearance: .minimal) {}
+```
+
+#### Case C — icon only, String accessibility label
+
+**Before (v2.2.0)**:
+```swift
+OUDSButton(icon: Image("ic_heart"), accessibilityLabel: "Like", appearance: .default) {}
+OUDSButton(icon: Image("ic_share"), accessibilityLabel: "Share", renderingMode: .original, appearance: .strong) {}
+```
+
+**After (v2.3.0)**:
+```swift
+// accessibilityLabel moves into OUDSImage
+OUDSButton(image: OUDSImage(asset: Image("ic_heart"), accessibilityLabel: "Like"), appearance: .default) {}
+OUDSButton(image: OUDSImage(asset: Image("ic_share"), accessibilityLabel: "Share", renderingMode: .original), appearance: .strong) {}
+```
+
+#### Case D — icon only, LocalizedStringKey accessibility label
+
+**Before (v2.2.0)**:
+```swift
+OUDSButton(icon: Image("ic_heart"),
+           accessibilityLabel: LocalizedStringKey("like_icon"),
+           bundle: Bundle.module,
+           appearance: .default) {}
+```
+
+**After (v2.3.0)**:
+```swift
+OUDSButton(image: OUDSImage(asset: Image("ic_heart"),
+                            accessibilityLabel: LocalizedStringKey("like_icon"),
+                            bundle: Bundle.module),
+           appearance: .default) {}
+```
+
+**Required action**:
+1. Replace `icon: Image(…)` with `image: OUDSImage(asset: Image(…))`.
+2. Move `flipIcon: Bool` → `OUDSImage(asset:, flipped:)` (omit if `false`).
+3. Move `renderingMode:` → `OUDSImage(asset:, renderingMode:)` (omit if `.template`).
+4. Move `accessibilityLabel:` (String or LocalizedStringKey) and optional `bundle:` into `OUDSImage`.
+5. Remove the now-unused `flipIcon`, `renderingMode` and `accessibilityLabel` parameters from the `OUDSButton` call site.
+
+---
+
+## Verification checklist
+
+After completing all transformations, run:
+
+```bash
+# Build — must succeed with zero errors
+swift build
+
+# Deprecation warnings — must return no OUDS-related lines
+swift build 2>&1 | grep -i "deprecated" | grep -iv "apple\|system\|swift\|foundation"
+
+# Residual deprecated or removed symbols — must return no results
+grep -rn \
+  "OUDSBadge\b\|OUDSIcon\b\|icon: Image\|flipIcon\|spacePaddingBlockDensityCompactTopAlignmentTopText_container\|buttonBorderRadius\|buttonBorderWidth\|Multiple.*Tokens\b\|OrangeBusinessTools\|oudsVerticalSizeClass\|UnorderedIcon\|\.ouds[A-Z]" \
+  --include="*.swift" .
+
+# Tests — must pass
+swift test
+```


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1511 

### Description

<!-- Describe your changes in detail -->
Update API, doc, skills and components to use rendering mode for image to let use apply template mode (for tinted icons) or original mode (for raw image mode).

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
