### PR TITLE
[#1530] Add dedicated view modifier to close virtual keyboard on tap outside components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `View modifier` to force keyboard closing on tap (Orange-OpenSource/ouds-ios#1530)
 - `View modifier` to apply theme to Liquid Glass SwiftUI `TabView` (Orange-OpenSource/ouds-ios#1459)
 - `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)
 - Flag to let `link` component take full width (Orange-OpenSource/ouds-ios#1576)

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/DismissKeyboardOnTapModifier.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/DismissKeyboardOnTapModifier.swift
@@ -1,0 +1,90 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+#if canImport(UIKit) && (os(iOS) || os(iPadOS) || os(visionOS))
+import SwiftUI
+import UIKit
+
+// MARK: - Dismiss Keyboard On Tap Modifier
+
+/// A `ViewModifier` which dismisses the software keyboard when the user taps
+/// anywhere on the screen outside a text input field.
+///
+/// Attaches a `UITapGestureRecognizer` directly to the key `UIWindow` so that
+/// taps anywhere on the screen — including areas outside the modified view —
+/// trigger keyboard dismissal. `cancelsTouchesInView` is set to `false` so
+/// interactive child views (buttons, text fields, etc.) still receive their taps.
+///
+/// The gesture recognizer is added when the view appears and removed when it
+/// disappears to avoid memory leaks.
+///
+/// Applied via ``SwiftUICore/View/oudsHideKeyboardOnTap()``.
+struct DismissKeyboardOnTapModifier: ViewModifier {
+
+    // MARK: Body
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear {
+                addGestureRecognizer()
+            }
+            .onDisappear {
+                removeGestureRecognizer()
+            }
+    }
+
+    // MARK: Private helpers
+
+    private var keyWindow: UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first { $0.isKeyWindow }
+    }
+
+    private func addGestureRecognizer() {
+        guard let window = keyWindow else { return }
+        let recognizer = UITapGestureRecognizer(target: DismissKeyboardTarget.shared,
+                                                action: #selector(DismissKeyboardTarget.dismissKeyboard))
+        recognizer.cancelsTouchesInView = false
+        recognizer.name = DismissKeyboardTarget.gestureRecognizerName
+        window.addGestureRecognizer(recognizer)
+    }
+
+    private func removeGestureRecognizer() {
+        guard let window = keyWindow else { return }
+        window.gestureRecognizers?
+            .filter { $0.name == DismissKeyboardTarget.gestureRecognizerName }
+            .forEach { window.removeGestureRecognizer($0) }
+    }
+}
+
+// MARK: - Dismiss Keyboard Target
+
+/// Objective-C target for the `UITapGestureRecognizer` attached to the key window.
+private final class DismissKeyboardTarget: NSObject {
+
+    nonisolated(unsafe) static let shared = DismissKeyboardTarget()
+    static let gestureRecognizerName = "OUDSDismissKeyboardOnTap"
+
+    deinit {}
+
+    @MainActor @objc func dismissKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil,
+            from: nil,
+            for: nil)
+    }
+}
+#endif

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/View+DismissKeyboard.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/View+DismissKeyboard.swift
@@ -15,8 +15,8 @@ import SwiftUI
 
 extension View {
 
-    /// Dismisses the software keyboard when the user taps on any non-interactive
-    /// area of the screen outside a text input field.
+    /// Dismisses the software keyboard when the user taps anywhere
+    /// outside a text input field.
     ///
     /// Apply this modifier on the parent view containing an ``OUDSTextInput``
     /// or ``OUDSTextArea`` for example.

--- a/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/View+DismissKeyboard.swift
+++ b/OUDS/Core/Components/Sources/_/ViewModifiers/DismissKeyboardModifiers/View+DismissKeyboard.swift
@@ -1,0 +1,38 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+extension View {
+
+    /// Dismisses the software keyboard when the user taps on any non-interactive
+    /// area of the screen outside a text input field.
+    ///
+    /// Apply this modifier on the parent view containing an ``OUDSTextInput``
+    /// or ``OUDSTextArea`` for example.
+    ///
+    /// ```swift
+    /// VStack {
+    ///     OUDSTextInput(label: "Email", text: $email)
+    ///     OUDSTextInput(label: "Name", text: $name)
+    /// }
+    /// .oudsHideKeyboardOnTap()
+    /// ```
+    public func oudsHideKeyboardOnTap() -> some View {
+        #if os(iOS) || os(iPadOS) || os(visionOS)
+        modifier(DismissKeyboardOnTapModifier())
+        #else
+        self
+        #endif
+    }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1530 

### Description

<!-- Describe your changes in detail -->
Add view modifier to handle tap gesture on window to close virtual keyboard so as to close it when user taps outside of text input or text area components

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Close virtual keyboard on focus most

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
