### PR TITLE
[#1561] Vocalisation of "info" status for `alert` components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- For alerts components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
 - Icon assets for unordered list item not displayed (Orange-OpenSource/ouds-ios#1615)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,8 +34,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- For alerts components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
-- Icon assets for unordered list item not displayed (Orange-OpenSource/ouds-ios#1615)
+- For `alert` components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
+- Icon assets for unordered `bullet list` item not displayed (Orange-OpenSource/ouds-ios#1615)
 
 ### Removed
 

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
@@ -88,6 +88,8 @@ struct AlertMessageContent: View {
             "core_alertMessage_warning_a11y".localized() + ","
         case .negative:
             "core_alertMessage_negative_a11y".localized() + ","
+        case .info:
+            "core_alertMessage_info_a11y".localized() + ","
         default:
             ""
         }

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/InlineAlert/InlineAlertLabel.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/InlineAlert/InlineAlertLabel.swift
@@ -55,6 +55,8 @@ struct InlineAlertLabel: View {
             "core_alertMessage_warning_a11y".localized() + ","
         case .negative:
             "core_alertMessage_negative_a11y".localized() + ","
+        case .info:
+            "core_alertMessage_info_a11y".localized() + ","
         default:
             ""
         }

--- a/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
@@ -28,6 +28,30 @@
         }
       }
     },
+    "core_alertMessage_info_a11y" : {
+      "comment" : "Component - Alerts",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "معلومة"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Information"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Information"
+          }
+        }
+      }
+    },
     "core_alertMessage_negative_a11y" : {
       "comment" : "Component - Alerts",
       "extractionState" : "manual",


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1561

### Description

<!-- Describe your changes in detail -->
Manage _info_ status to build text to vocalize

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Precise to user the content is informational

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
