### PR TITLE
[#1459] Add dedicated `view modifier` to apply themes on SwiftUI TabView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `View modifier` to apply theme on Liquid Glass SwiftUI `TabView` (Orange-OpenSource/ouds-ios#1459)
 - `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)
 - Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)
 - Component tokens for `accordions`, `progress indicators` and `typography` components (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `View modifier` to apply theme on Liquid Glass SwiftUI `TabView` (Orange-OpenSource/ouds-ios#1459)
+- `View modifier` to apply theme to Liquid Glass SwiftUI `TabView` (Orange-OpenSource/ouds-ios#1459)
 - `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)
 - Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)
 - Component tokens for `accordions`, `progress indicators` and `typography` components (tokens library v2.6.0) (Orange-OpenSource/ouds-ios#1579)

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -319,7 +319,7 @@ public struct OUDSTabBar<Content: View>: View {
             TabView(selection: $selectedTab) {
                 content()
             }
-            .modifier(TabBarViewModifier())
+            .modifier(OUDSTabBarViewModifier())
 
             SelectedTabIndicator(selected: $selectedTab, count: tabCount, isTabBarHidden: $isTabBarHidden)
                 .opacity(shouldShowTabIndicator ? 1 : 0)

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
@@ -18,10 +18,13 @@ import OUDSThemesContract
 import SwiftUI
 
 /// Defines the look and feel the tab bar must have by applying the OUDS tokens.
+/// Changes only colors and typgraphies, and does not add additional items like indicator of selected tab or divider.
+/// To use these elements in your tab view, use instead ``OUDSTabBar``.
 ///
 /// ## Rendering
 ///
 /// iOS 26 brings Liquid Glass, the new Apple look and feel which will prevent developers to define specific styles for some critical components like bars.
+///
 /// Because today the OUDS tab bar relies on native component and is not designed from scratch, some elements will look different between iOS 26 and older versions:
 /// - background color of tab bar can be changed for iOS lower than 26
 /// - background color of tab bar does not change since iOS 26
@@ -31,8 +34,9 @@ import SwiftUI
 ///
 /// In addition the badges colors will be the same and cannot be changed (except with token definition). These particular badges do not rely on OUDS badge components.
 ///
+/// - Since: 3.0.0
 @available(iOS 15, *)
-struct TabBarViewModifier: ViewModifier {
+public struct OUDSTabBarViewModifier: ViewModifier {
 
     // MARK: Properties
 
@@ -44,16 +48,16 @@ struct TabBarViewModifier: ViewModifier {
 
     // MARK: Init
 
-    init() {}
+    public init() {}
 
     // MARK: Body
 
     #if os(macOS)
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
     }
     #else
-    func body(content: Content) -> some View {
+    public func body(content: Content) -> some View {
         content
             // Do not use task(), it's async, effects may be applied too late
             .onAppear {


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1459 

### Description

<!-- Describe your changes in detail -->
Open existing internal view modifier to apply style on tab view.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let people apply themes styles on `TabView` if the ney do use OUDSTabBar (missing missing features like search etc).

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [ ] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
