### PR TITLE
[#1576] Add option for `link` full width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)
 - Component tokens for `accordions`, `progress indicators` and `typography` components (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 - Semantic tokens of `colors` dedicated to AI (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579) 
 - Components tokens for `list item` (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -23,6 +23,7 @@ struct LinkButtonStyle: ButtonStyle {
 
     let layout: OUDSLink.Layout
     let size: OUDSLink.Size
+    let isFullWidth: Bool
 
     @State private var isHover: Bool
     @Environment(\.theme) private var theme
@@ -30,9 +31,10 @@ struct LinkButtonStyle: ButtonStyle {
 
     // MARK: Initializer
 
-    init(layout: OUDSLink.Layout, size: OUDSLink.Size) {
+    init(layout: OUDSLink.Layout, size: OUDSLink.Size, isFullWidth: Bool) {
         self.layout = layout
         self.size = size
+        self.isFullWidth = isFullWidth
         isHover = false
     }
 
@@ -44,7 +46,7 @@ struct LinkButtonStyle: ButtonStyle {
             switch layout {
             case let .indicator(indicator):
                 configuration.label
-                    .labelStyle(LinkIndicatorLabelStyle(interactionState: interactionState, size: size, indicator: indicator))
+                    .labelStyle(LinkIndicatorLabelStyle(interactionState: interactionState, size: size, indicator: indicator, isFullWidth: isFullWidth))
             case .textOnly:
                 configuration.label
                     .labelStyle(LinkTextAndIconLabelStyle(interactionState: interactionState, size: size, layout: layout))
@@ -56,6 +58,8 @@ struct LinkButtonStyle: ButtonStyle {
         .padding(.horizontal, theme.link.spacePaddingInline)
         .padding(.vertical, theme.link.spacePaddingBlockDefault)
         .frame(minWidth: minWidth, minHeight: minHeight)
+        .frame(maxWidth: isFullWidth ? .infinity : nil)
+        .contentShape(Rectangle())
         #if !os(watchOS) && !os(tvOS)
             .onHover { isHover in
                 self.isHover = isHover
@@ -83,6 +87,7 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
     let interactionState: OUDSButtonInteractionState
     let size: OUDSLink.Size
     let indicator: OUDSLink.Indicator
+    let isFullWidth: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         HStack(alignment: .center, spacing: spacing) {
@@ -90,6 +95,10 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
                 configuration.icon
                     .modifier(LinkSizeIconModifier(size: size))
                     .modifier(LinkColorIndicatorModifier(interactionState: interactionState))
+
+                if isFullWidth {
+                    Spacer(minLength: 0)
+                }
             }
 
             configuration.title
@@ -97,15 +106,24 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
                 .modifier(LinkColorContentModifier(interactionState: interactionState))
 
             if indicator == .next {
+                if isFullWidth {
+                    Spacer(minLength: 0)
+                }
+
                 configuration.icon
                     .modifier(LinkSizeIconModifier(size: size))
                     .modifier(LinkColorIndicatorModifier(interactionState: interactionState))
             }
         }
+        .frame(minWidth: indicatorMinWidth)
     }
 
     private var spacing: Double {
         size == .small ? theme.link.spaceColumnGapChevronSmall : theme.link.spaceColumnGapChevronDefault
+    }
+
+    private var indicatorMinWidth: Double {
+        size == .small ? theme.link.sizeMinWidthSmall : theme.link.sizeMinWidth
     }
 }
 

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -115,15 +115,10 @@ private struct LinkIndicatorLabelStyle: LabelStyle {
                     .modifier(LinkColorIndicatorModifier(interactionState: interactionState))
             }
         }
-        .frame(minWidth: indicatorMinWidth)
     }
 
     private var spacing: Double {
         size == .small ? theme.link.spaceColumnGapChevronSmall : theme.link.spaceColumnGapChevronDefault
-    }
-
-    private var indicatorMinWidth: Double {
-        size == .small ? theme.link.sizeMinWidthSmall : theme.link.sizeMinWidth
     }
 }
 

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -195,7 +195,7 @@ public struct OUDSLink: View {
     ///   When `OUDSLink.Indicator.next`, the indicator is displayed after the text.
     ///   - size: Size of the link
     ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
-    ///   The label stays anchored to the leading edge and the indicator to the trailing edge.
+    ///   The label stays anchored to the an edge and the indicator to the other edge.
     ///   Defaults to `false` (intrinsic sizing).
     ///   - action: The action to perform when the user triggers the link
     public init(text: String, indicator: Indicator, size: Size = .default, isFullWidth: Bool = false, action: @escaping () -> Void) {
@@ -219,7 +219,7 @@ public struct OUDSLink: View {
     ///   - indicator: Indicator displayed in the link
     ///   - size: Size of the link
     ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
-    ///   The label stays anchored to the leading edge and the indicator to the trailing edge.
+    ///   The label stays anchored to one edge and the indicator to the other edge.
     ///   Defaults to `false` (intrinsic sizing).
     ///   - action: The action to perform when the user triggers the link
     public init(_ key: LocalizedStringKey,

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -48,6 +48,9 @@ import SwiftUI
 ///
 ///     // Navigate to previous page with link in a default size
 ///     OUDSLink(text: "Back", indicator: .back, size: .default) { /* the action to process */ }
+///
+///     // Full-width: label stays, chevron anchored to the right / left
+///     OUDSLink(text: "See all", indicator: .next, isFullWidth: true) { /* the action to process */ }
 /// ```
 ///
 /// ## Colored Surface
@@ -86,6 +89,7 @@ public struct OUDSLink: View {
     private let layout: Layout
     private let text: String
     private let size: Size
+    private let isFullWidth: Bool
     private let action: () -> Void
 
     @Environment(\.theme) private var theme
@@ -136,6 +140,7 @@ public struct OUDSLink: View {
         layout = image.map { .textAndIcon($0) } ?? .textOnly
         self.text = text
         self.size = size
+        isFullWidth = false
         self.action = action
     }
 
@@ -166,10 +171,11 @@ public struct OUDSLink: View {
                 size: Size = .default,
                 action: @escaping () -> Void)
     {
-        self.init(text: key.resolved(tableName: tableName, bundle: bundle),
-                  image: image,
-                  size: size,
-                  action: action)
+        layout = image.map { .textAndIcon($0) } ?? .textOnly
+        text = key.resolved(tableName: tableName, bundle: bundle)
+        self.size = size
+        isFullWidth = false
+        self.action = action
     }
 
     // MARK: - Initializers — indicator (unchanged)
@@ -188,11 +194,15 @@ public struct OUDSLink: View {
     ///   When `OUDSLink.Indicator.back`, the indicator is displayed before the text.
     ///   When `OUDSLink.Indicator.next`, the indicator is displayed after the text.
     ///   - size: Size of the link
+    ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
+    ///   The label stays anchored to the leading edge and the indicator to the trailing edge.
+    ///   Defaults to `false` (intrinsic sizing).
     ///   - action: The action to perform when the user triggers the link
-    public init(text: String, indicator: Indicator, size: Size = .default, action: @escaping () -> Void) {
+    public init(text: String, indicator: Indicator, size: Size = .default, isFullWidth: Bool = false, action: @escaping () -> Void) {
         layout = .indicator(indicator)
         self.text = text
         self.size = size
+        self.isFullWidth = isFullWidth
         self.action = action
     }
 
@@ -208,17 +218,22 @@ public struct OUDSLink: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - indicator: Indicator displayed in the link
     ///   - size: Size of the link
+    ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
+    ///   The label stays anchored to the leading edge and the indicator to the trailing edge.
+    ///   Defaults to `false` (intrinsic sizing).
     ///   - action: The action to perform when the user triggers the link
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 indicator: Indicator,
                 size: Size = .default,
+                isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
         layout = .indicator(indicator)
         text = key.resolved(tableName: tableName, bundle: bundle)
         self.size = size
+        self.isFullWidth = isFullWidth
         self.action = action
     }
 
@@ -256,7 +271,7 @@ public struct OUDSLink: View {
                 }
             }
         }
-        .buttonStyle(LinkButtonStyle(layout: layout, size: size))
+        .buttonStyle(LinkButtonStyle(layout: layout, size: size, isFullWidth: isFullWidth))
         .accessibilityRemoveTraits(.isButton)
         .accessibilityAddTraits(.isLink)
     }

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -509,12 +509,12 @@ OUDSLink(text: "Text", size: .default) {}
 OUDSLink(text: "Text", indicator: .back, size: .default) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic")), size: .default) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
-// Full-width indicator: label leading, indicator trailing, entire width is tappable
+// Full-width indicator: label in one edge, indicator in the other edge, entire width is tappable
 OUDSLink(text: "Text", indicator: .next, isFullWidth: true, size: .default) {}
 OUDSLink(text: "Text", indicator: .back, isFullWidth: true, size: .default) {}
 ```
 
-> `isFullWidth` is only available on `indicator` layouts (`.back` / `.next`). When `true`, the link stretches to fill all available horizontal width — the label anchors to the leading edge and the indicator to the trailing edge. The entire width between them is tappable. Defaults to `false` (intrinsic sizing).
+> `isFullWidth` is only available on `indicator` layouts (`.back` / `.next`). When `true`, the link stretches to fill all available horizontal width — the label anchors to the leading/trailong edge and the indicator to the trailing/leading edge. The entire width between them is tappable. Defaults to `false` (intrinsic sizing).
 
 ---
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -509,7 +509,12 @@ OUDSLink(text: "Text", size: .default) {}
 OUDSLink(text: "Text", indicator: .back, size: .default) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic")), size: .default) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
+// Full-width indicator: label leading, indicator trailing, entire width is tappable
+OUDSLink(text: "Text", indicator: .next, isFullWidth: true, size: .default) {}
+OUDSLink(text: "Text", indicator: .back, isFullWidth: true, size: .default) {}
 ```
+
+> `isFullWidth` is only available on `indicator` layouts (`.back` / `.next`). When `true`, the link stretches to fill all available horizontal width — the label anchors to the leading edge and the indicator to the trailing edge. The entire width between them is tappable. Defaults to `false` (intrinsic sizing).
 
 ---
 


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1576 

### Description

<!-- Describe your changes in detail -->
Add boolean parameter (default set to false) to let link component take all the availablz width.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let link take all the width or not

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
