### PR TITLE
[#1615] Fix use of icons for unordered bullet list items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BREAKING**: Components token for `icon` component  (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 - **BREAKING**: Components token for `button` component  (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 
+### Fixed
+
+- Icon assets for unordered list item not displayed (Orange-OpenSource/ouds-ios#1615)
+
 ### Removed
 
 - **BREAKING**: Deprecated `OUDSBadge` API

--- a/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/BulletListItem.swift
+++ b/OUDS/Core/Components/Sources/ContentDisplay/BulletList/Internal/BulletListItem.swift
@@ -63,7 +63,7 @@ struct BulletListItem: View {
     var body: some View {
         VStack(alignment: .leading, spacing: theme.spaces.fixedNone) {
             HStack(alignment: .top, spacing: spacing) {
-                Bullet(type: type, level: level, textStyle: textStyle, isBold: isBold, index: index)
+                Bullet(type: item.subListType ?? type, level: level, textStyle: textStyle, isBold: isBold, index: index)
                 BulletListLabel(label: item.text, textStyle: textStyle, isBold: isBold)
             }
             .accessibilityElement(children: .combine)
@@ -123,7 +123,8 @@ struct BulletListItem: View {
     }
 
     private var accessibilityLabel: String {
-        let orderedPrefix: String? = if case .ordered = type {
+        let effectiveType = item.subListType ?? type
+        let orderedPrefix: String? = if case .ordered = effectiveType {
             accessibilityLabelPrefix
         } else {
             nil


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1615 

### Description

<!-- Describe your changes in detail -->
Propagates subType elements to use icons for final item

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let user add dedicated images per item

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
