### PR TITLE
[#1577] Add missing localized string for `back` button of `toolbar top` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)
 - Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)
 - Component tokens for `accordions`, `progress indicators` and `typography` components (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
-- Semantic tokens of `colors` dedicated to AI (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579) 
+- Semantic tokens of `colors` dedicated to AI (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 - Components tokens for `list item` (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 - Components tokens for `button` dedicated to AI (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)
 
@@ -34,10 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Missing "core_common_back" localized string for `back` button of `toolbar top` component (Orange-OpenSource/ouds-ios#1577)
 - For `alert` components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
 - Icon assets for unordered `bullet list` item not displayed (Orange-OpenSource/ouds-ios#1615)
-- Missing "core_common_back" localized string for `back` button of `toolbar top` component (Orange-OpenSource/ouds-ios#1577) 
-- Icon assets for unordered list item not displayed (Orange-OpenSource/ouds-ios#1615)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - For `alert` components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
 - Icon assets for unordered `bullet list` item not displayed (Orange-OpenSource/ouds-ios#1615)
+- Missing "core_common_back" localized string for `back` button of `toolbar top` component (Orange-OpenSource/ouds-ios#1577) 
+- Icon assets for unordered list item not displayed (Orange-OpenSource/ouds-ios#1615)
 
 ### Removed
 

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -141,8 +141,8 @@ public struct OUDSToolBarItem: View, Identifiable {
         /// **Warning: if OS is iOS 26+ / Liquid Glass, the label will not appear**
         ///
         ///  - Parameters:
-        ///     - label; The optional string label displayed near to the back indicator
-        ///     - accessibilityLabel: The accessibility label to describe the back action that could be overtied if needed,d efault set to *core_common_back*
+        ///     - label: The optional string label displayed near to the back indicator
+        ///     - accessibilityLabel: The accessibility label to describe the back action that could be overriden if needed, default set to *core_common_back*
         ///     - action: The action to do when clicked. If *nil* (default) the button is disabled. By default the dismiss is done after `action` is called..
         case back(label: String? = nil, accessibilityLabel: String = "core_common_back".localized(), action: (() -> Void)? = nil)
 

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -142,7 +142,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         ///
         ///  - Parameters:
         ///     - label: The optional string label displayed near to the back indicator
-        ///     - accessibilityLabel: The accessibility label to describe the back action that could be overriden if needed, default set to *core_common_back*
+        ///     - accessibilityLabel: The accessibility label to describe the back action that could be overridden if needed, default set to *core_common_back*
         ///     - action: The action to do when clicked. If *nil* (default) the button is disabled. By default the dismiss is done after `action` is called..
         case back(label: String? = nil, accessibilityLabel: String = "core_common_back".localized(), action: (() -> Void)? = nil)
 

--- a/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
@@ -478,6 +478,30 @@
         }
       }
     },
+    "core_common_back" : {
+      "comment" : "Common",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "خلف"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Back"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retour"
+          }
+        }
+      }
+    },
     "core_common_close_a11y" : {
       "comment" : "Common",
       "extractionState" : "manual",

--- a/OUDS/Core/Themes/Orange/Sources/Providers/SemanticTokens/OrangeThemeColorChartSemanticTokensProvider.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Providers/SemanticTokens/OrangeThemeColorChartSemanticTokensProvider.swift
@@ -20,7 +20,7 @@ import OUDSThemesContract
 /// This provider should be integrated as a `AllColorChartSemanticTokensProvider` implementation inside `OUDSTheme` so as to provide
 /// all tokens to the users.
 ///
-/// The tokens it exposes cannot be overriden as these colors are strongly related to the Orange brand.
+/// The tokens it exposes cannot be overridden as these colors are strongly related to the Orange brand.
 ///
 /// If you think you need to overide some colors or have your own set of colors, start a new discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/categories/q-a).
 ///

--- a/OUDS/Core/Themes/Orange/Sources/Providers/SemanticTokens/OrangeThemeColorDecorativeSemanticTokensProvider.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Providers/SemanticTokens/OrangeThemeColorDecorativeSemanticTokensProvider.swift
@@ -20,7 +20,7 @@ import OUDSThemesContract
 /// This provider should be integrated as a `AllColorDecorativeSemanticTokensProvider` implementation inside `OUDSTheme` so as to provide
 /// all tokens to the users.
 ///
-/// The tokens it exposes cannot be overriden as these colors are strongly related to the Orange brand.
+/// The tokens it exposes cannot be overridden as these colors are strongly related to the Orange brand.
 ///
 /// If you think you need to overide some colors or have your own set of colors, start a new discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/categories/q-a).
 ///

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorChartMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorChartMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for `semanticTokens` so as to pack them as light and dark modes colors.
-/// These values cannot be overriden as not specified / allowed, forbidden by design.
+/// These values cannot be overridden as not specified / allowed, forbidden by design.
 ///
 /// Helps to expose color chart semantic tokens with two values to use depending to the color scheme (*Figma* cannot manage such tokens and generate them).
 extension OrangeThemeColorChartSemanticTokensProvider: ColorChartMultipleSemanticTokens {

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorModeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorModeMultipleSemanticTokens.swift
@@ -23,7 +23,7 @@ import SwiftUI
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorModeSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values can be overriden inside `OrangeThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `OrangeThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeThemeColorModeSemanticTokensProvider: ColorModeMultipleSemanticTokens {
 
     // MARK: - Multiple tokens

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ColorMultipleSemanticTokens.swift
@@ -21,9 +21,9 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values can be overriden inside `OrangeThemeColorSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
-/// Some tokens do not have values assigned in the design system, and must be overriden.
-/// Some tokens must be overriden in `OrangeTheme` side because they rely on Orange brand colors.
+/// These values can be overridden inside `OrangeThemeColorSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// Some tokens do not have values assigned in the design system, and must be overridden.
+/// Some tokens must be overridden in `OrangeTheme` side because they rely on Orange brand colors.
 /// Helps to expose color semantic tokens with two values to use depending to the color scheme (*Figma* cannot manage such tokens and generate them).
 extension OrangeThemeColorSemanticTokensProvider: ColorMultipleSemanticTokens {
 

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ElevationCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ElevationCompositeSemanticTokens.swift
@@ -20,7 +20,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines basic values common to all themes for `ElevationCompositeSemanticTokens``.
-/// These values can be overriden inside ``OrangeThemeElevationSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``OrangeThemeElevationSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 /// The aim of this extension is to make relationships between all semantic tokens for elevations and associated raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ElevationMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+ElevationMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for elevation semantic tokens but "multiple", i.e. tokens with values depending to color schemes.
-/// These values can be overriden inside `OrangeThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `OrangeThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeThemeElevationSemanticTokensProvider: ElevationMultipleSemanticTokens {
 
     @objc open var colorElevated: ElevationMultipleColorSemanticToken { MultipleColorSemanticToken(light: colorElevatedLight, dark: colorElevatedDark) }

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontCompositeSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines basic values common to all themes for `FontCompositeSemanticToken`.
-/// These values can be overriden inside ``OrangeThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside ``OrangeThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 /// The aim of this extensions is to make relationships between all composite semantic tokens for typography / fonts and associated composite raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.
 extension OrangeThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+FontMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for font semantic tokens but "multiple", i.e. tokens with values depending to size classes or color schemes.
-/// These values can be overriden inside `OrangeThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `OrangeThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeThemeFontSemanticTokensProvider: FontMultipleSemanticTokens {
 
     // MARK: - Semantic token - Typography - Font - Size

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+SizeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+SizeMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for size semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``OrangeThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside ``OrangeThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeThemeSizeSemanticTokensProvider: SizeMultipleSemanticTokens {
 
     // MARK: - Semantic token - Sizing - Icon with typography

--- a/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+SpaceMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Orange/Sources/Values/SemanticTokens/OrangeTheme+SpaceMultipleSemanticTokens.swift
@@ -19,7 +19,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for space semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``OrangeThemeSpaceSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``OrangeThemeSpaceSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeThemeSpaceSemanticTokensProvider: SpaceMultipleSemanticTokens {
 

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Providers/SemanticTokens/OrangeCompactThemeColorChartSemanticTokensProvider.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Providers/SemanticTokens/OrangeCompactThemeColorChartSemanticTokensProvider.swift
@@ -20,7 +20,7 @@ import OUDSThemesContract
 /// This provider should be integrated as a `AllColorChartSemanticTokensProvider` implementation inside `OUDSTheme` so as to provide
 /// all tokens to the users.
 ///
-/// The tokens it exposes cannot be overriden as these colors are strongly related to the Orange brand.
+/// The tokens it exposes cannot be overridden as these colors are strongly related to the Orange brand.
 ///
 /// If you think you need to overide some colors or have your own set of colors, start a new discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/categories/q-a).
 ///

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Providers/SemanticTokens/OrangeCompactThemeColorDecorativeSemanticTokensProvider.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Providers/SemanticTokens/OrangeCompactThemeColorDecorativeSemanticTokensProvider.swift
@@ -20,7 +20,7 @@ import OUDSThemesContract
 /// This provider should be integrated as a `AllColorDecorativeSemanticTokensProvider` implementation inside `OUDSTheme` so as to provide
 /// all tokens to the users.
 ///
-/// The tokens it exposes cannot be overriden as these colors are strongly related to the Orange brand.
+/// The tokens it exposes cannot be overridden as these colors are strongly related to the Orange brand.
 ///
 /// If you think you need to overide some colors or have your own set of colors, start a new discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/categories/q-a).
 ///

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ColorChartMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ColorChartMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorChartSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values cannot be overriden as not specified / allowed, forbidden by design.
+/// These values cannot be overridden as not specified / allowed, forbidden by design.
 ///
 /// Helps to expose color chart semantic tokens with two values to use depending to the color scheme (*Figma* cannot manage such tokens and generate them).
 extension OrangeCompactThemeColorChartSemanticTokensProvider: ColorChartMultipleSemanticTokens {

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ColorModeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ColorModeMultipleSemanticTokens.swift
@@ -23,7 +23,7 @@ import SwiftUI
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorModeSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values can be overriden inside `OrangeCompactThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `OrangeCompactThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeCompactThemeColorModeSemanticTokensProvider: ColorModeMultipleSemanticTokens {
 
     // MARK: - Multiple tokens

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ElevationMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+ElevationMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for elevation semantic tokens but "multiple", i.e. tokens with values depending to color schemes.
-/// These values can be overriden inside `OrangeCompactThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `OrangeCompactThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension OrangeCompactThemeElevationSemanticTokensProvider: ElevationMultipleSemanticTokens {
 
     public var colorElevated: ElevationMultipleColorSemanticToken { MultipleColorSemanticToken(light: colorElevatedLight, dark: colorElevatedDark) }

--- a/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/OrangeCompact/Sources/Values/SemanticTokens/OrangeCompactTheme+FontCompositeSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines basic values common to all themes for `FontCompositeSemanticToken`.
-/// These values can be overriden inside ``OrangeCompactThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
+/// These values can be overridden inside ``OrangeCompactThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
 /// The aim of this extensions is to make relationships between all composite semantic tokens for typography / fonts and associated composite raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.
 extension OrangeCompactThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ColorModeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ColorModeMultipleSemanticTokens.swift
@@ -23,7 +23,7 @@ import SwiftUI
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorModeSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values can be overriden inside `SoshThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `SoshThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension SoshThemeColorModeSemanticTokensProvider: ColorModeMultipleSemanticTokens {
 
     // MARK: - Multiple tokens

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ElevationCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ElevationCompositeSemanticTokens.swift
@@ -20,7 +20,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines basic values common to all themes for `ElevationCompositeSemanticTokens``.
-/// These values can be overriden inside ``SoshThemeElevationSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``SoshThemeElevationSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 /// The aim of this extension is to make relationships between all semantic tokens for elevations and associated raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ElevationMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+ElevationMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for elevation semantic tokens but "multiple", i.e. tokens with values depending to color schemes.
-/// These values can be overriden inside `SoshThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `SoshThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension SoshThemeElevationSemanticTokensProvider: ElevationMultipleSemanticTokens {
 
     public var colorElevated: ElevationMultipleColorSemanticToken { MultipleColorSemanticToken(light: colorElevatedLight, dark: colorElevatedDark) }

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontCompositeSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines basic values common to all themes for `FontCompositeSemanticToken`.
-/// These values can be overriden inside ``SoshThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
+/// These values can be overridden inside ``SoshThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
 /// The aim of this extensions is to make relationships between all composite semantic tokens for typography / fonts and associated composite raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.
 extension SoshThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+FontMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for font semantic tokens but "multiple", i.e. tokens with values depending to size classes or color schemes.
-/// These values can be overriden inside `SoshThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `SoshThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension SoshThemeFontSemanticTokensProvider: FontMultipleSemanticTokens {
 
     // MARK: - Semantic token - Typography - Font - Size

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+SizeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+SizeMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for size semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``SoshThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside ``SoshThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension SoshThemeSizeSemanticTokensProvider: SizeMultipleSemanticTokens {
 
     // MARK: - Semantic token - Sizing - Icon with typography

--- a/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+SpaceMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Sosh/Sources/Values/SemanticTokens/SoshTheme+SpaceMultipleSemanticTokens.swift
@@ -19,7 +19,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for space semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``SoshThemeSpaceSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``SoshThemeSpaceSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension SoshThemeSpaceSemanticTokensProvider: SpaceMultipleSemanticTokens {
 

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ColorModeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ColorModeMultipleSemanticTokens.swift
@@ -23,7 +23,7 @@ import SwiftUI
 // swiftlint:disable line_length
 
 /// Defines provider objects for `ColorModeSemanticTokens` so as to pack them as light and dark modes colors.
-/// These values can be overriden inside `WireframeThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `WireframeThemeColorModeSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension WireframeThemeColorModeSemanticTokensProvider: ColorModeMultipleSemanticTokens {
 
     // MARK: - Multiple tokens

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ElevationCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ElevationCompositeSemanticTokens.swift
@@ -20,7 +20,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines basic values common to all themes for `ElevationCompositeSemanticTokens``.
-/// These values can be overriden inside ``WireframeThemeElevationSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``WireframeThemeElevationSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 /// The aim of this extension is to make relationships between all semantic tokens for elevations and associated raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ElevationMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+ElevationMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for elevation semantic tokens but "multiple", i.e. tokens with values depending to color schemes.
-/// These values can be overriden inside `WireframeThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `WireframeThemeElevationSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension WireframeThemeElevationSemanticTokensProvider: ElevationMultipleSemanticTokens {
 
     public var colorElevated: ElevationMultipleColorSemanticToken { MultipleColorSemanticToken(light: colorElevatedLight, dark: colorElevatedDark) }

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontCompositeSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontCompositeSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines basic values common to all themes for `FontCompositeSemanticToken`.
-/// These values can be overriden inside ``WireframeThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
+/// These values can be overridden inside ``WireframeThemeFontSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc public final` combination.
 /// The aim of this extensions is to make relationships between all composite semantic tokens for typography / fonts and associated composite raw tokens.
 /// The *tokenator* is not able to provide code for such "composite" objects because the *Figma* tool itself cannot manage that and does not output anything in its JSON to process.
 extension WireframeThemeFontSemanticTokensProvider: FontCompositeSemanticTokens {

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+FontMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // swiftlint:disable line_length
 
 /// Defines provider objects for font semantic tokens but "multiple", i.e. tokens with values depending to size classes or color schemes.
-/// These values can be overriden inside `WireframeThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside `WireframeThemeFontSemanticTokensProvider` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension WireframeThemeFontSemanticTokensProvider: FontMultipleSemanticTokens {
 
     // MARK: - Semantic token - Typography - Font - Size

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+SizeMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+SizeMultipleSemanticTokens.swift
@@ -21,7 +21,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for size semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``WireframeThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
+/// These values can be overridden inside ``WireframeThemeSizeSemanticTokensProvider`` subclasses (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension WireframeThemeSizeSemanticTokensProvider: SizeMultipleSemanticTokens {
 
     // MARK: - Semantic token - Sizing - Icon with typography

--- a/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+SpaceMultipleSemanticTokens.swift
+++ b/OUDS/Core/Themes/Wireframe/Sources/Values/SemanticTokens/WireframeTheme+SpaceMultipleSemanticTokens.swift
@@ -19,7 +19,7 @@ import OUDSTokensSemantic
 // Create an issue for update https://github.com/Orange-OpenSource/ouds-ios/issues/new?template=token_update.yml
 
 /// Defines provider objects for space semantic tokens (i.e. in the end `DimensionRawTokens`).
-/// These values can be overriden inside ``WireframeThemeSpaceSemanticTokensProvider`` subclasses
+/// These values can be overridden inside ``WireframeThemeSpaceSemanticTokensProvider`` subclasses
 /// (in extensions or not, in the same module or not) thanks to the `@objc open` combination.
 extension WireframeThemeSpaceSemanticTokensProvider: SpaceMultipleSemanticTokens {
 

--- a/OUDS/Core/ThemesContract/Sources/OUDSTheme/OUDSTheme.swift
+++ b/OUDS/Core/ThemesContract/Sources/OUDSTheme/OUDSTheme.swift
@@ -20,7 +20,7 @@ import OUDSTokensSemantic
 /// A Swift `class` has been used so as to allow to easily override some attributes and have inheritance, without having for developers
 /// to implement all tokens.
 /// Any properties of an overridable theme should be defined so as to provide defaults values.
-/// We allow this theme to be derivated and be overriden.
+/// We allow this theme to be derivated and be overridden.
 /// ``OUDSTheme`` can be seen as a kind of "abstract class" in _object oriented paradigm_, or *theme contract*.
 /// Because `OUDSTheme` is not a *final* class, its type cannot be seen as `Sendable`, that is the reason why this conformity is unchecked.
 ///
@@ -50,7 +50,7 @@ open class OUDSTheme: @unchecked Sendable, Equatable {
     /// All color charts semantic tokens exposed in one obejct
     ///
     /// If nil the theme does not provide color charts (like today `SoshTheme`).
-    /// In this case it cannot be used but can be overriden by local implementation of `AllColorChartSemanticTokensProvider`.
+    /// In this case it cannot be used but can be overridden by local implementation of `AllColorChartSemanticTokensProvider`.
     ///
     /// If you think your theme must have such colors, feel free to subit an issue (https://github.com/Orange-OpenSource/ouds-ios/issues)
     /// or open a discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/new?category=q-a)
@@ -59,7 +59,7 @@ open class OUDSTheme: @unchecked Sendable, Equatable {
     /// All color decorative semantic tokens exposed in one obejct
     ///
     /// If nil the theme does not provide color decorative (like today `SoshTheme`).
-    /// In this case it cannot be used but can be overriden by local implementation of `AllColorDecorativeSemanticTokensProvider`
+    /// In this case it cannot be used but can be overridden by local implementation of `AllColorDecorativeSemanticTokensProvider`
     ///
     /// If you think your theme must have such colors, feel free to subit an issue (https://github.com/Orange-OpenSource/ouds-ios/issues)
     /// or open a discussion (https://github.com/Orange-OpenSource/ouds-ios/discussions/new?category=q-a)

--- a/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Themes.md
+++ b/OUDS/Core/ThemesContract/Sources/_ThemesContract.docc/Themes.md
@@ -21,7 +21,7 @@ Theme                                                                           
 All themes are based on a theme contract called `OUDSTheme`.
 
 _Themes_ use *tokens providers* which provide the *semantic tokens* and *component tokens* to apply in the project. 
-These tokens in most of cases can be overriden thanks to `@objc open` combination so as to make possible to override these values in extensions (thanks to `@objc`) and from objects outside the module (thanks to `open`). 
+These tokens in most of cases can be overridden thanks to `@objc open` combination so as to make possible to override these values in extensions (thanks to `@objc`) and from objects outside the module (thanks to `open`). 
 Thus we can split values and responsabilities in different _Swift Package Manager_ targets and keep overriding and inheritance possible.
 
 > Important: Only one theme, the Orange theme, can be subclassed.

--- a/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
+++ b/OUDS/Core/Tokens/RawTokens/Sources/_OUDSTokensRaw.docc/OUDSTokensRaw.md
@@ -27,7 +27,7 @@ To keep the same semantics as the ones used in our *Figma* specifications, _type
 
 Using more simple and primitive types will help also to test the library. With also type aliases we force users to use our types and not higher level types like _SwiftUI_ types. Type aliases pointing to raw values will improve also to use of thes values wuthout needing to deal with intermediate types.
 
-We also choose to add in _extension_ all the tokens values in a separated file so as to help the *tokenator* to build files to copy and paste easily in the project and keeping all the other objects. In fact, declaring the tokens *enums* in separated file helps us to document the associated tokens. The tokens are defined in an extension inside dedicated file which can be overriden anytime ; the result is trasnparent for the users.
+We also choose to add in _extension_ all the tokens values in a separated file so as to help the *tokenator* to build files to copy and paste easily in the project and keeping all the other objects. In fact, declaring the tokens *enums* in separated file helps us to document the associated tokens. The tokens are defined in an extension inside dedicated file which can be overridden anytime ; the result is trasnparent for the users.
 
 Example for ``ColorRawTokens``:
 

--- a/OUDS/Core/Tokens/SemanticTokens/Sources/Values/DimensionSemanticTokens.swift
+++ b/OUDS/Core/Tokens/SemanticTokens/Sources/Values/DimensionSemanticTokens.swift
@@ -21,7 +21,7 @@
 /// It defines all ``DimensionSemanticToken`` a theme must have.
 /// Any dimension semantic token must be declared there.
 ///
-/// These dimension semantic tokens should not be overriden by design.
+/// These dimension semantic tokens should not be overridden by design.
 /// They are considered as "closed" tokens but still defined in this library so as to keep consistancy between Figma specifications
 /// and library. The tokens are not hidden from developers.
 ///


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1577 

### Description

<!-- Describe your changes in detail -->
Add missing wording key for default a11Y label of toolbar top back button

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Fix a11y issue where Voice Over vocalized wording key

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
