### PR TITLE
[#1597] Add `view modifier` for additional a11y traits for `text area` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)
 - Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)
 - Component tokens for `accordions`, `progress indicators` and `typography` components (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 - Semantic tokens of `colors` dedicated to AI (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579) 

--- a/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaInputText.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextArea/Internal/TextAreaInputText.swift
@@ -29,6 +29,7 @@ struct TextAreaInputText: View {
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.additionalTraits) private var additionalTraits
 
     // MARK: - Body
 
@@ -56,6 +57,7 @@ struct TextAreaInputText: View {
                 .padding(EdgeInsets(top: -8, leading: -5, bottom: -8, trailing: 0))
                 .frame(minHeight: theme.textArea.sizeMinHeightInput)
                 .frame(maxHeight: constrainedMaxHeight ? theme.textArea.sizeMinHeightInput : theme.textArea.sizeMaxHeightInput)
+                .accessibilityAddTraits(additionalTraits)
         }
     }
 

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibilityTraitsModifier/OUDSComponentAccessibilityTraitsModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibilityTraitsModifier/OUDSComponentAccessibilityTraitsModifier.swift
@@ -1,0 +1,70 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+// MARK: - Environment values
+
+extension EnvironmentValues {
+
+    /// Some accessibility traits to add in specific parts of some compatible OUDS components.
+    @Entry var additionalTraits: AccessibilityTraits = []
+}
+
+// MARK: - OUDS Component Accessibility Traits Modifier
+
+/// `ViewModifier` that propagates accessibility traits down the environment so that
+/// specific parts of some compatible OUDS components can get additional accessibility traits.
+///
+/// Prefer the convenience methods on `View`:
+/// - ``View/oudsAccessibilityAddTraits(_:)-single``
+/// - ``View/oudsAccessibilityAddTraits(_:)-array``
+struct OUDSComponentAccessibilityTraitsModifier: ViewModifier {
+
+    let traits: AccessibilityTraits
+
+    func body(content: Content) -> some View {
+        content.environment(\.additionalTraits, traits)
+    }
+}
+
+// MARK: - View extension
+
+extension View {
+
+    /// Adds one accessibility trait to add to any compatible OUDS components in the view subtree.
+    ///
+    /// ```swift
+    /// OUDSTextArea(label: "Title", text: $text)
+    ///     .oudsAccessibilityAddTraits(.isHeader) // Will add "header" trait to text editor
+    /// ```
+    ///
+    /// - Parameter trait: The `AccessibilityTraits` value to add.
+    /// - Returns: A view that sets the given trait on the inner text editor.
+    public func oudsAccessibilityAddTraits(_ trait: AccessibilityTraits) -> some View {
+        modifier(OUDSComponentAccessibilityTraitsModifier(traits: trait))
+    }
+
+    /// Adds multiple accessibility traits to add to any compatible OUDS components in the view subtree.
+    ///
+    /// ```swift
+    /// OUDSTextArea(label: "Title", text: $text)
+    ///     .oudsAccessibilityAddTraits([.isHeader, .updatesFrequently]) // Will traits to text editor
+    /// ```
+    ///
+    /// - Parameter traits: An array of `AccessibilityTraits` values to add.
+    /// - Returns: A view that sets the union of the given traits on the inner text editor.
+    public func oudsAccessibilityAddTraits(_ traits: [AccessibilityTraits]) -> some View {
+        modifier(OUDSComponentAccessibilityTraitsModifier(traits: traits.reduce(into: AccessibilityTraits()) { $0.formUnion($1) }))
+    }
+}

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibilityTraitsModifier/OUDSComponentAccessibilityTraitsModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/AccessibilityTraitsModifier/OUDSComponentAccessibilityTraitsModifier.swift
@@ -34,7 +34,7 @@ struct OUDSComponentAccessibilityTraitsModifier: ViewModifier {
     let traits: AccessibilityTraits
 
     func body(content: Content) -> some View {
-        content.environment(\.additionalTraits, traits)
+        content.transformEnvironment(\.additionalTraits) { $0.formUnion(traits) }
     }
 }
 
@@ -59,7 +59,7 @@ extension View {
     ///
     /// ```swift
     /// OUDSTextArea(label: "Title", text: $text)
-    ///     .oudsAccessibilityAddTraits([.isHeader, .updatesFrequently]) // Will traits to text editor
+    ///     .oudsAccessibilityAddTraits([.isHeader, .updatesFrequently]) // Will add traits to text editor
     /// ```
     ///
     /// - Parameter traits: An array of `AccessibilityTraits` values to add.


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1597 

### Description

<!-- Describe your changes in detail -->
Define view modifier and View extension to add additional traits as environment value.
Read such value for text area component and apply it on the text editor.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let user add custom traits like _isHeader_ to ease navigations with Voice Over

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
