### PR TITLE
[#1623] Fix display of badges and use of flag for edge case of Liquid Glass setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Detection of forced legacy layout for navigations elements
 - **BREAKING**: `.neutral` and `.accent` `badge icon status` signatures
 - **BREAKING**: `.neutral` and `.accent` `alert status` parameter name
 - **BREAKING**: `.icon` and `.textAndIcon` layouts for `chip picker data` object
@@ -35,12 +36,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Missing `badges` on `toolbar top` component for app on iOS 27 with Xcode 26.5 and disabled Liquid Glass configuration (Orange-OpenSource/ouds-ios#1623)
 - Missing "core_common_back" localized string for `back` button of `toolbar top` component (Orange-OpenSource/ouds-ios#1577)
 - For `alert` components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)
 - Icon assets for unordered `bullet list` item not displayed (Orange-OpenSource/ouds-ios#1615)
 
 ### Removed
 
+- **BREAKING**: `forceOUDSLegacyTabBar` and `OUDSLegacyTabBarModifier`, for `forceOUDSLegacyLayout` and `OUDSLegacyLayoutModifier` 
 - **BREAKING**: Deprecated `OUDSBadge` API
 - **BREAKING**: Deprecated type `OUDSIcon`
 - **BREAKING**: Deprecated initializers for `button`, `checkbox`, `chips`, `radio`, `switch`, `checkbox`, `text input`, `badge`, `link`, `tag` components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Detection of forced legacy layout for navigations elements
+- Detection of forced legacy layout for navigation elements
 - **BREAKING**: `.neutral` and `.accent` `badge icon status` signatures
 - **BREAKING**: `.neutral` and `.accent` `alert status` parameter name
 - **BREAKING**: `.icon` and `.textAndIcon` layouts for `chip picker data` object
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- **BREAKING**: `forceOUDSLegacyTabBar` and `OUDSLegacyTabBarModifier`, for `forceOUDSLegacyLayout` and `OUDSLegacyLayoutModifier` 
+- **BREAKING**: `forceOUDSLegacyTabBar` and `OUDSLegacyTabBarModifier`, for `forceOUDSLegacyLayout` and `OUDSLegacyLayoutModifier`
 - **BREAKING**: Deprecated `OUDSBadge` API
 - **BREAKING**: Deprecated type `OUDSIcon`
 - **BREAKING**: Deprecated initializers for `button`, `checkbox`, `chips`, `radio`, `switch`, `checkbox`, `text input`, `badge`, `link`, `tag` components

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -224,6 +224,39 @@ To be aligned with new `OUDSImage` API, the `accent` and `neutral` `badge icon s
 
 **Reason for Change**: Use new `OUDSImage` API
 
+### Renamed layout modifier for legacy tab bar
+
+The `.forceOUDSLegacyTabBar()` view modifier and its underlying `OUDSLegacyTabBarModifier` type have been renamed to reflect a broader layout scope.
+
+**Impact**: High
+
+| Old v2 name | New v3 name |
+|---|---|
+| `forceOUDSLegacyTabBar` | `forceOUDSLegacyLayout` |
+| `OUDSLegacyTabBarModifier` | `OUDSLegacyLayoutModifier` |
+
+**Before (v2.3.0)**:
+```swift
+SomeView()
+    .forceOUDSLegacyTabBar()
+
+let modifier: OUDSLegacyTabBarModifier = ...
+```
+
+**After (v3.0.0)**:
+```swift
+SomeView()
+    .forceOUDSLegacyLayout()
+
+let modifier: OUDSLegacyLayoutModifier = ...
+```
+
+**Required Action**:
+- Replace any call to `.forceOUDSLegacyTabBar()` with `.forceOUDSLegacyLayout()`
+- Replace any reference to `OUDSLegacyTabBarModifier` with `OUDSLegacyLayoutModifier`
+
+**Reason for Change**: The modifier is no longer specific to the tab bar; it applies to the overall layout.
+
 ### Compatibility
 
 - **Backward Compatibility**: No

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -224,7 +224,7 @@ To be aligned with new `OUDSImage` API, the `accent` and `neutral` `badge icon s
 
 **Reason for Change**: Use new `OUDSImage` API
 
-### Renamed layout modifier for legacy tab bar
+### Renamed legacy layout modifier
 
 The `.forceOUDSLegacyTabBar()` view modifier and its underlying `OUDSLegacyTabBarModifier` type have been renamed to reflect a broader layout scope.
 

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -216,7 +216,7 @@ public struct OUDSTabBar<Content: View>: View {
     @State private var isTabBarHidden: Bool = false
     #endif
 
-    @Environment(\.forceOUDSLegacyTabBar) private var forceOUDSLegacyTabBar
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Initializers
@@ -359,7 +359,7 @@ public struct OUDSTabBar<Content: View>: View {
     /// Determines if the selected tab indicator should be shown, i.e. if iOS lower than 26 in portrait mode.
     private var shouldShowTabIndicator: Bool {
         #if canImport(UIKit) && !os(watchOS)
-        if forceOUDSLegacyTabBar { return true }
+        if forceOUDSLegacyLayout { return true }
         guard isLiquidGlassDisabled else { return false }
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         return !isLandscape
@@ -371,7 +371,7 @@ public struct OUDSTabBar<Content: View>: View {
     /// - Returns Bool: true if iOS lower than 26.0 for iPhone or iOS lower than 18.0 for iPad, false otherwise
     private var hasLegacyLayout: Bool {
         #if canImport(UIKit) && !os(watchOS)
-        if forceOUDSLegacyTabBar { return true }
+        if forceOUDSLegacyLayout { return true }
         // iOS < 26
         if isLiquidGlassDisabled {
             // iPhone

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
@@ -43,7 +43,7 @@ public struct OUDSTabBarViewModifier: ViewModifier {
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.verticalSizeClass) private var verticalSizeClass
-    @Environment(\.forceOUDSLegacyTabBar) private var forceOUDSLegacyTabBar
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Init
@@ -154,7 +154,7 @@ public struct OUDSTabBarViewModifier: ViewModifier {
          It could mean in dark mode the text is not readable at all.
          Thus apply the unselector color only for cases where everything works, i.e. not Liquid Glass
          */
-        if forceOUDSLegacyTabBar || isLiquidGlassDisabled { // No Liquid Glass (i.e. iOS 26 with disabled option, and iOS < 26)
+        if forceOUDSLegacyLayout || isLiquidGlassDisabled { // No Liquid Glass (i.e. iOS 26 with disabled option, and iOS < 26)
             let unselectedUIColor = themeToApply.bar.colorContentUnselectedEnabled.color(for: colorSchemeToApply).uiColor
             tabBarItemAppearance.normal.iconColor = unselectedUIColor
             tabBarItemAppearance.normal.titleTextAttributes = [
@@ -169,7 +169,7 @@ public struct OUDSTabBarViewModifier: ViewModifier {
 
         // MARK: Tab bar selected item
 
-        if forceOUDSLegacyTabBar || isLiquidGlassDisabled {
+        if forceOUDSLegacyLayout || isLiquidGlassDisabled {
             let selectedUIColor = themeToApply.bar.colorContentSelectedEnabled.color(for: colorSchemeToApply).uiColor
             tabBarItemAppearance.selected.iconColor = selectedUIColor
             tabBarItemAppearance.selected.titleTextAttributes = [

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/NavigationStackRefresher.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/NavigationStackRefresher.swift
@@ -25,6 +25,7 @@ struct NavigationStackRefresher: ViewModifier {
 
     @Environment(\.theme) private var theme: OUDSTheme
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: - Initializer
@@ -157,7 +158,7 @@ struct NavigationStackRefresher: ViewModifier {
 
         // Background and tint colors
 
-        if isLiquidGlassDisabled {
+        if isLiquidGlassDisabled || forceOUDSLegacyLayout {
             appearance.configureWithOpaqueBackground()
             appearance.backgroundColor = newTheme.bar.colorBgTranslucent.color(for: newColorScheme).uiColor
         }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItemModifiers.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItemModifiers.swift
@@ -60,6 +60,7 @@ struct ToolBarActionItemStyle: ButtonStyle {
 
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Body
@@ -68,7 +69,7 @@ struct ToolBarActionItemStyle: ButtonStyle {
         if !isEnabled {
             configuration.label.foregroundColor(theme.button.colorContentMinimalDisabled)
         } else {
-            if isLiquidGlassDisabled {
+            if isLiquidGlassDisabled || forceOUDSLegacyLayout {
                 if configuration.isPressed {
                     configuration.label.foregroundColor(theme.button.colorContentMinimalPressed)
                 } else {
@@ -102,12 +103,13 @@ struct ToolBarTopItemNavigationStyle: ButtonStyle {
 
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Body
 
     func makeBody(configuration: Configuration) -> some View {
-        if isLiquidGlassDisabled {
+        if isLiquidGlassDisabled || forceOUDSLegacyLayout {
             configuration.label
                 .foregroundColor(foregroundColor)
         } else {

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarItems.swift
@@ -26,6 +26,7 @@ struct ToolBarItemActionButton: View {
     let type: OUDSToolBarItem.ActionType
     let style: OUDSToolBarItem.ActionStyle
 
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Body
@@ -38,7 +39,7 @@ struct ToolBarItemActionButton: View {
             } label: {
                 // fixedSize(). to let items use suitable size to display text withut beeing truncated all the times
                 // padding of 4 to make the text "breath" and not be to stucked to items borders
-                if isLiquidGlassDisabled {
+                if isLiquidGlassDisabled || forceOUDSLegacyLayout {
                     Text(label).modifier(FontLabelModifier(style: emphasized ? .medium : .regular)).fixedSize().padding(4)
                 } else {
                     Text(label).modifier(FontLabelModifier(style: .medium)).fixedSize().padding(4)
@@ -76,11 +77,13 @@ struct ToolBarItemActionButton: View {
 private struct ToolBarItemBadgeModifier: ViewModifier {
 
     let type: OUDSToolBarItem.BadgeType?
+
     @Environment(\.toolbarItemLocation) private var location
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
 
     func body(content: Content) -> some View {
-        if isLiquidGlassDisabled {
+        if isLiquidGlassDisabled || forceOUDSLegacyLayout {
             oudsBadgeLayout(content)
         } else {
             switch location {
@@ -133,6 +136,7 @@ struct ToolBarItemNavigationButton: View {
     @Environment(\.theme) private var theme
     @Environment(\.layoutDirection) private var layoutDirection
     @Environment(\.presentationMode) private var presentationMode
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
     @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: - Body
@@ -141,7 +145,7 @@ struct ToolBarItemNavigationButton: View {
         Group {
             switch type {
             case let .back(label, accessibilityLabel, action):
-                if isLiquidGlassDisabled {
+                if isLiquidGlassDisabled || forceOUDSLegacyLayout {
                     Button {
                         action?()
                         presentationMode.wrappedValue.dismiss()

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/LayoutModifiers/OUDSLegacyLayoutModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/LayoutModifiers/OUDSLegacyLayoutModifier.swift
@@ -22,27 +22,29 @@ import SwiftUI
 ///
 /// The edge case is when the OS version is 27, the flag *UIDesignRequiresCompatibility* stils exists but the app is compiled with Xcode 26.
 /// This case is extreme: the system does not force Liquid Glass, the flag is here, and OUDS cannot only rely on the OS version.
-/// Thus, this ``OUDSLegacyTabBarModifier``  will define an environment value saying any legacy layout things (appearances, selector, divider) must be displayed.
+/// Thus, this ``OUDSLegacyLayoutModifier``  will define an environment value saying any legacy layout things (appearances, selector, divider) must be displayed.
 ///
 /// **You must use this `ViewModifier` with care, and only if you are using Xcode 26 and  _UIDesignRequiresCompatibility_ to YES **.
 /// Prefer build with Xcode 27 without the *UIDesignRequiresCompatibility*  flag.
 ///
 /// ```swift
 ///   OUDSTabBar(selectedTab: ..., count: ...) { ... )
-///     .modifier(OUDSLegacyTabBarModifier())
+///     .modifier(OUDSLegacyLayoutModifier())
 /// ```
 ///
-/// - Since: 2.2.0
-public struct OUDSLegacyTabBarModifier: ViewModifier {
+/// **Note: You should use this view modifier in your root view because the flag is defines in deeper levels is used for all navigations components like bars**
+///
+/// - Since: 3.0.0
+public struct OUDSLegacyLayoutModifier: ViewModifier {
 
     /// To prevent to pollute logs
     private static var usersHaveBeenWarned: Bool = false
 
-    /// Instanciates the `OUDSLegacyTabBarModifier` and displays error messages in the standard output
+    /// Instanciates the `OUDSLegacyLayoutModifier` and displays error messages in the standard output
     public init() {
         if !Self.usersHaveBeenWarned {
-            OL.warning("You should not force the legacy layout of the tab bar; please embrace Liquid Glass!")
-            OL.warning("You should not use this OUDSLegacyTabBarModifier with Xcode 27 or with Xcode 26 without UIDesignRequiresCompatibility or set to NO")
+            OL.warning("You should not force the legacy layout of the navigation elements like bars; please embrace Liquid Glass!")
+            OL.warning("You should not use this OUDSLegacyLayoutModifier with Xcode 27 or with Xcode 26 without UIDesignRequiresCompatibility or set to NO")
             Self.usersHaveBeenWarned = true
         }
     }
@@ -50,12 +52,12 @@ public struct OUDSLegacyTabBarModifier: ViewModifier {
     /// Defines environment variable to precise the legacy tab bar must be forced
     public func body(content: Content) -> some View {
         content
-            .environment(\.forceOUDSLegacyTabBar, true)
+            .environment(\.forceOUDSLegacyLayout, true)
     }
 }
 
 extension EnvironmentValues {
 
     /// A flag indicating the OUDS tab bar must have the legacy layout.
-    @Entry public var forceOUDSLegacyTabBar: Bool = false
+    @Entry public var forceOUDSLegacyLayout: Bool = false
 }

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/LayoutModifiers/OUDSLegacyLayoutModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/LayoutModifiers/OUDSLegacyLayoutModifier.swift
@@ -34,7 +34,7 @@ import SwiftUI
 ///
 /// **Note: You should use this view modifier in your root view because the flag is defines in deeper levels is used for all navigations components like bars**
 ///
-/// - Since: 3.0.0
+/// - Since: 3.0.0H
 public struct OUDSLegacyLayoutModifier: ViewModifier {
 
     /// To prevent to pollute logs

--- a/skills/ouds-ios-migration/SKILL.md
+++ b/skills/ouds-ios-migration/SKILL.md
@@ -23,7 +23,7 @@ For full before/after examples, refer to `MIGRATION.md` in the project root.
 | v2.0.0 → v2.1.0 | Low | Component token `spacePaddingBlockDensityCompactTopAlignmentTopText_container` renamed |
 | v2.0.0 → v2.2.0 | Medium | `OUDSBadge` split into `OUDSBadgeStandard`, `OUDSBadgeCount`, `OUDSBadgeIcon` |
 | v2.2.0 → v2.3.0 | Low | `OUDSIcon` → `OUDSImage`; all `icon: Image` + `flipIcon` + `renderingMode` params replaced by `OUDSImage` |
-| v2.3.0 → v3.0.0 | High | Button/tag/link component token renames (add `Default` suffix); `icon.colorContentDefault` removed; `theme.controlItem` → `theme.listItem`; `OUDSChipPickerData.Layout.icon(icon:…)` → `.image(image:)`; `.textAndIcon` → `.textAndImage`; alert status `.neutral(icon:)`/`.accent(icon:)` → `(image:)`; `OUDSBadgeIcon` status `.neutral(icon:flipped:renderingMode:)`/`.accent(…)` → `(image: OUDSImage)` |
+| v2.3.0 → v3.0.0 | High | Button/tag/link component token renames (add `Default` suffix); `icon.colorContentDefault` removed; `theme.controlItem` → `theme.listItem`; `OUDSChipPickerData.Layout.icon(icon:…)` → `.image(image:)`; `.textAndIcon` → `.textAndImage`; alert status `.neutral(icon:)`/`.accent(icon:)` → `(image:)`; `OUDSBadgeIcon` status `.neutral(icon:flipped:renderingMode:)`/`.accent(…)` → `(image: OUDSImage)`; `forceOUDSLegacyTabBar` → `forceOUDSLegacyLayout`; `OUDSLegacyTabBarModifier` → `OUDSLegacyLayoutModifier` |
 
 ---
 
@@ -42,7 +42,7 @@ For full before/after examples, refer to `MIGRATION.md` in the project root.
 ```bash
 # Breaking changes (v3.0.0)
 grep -rn \
-  "theme\.controlItem\|icon\.colorContentDefault\|spaceInsetLoader\|\.sizeMaxHeightIconOnly\b\|\.sizeMinHeight\b\|\.sizeMinWidth\b\|\.sizeIcon\b\|\.sizeIconOnly\b\|\.sizeProgressIndicator\b\|\.spaceColumnGapIconChevron\b\|\.spaceColumnGapChevron\b\|\.spaceInsetIconOnly\b\|\.spacePaddingBlock\b\|\.spacePaddingInlineChevronEnd\b\|\.spacePaddingInlineChevronStart\b\|\.spacePaddingInlineEndIconStart\b\|\.spacePaddingInlineIconNone\b\|\.spacePaddingInlineStartIconEnd\b" \
+  "theme\.controlItem\|icon\.colorContentDefault\|spaceInsetLoader\|\.sizeMaxHeightIconOnly\b\|\.sizeMinHeight\b\|\.sizeMinWidth\b\|\.sizeIcon\b\|\.sizeIconOnly\b\|\.sizeProgressIndicator\b\|\.spaceColumnGapIconChevron\b\|\.spaceColumnGapChevron\b\|\.spaceInsetIconOnly\b\|\.spacePaddingBlock\b\|\.spacePaddingInlineChevronEnd\b\|\.spacePaddingInlineChevronStart\b\|\.spacePaddingInlineEndIconStart\b\|\.spacePaddingInlineIconNone\b\|\.spacePaddingInlineStartIconEnd\b\|forceOUDSLegacyTabBar\|OUDSLegacyTabBarModifier" \
   --include="*.swift" .
 
 # Active deprecations (v2.x)
@@ -459,6 +459,29 @@ The `.neutral(icon:)` and `.accent(icon:)` cases of alert status have two change
 
 ---
 
+### Modifier renamed: `forceOUDSLegacyTabBar` → `forceOUDSLegacyLayout`
+
+The `.forceOUDSLegacyTabBar()` view modifier and its underlying `OUDSLegacyTabBarModifier` type have been renamed to reflect a broader layout scope.
+
+| Old (v2.3) | New (v3.0) |
+|---|---|
+| `.forceOUDSLegacyTabBar()` | `.forceOUDSLegacyLayout()` |
+| `OUDSLegacyTabBarModifier` | `OUDSLegacyLayoutModifier` |
+
+```swift
+// Before (v2.3)
+SomeView().forceOUDSLegacyTabBar()
+let modifier: OUDSLegacyTabBarModifier = ...
+
+// After (v3.0)
+SomeView().forceOUDSLegacyLayout()
+let modifier: OUDSLegacyLayoutModifier = ...
+```
+
+**Required action**: global find-and-replace `forceOUDSLegacyTabBar` → `forceOUDSLegacyLayout` and `OUDSLegacyTabBarModifier` → `OUDSLegacyLayoutModifier`.
+
+---
+
 ## Verification checklist
 
 ```bash
@@ -468,7 +491,7 @@ swift build 2>&1 | grep -i "deprecated" | grep -iv "apple\|system\|swift\|founda
 
 # v3.0 breaking changes — must return nothing
 grep -rn \
-  "theme\.controlItem\|icon\.colorContentDefault\|spaceInsetLoader\|\.sizeMaxHeightIconOnly\b\|\.sizeMinHeight\b\|\.sizeMinWidth\b\|\.sizeIcon\b\|\.sizeIconOnly\b\|\.sizeProgressIndicator\b\|\.spaceColumnGapIconChevron\b\|\.spaceColumnGapChevron\b\|\.spaceInsetIconOnly\b\|\.spacePaddingBlock\b\|\.spacePaddingInlineChevronEnd\b\|\.spacePaddingInlineChevronStart\b\|\.spacePaddingInlineEndIconStart\b\|\.spacePaddingInlineIconNone\b\|\.spacePaddingInlineStartIconEnd\b\|Layout\.icon(icon:\|\.textAndIcon\b\|\.neutral(icon:\|\.accent(icon:\|neutral(icon:\|accent(icon:\|OrangeThemeControlItemComponentTokensProvider\|OrangeCompactThemeControlItemComponentTokensProvider\|SoshThemeControlItemComponentTokensProvider\|WireframeThemeControlItemComponentTokensProvider\|AllControlItemComponentTokensProvider\|ControlItemComponentTokens" \
+  "theme\.controlItem\|icon\.colorContentDefault\|spaceInsetLoader\|\.sizeMaxHeightIconOnly\b\|\.sizeMinHeight\b\|\.sizeMinWidth\b\|\.sizeIcon\b\|\.sizeIconOnly\b\|\.sizeProgressIndicator\b\|\.spaceColumnGapIconChevron\b\|\.spaceColumnGapChevron\b\|\.spaceInsetIconOnly\b\|\.spacePaddingBlock\b\|\.spacePaddingInlineChevronEnd\b\|\.spacePaddingInlineChevronStart\b\|\.spacePaddingInlineEndIconStart\b\|\.spacePaddingInlineIconNone\b\|\.spacePaddingInlineStartIconEnd\b\|Layout\.icon(icon:\|\.textAndIcon\b\|\.neutral(icon:\|\.accent(icon:\|neutral(icon:\|accent(icon:\|OrangeThemeControlItemComponentTokensProvider\|OrangeCompactThemeControlItemComponentTokensProvider\|SoshThemeControlItemComponentTokensProvider\|WireframeThemeControlItemComponentTokensProvider\|AllControlItemComponentTokensProvider\|ControlItemComponentTokens\|forceOUDSLegacyTabBar\|OUDSLegacyTabBarModifier" \
   --include="*.swift" .
 
 # v2.x deprecated symbols — must return nothing


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1623 

### Description

<!-- Describe your changes in detail -->
For top toolbar check flag for forced legacy layout to display badges.
Rename also dedicated flag and view modifier which are not now targeting only tab bar.
Update components to to check both Liquid Glass status and forced legacy layout status.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Fix missing badges for top toolbar, and manage in all cases the edge case where legacy layout has been forced.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Breaking change (fix or feature that would change existing functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
