### PR TITLE
[#1529] Fix `PIN code input` component usage with Voice Over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `PIN code input` component usage with Voice Over (Orange-OpenSource/ouds-ios#1529)
 - Missing `badges` on `toolbar top` component for app on iOS 27 with Xcode 26.5 and disabled Liquid Glass configuration (Orange-OpenSource/ouds-ios#1623)
 - Missing "core_common_back" localized string for `back` button of `toolbar top` component (Orange-OpenSource/ouds-ios#1577)
 - For `alert` components, add default vocalisation on "info" status (Orange-OpenSource/ouds-ios#1561)

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -16,7 +16,7 @@ import OUDSFoundations
 import OUDSTokensSemantic
 import SwiftUI
 
-// MARK: - Pin Code Input Container
+// swiftlint:disable type_body_length
 
 struct PinCodeInputContainer: View {
 
@@ -309,6 +309,7 @@ struct PinCodeInputContainer: View {
             } else if index < length.rawValue - 1 {
                 focusedIndex = index + 1
                 value = ""
+                announceFocusChanged(forInputAt: index + 1)
             } else {
                 value = ""
             }
@@ -339,12 +340,14 @@ struct PinCodeInputContainer: View {
                     digits[previousIndex] = ""
                     value = ""
                     focusedIndex = previousIndex
+                    announceFocusChanged(forInputAt: previousIndex)
                 }
             } else {
                 lastBackspaceIndex = index
                 digits[index] = ""
                 value = ""
                 focusedIndex = index
+                announceFocusChanged(forInputAt: index)
             }
         }
     }
@@ -374,5 +377,26 @@ struct PinCodeInputContainer: View {
             focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
         }
     }
+
+    private func announceFocusChanged(forInputAt index: Int) {
+        #if canImport(UIKit)
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        #endif
+        let message = "core_pinCodeInput_digitLabel_a11y_\(index + 1)".localized()
+        if #available(iOS 17, *), #available(macOS 14, *) {
+            var announcement = AttributedString(message)
+            announcement.accessibilitySpeechAnnouncementPriority = .high
+            AccessibilityNotification.Announcement(announcement).post()
+        } else {
+            #if canImport(UIKit)
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: message)
+            #endif
+        }
+    }
 }
+
+// swiftlint:enable type_body_length
+
 #endif

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -383,7 +383,7 @@ struct PinCodeInputContainer: View {
         guard UIAccessibility.isVoiceOverRunning else { return }
         #endif
         let message = "core_pinCodeInput_digitLabel_a11y_\(index + 1)".localized()
-        if #available(iOS 17, *), #available(macOS 14, *) {
+        if #available(iOS 17, visionOS 1, macOS 14, *) {
             var announcement = AttributedString(message)
             announcement.accessibilitySpeechAnnouncementPriority = .high
             AccessibilityNotification.Announcement(announcement).post()

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -160,18 +160,6 @@ struct PinCodeInputContainer: View {
         }
     }
 
-    /// Returns `true` when VoiceOver (or any assistive technology that relies on explicit focus
-    /// control) is currently running.
-    /// When `true`, automatic focus advancement to the next field is suppressed so that the user
-    /// can navigate fields at their own pace via VoiceOver swipe gestures.
-    private var isVoiceOverRunning: Bool {
-        #if canImport(UIKit)
-        UIAccessibility.isVoiceOverRunning
-        #else
-        false
-        #endif
-    }
-
     private func accessibilityValue(for index: Int) -> String {
         let value = digits[index]
         if value.isEmpty {
@@ -296,13 +284,8 @@ struct PinCodeInputContainer: View {
                 focusedIndex = nil
             } else {
                 value = ""
-                // Move focus to the next empty field only when VoiceOver is not running.
-                // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
-                // would interrupt their navigation.
-                if !isVoiceOverRunning {
-                    let nextIndex = index + toDistribute.count
-                    focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
-                }
+                let nextIndex = index + toDistribute.count
+                focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
             }
             return
         }
@@ -324,12 +307,7 @@ struct PinCodeInputContainer: View {
                 value = joined
                 focusedIndex = nil
             } else if index < length.rawValue - 1 {
-                // Move focus to the next field only when VoiceOver is not running.
-                // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
-                // would interrupt their navigation.
-                if !isVoiceOverRunning {
-                    focusedIndex = index + 1
-                }
+                focusedIndex = index + 1
                 value = ""
             } else {
                 value = ""
@@ -392,13 +370,8 @@ struct PinCodeInputContainer: View {
             focusedIndex = nil
         } else {
             value = ""
-            // Move focus to the next empty field only when VoiceOver is not running.
-            // VoiceOver users navigate fields via swipe gestures; auto-advancing focus
-            // would interrupt their navigation.
-            if !isVoiceOverRunning {
-                let nextIndex = index + toDistribute.count
-                focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
-            }
+            let nextIndex = index + toDistribute.count
+            focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -177,7 +177,7 @@ struct PinCodeInputContainer: View {
     /// - Parameter index: The 0-based index of the digit field
     /// - Returns: The localized positional label
     private func accessibilityLabel(for index: Int) -> String {
-        "core_pinCodeInput_digitLabel_a11y" <- (index + 1)
+        "core_pinCodeInput_digitLabel_a11y_\(index + 1)".localized()
     }
 
     /// Returns the accessibility label for the group container of all digit fields.

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBorderModifier.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageBorderModifier.swift
@@ -31,6 +31,7 @@ struct AlertMessageBorderModifier: ViewModifier {
                     radius: radius,
                     color: color)
             .clipShape(RoundedRectangle(cornerRadius: radius))
+            .contentShape(RoundedRectangle(cornerRadius: radius))
     }
 
     // MARK: - Helpers

--- a/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
+++ b/OUDS/Core/Components/Sources/_/Resources/Localizable.xcstrings
@@ -826,6 +826,198 @@
         }
       }
     },
+    "core_pinCodeInput_digitLabel_a11y_1" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الأول"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1st digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "1er chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_2" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الثاني"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2nd digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "2ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_3" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الثالث"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3rd digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "3ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_4" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الرابع"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4th digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "4ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_5" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الخامس"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5th digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "5ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_6" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم السادس"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6th digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "6ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_7" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم السابع"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7th digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "7ème chiffre"
+          }
+        }
+      }
+    },
+    "core_pinCodeInput_digitLabel_a11y_8" : {
+      "comment" : "Component - PIN Code Input",
+      "extractionState" : "manual",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "الرقم الثامن"
+          }
+        },
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8th digit"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "8ème chiffre"
+          }
+        }
+      }
+    },
     "core_pinCodeInput_empty_a11y" : {
       "comment" : "Component - Pin Code Input",
       "extractionState" : "manual",
@@ -1187,5 +1379,5 @@
       }
     }
   },
-  "version" : "1.1"
+  "version" : "1.2"
 }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1529 

### Description

<!-- Describe your changes in detail -->
Update wordings, keep autofocus whatever Voice Over configuration is, announce focused input on write / delete

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Fix usage of component with Voice Over

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
