### PR TITLE
[#1452] Add `tab view` component to manage `Tab` iOS 18+ API 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Tab view` component to use SwiftUI `Tab` API (Orange-OpenSource/ouds-ios#1452)
 - `View modifier` to force keyboard closing on tap (Orange-OpenSource/ouds-ios#1530)
 - `View modifier` to apply theme to Liquid Glass SwiftUI `TabView` (Orange-OpenSource/ouds-ios#1459)
 - `View modifier` to add custom accessibility traits inside `text area` component (Orange-OpenSource/ouds-ios#1597)

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -33,7 +33,7 @@ import SwiftUI
 /// or ``OUDSBadgeCount``, the native API is used instead.
 ///
 /// Because Liquid Glass is available since iOS 26, the tab bar will be liquified / glassified since this OS version, not before.
-/// However if an app is built with Xcode 26 and the flag *UIDesignRequiresCompatibility* set to *YES*, then Loquid Glass won't be applied but the alternative layout.
+/// However if an app is built with Xcode 26 and the flag *UIDesignRequiresCompatibility* set to *YES*, then Liquid Glass won't be applied but the alternative layout.
 /// Nevertheless with Xcode 27 and for iOS 27, Liquid Glass will be always applied, whatever the value of the flag is.
 ///
 /// If you use SF Symbols for images, if they exist their *fill* variant will be automatically used in the tab bar (native behaviour).
@@ -81,7 +81,7 @@ import SwiftUI
 ///
 /// ## Selection of tabs
 ///
-/// For iOS lower than 26, a selected tab indicator can be displayed in the `OUDSTabBar` if the `count` parameter is defined (to the number of tabs in the component)
+/// For iOS lower than 26, a selected tab indicator is displayed in the `OUDSTabBar` ; the `count` parameter must be defined (to the number of tabs in the component),
 /// and if the `selectedTab` binding value is equal to a given tag associated to a tab item.
 /// Otherwise the indicator won't appear; these parameters are mandatory to compute the location of the indicator.
 /// This rule is only applied if selected tab indicator must be displayed.
@@ -136,6 +136,11 @@ import SwiftUI
 ///             .tag(2) // Must be used for the selectedTab binding
 ///     }
 /// ```
+///
+/// ## Alernative components
+///
+/// If you want to use SwiftUI `Tab` View with or without rules, used instead `OUDSTabView`.
+/// If you target apps with Liquid Glass enabled and need `Tab` or rules, using instead `OUDSLiquidGlassTabView`.
 ///
 /// ## Design documentation
 ///

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBar.swift
@@ -137,10 +137,10 @@ import SwiftUI
 ///     }
 /// ```
 ///
-/// ## Alernative components
+/// ## Alternative components
 ///
-/// If you want to use SwiftUI `Tab` View with or without rules, used instead `OUDSTabView`.
-/// If you target apps with Liquid Glass enabled and need `Tab` or rules, using instead `OUDSLiquidGlassTabView`.
+/// If you want to use SwiftUI `Tab` View with or without rules, use instead ``OUDSTabView``.
+/// If you target apps with Liquid Glass enabled and need `Tab` or rules, use instead ``OUDSLiquidGlassTabView``.
 ///
 /// ## Design documentation
 ///

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabViews.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabViews.swift
@@ -1,0 +1,321 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+#if !os(tvOS) && !os(watchOS)
+import OUDSFoundations
+import SwiftUI
+
+// MARK: - OUDS Tab View
+
+/// A tab view component that accepts native SwiftUI `Tab` items (iOS 18+) while applying the full OUDS
+/// tab bar appearance — colors, typography, top divider and selected-tab indicator — just like ``OUDSTabBar``.
+///
+/// Use ``OUDSTabView`` instead of ``OUDSTabBar`` when you need iOS 18+ `Tab`-based API such as
+/// positional `Tab("Label", image:) { }` items with a selection binding or rules like `Tab(role: .search)`.
+/// For apps targeting iOS 15–17, use ``OUDSTabBar`` instead.
+/// When you need `Tab(role: .search)` on iOS 26+, **with Liquid Glass enabled**, use ``OUDSLiquidGlassTabView`` instead.
+///
+/// ## Selection binding
+///
+/// A `Binding<Int>` is always required and always kept in sync, regardless of the OS version.
+/// For iOS 18 or iOS 26 without Liquid Glass, also pass `count:` (the number of tabs) so the selected-tab indicator can be positioned.
+/// Each `Tab` must carry an explicit `value: Int` matching the `selectedTab` binding.
+/// For iOS 26+ with Liquid Glass, use ``OUDSLiquidGlassTabView``.
+///
+/// ## Appearances
+///
+/// iOS 26 brings Liquid Glass. The same rules as ``OUDSTabBar`` apply:
+/// - Background and unselected item colors are applied for iOS lower than 26.
+/// - On iOS 26+ with Liquid Glass enabled, only the selected accent color is applied.
+/// - The top divider and selected-tab indicator are shown for iOS 18 (portrait iPhone only for
+///   the indicator) and hidden under Liquid Glass.
+///
+/// ## Platform considerations
+///
+/// - Tailored for iOS and iPadOS. Requires iOS 18+.
+/// - On macOS 15+ and visionOS 2+: a bare `TabView(selection:)` is rendered without UIKit styling.
+/// - Not available on watchOS or tvOS.
+///
+/// ## Guidelines
+///
+/// OUDS guidelines recommend using tab bar item images at **26 × 26 pt**.
+///
+/// ## Code samples
+///
+/// ```swift
+/// // iOS 18 and 26 without Liquid Glass: binding + count required for the selected-tab indicator
+/// @State private var selectedTab = 0
+///
+/// OUDSTabView(selectedTab: $selectedTab, count: 4) {
+///     Tab("first_tab_label", image: "first-tab-image", value: 0) { FirstView() }
+///     Tab("second_tab_label", image: "second-tab-image", value: 1) { SecondView() }
+///     Tab("third_tab_label", image: "third-tab-image", value: 2) { ThirdView() }
+///     Tab(value: 3, role: .search) { SearchView() }
+/// }
+/// ```
+///
+/// ```swift
+/// // iOS 26+ with Liquid Glass enabled: binding without count (no custom indicator)
+/// // value: is still required — use OUDSLiquidGlassTabView for Tab without value: or Tab(role:)
+/// @State private var selectedTab = 0
+///
+/// if #available(iOS 26, *) {
+///     OUDSTabView(selectedTab: $selectedTab) {
+///         Tab("first_tab_label", image: "first-tab-image", value: 0) { FirstView() }
+///         Tab("second_tab_label", image: "second-tab-image", value: 1) { SecondView() }
+///         Tab("third_tab_label", image: "third-tab-image", value: 2) { ThirdView() }
+///     }
+/// }
+/// ```
+///
+/// - Version: 1.0.0
+/// - Since: 3.0.0
+@available(iOS 18, macOS 15, visionOS 2, *) // Cannot be used for OS lower than 18 because of missing `Tab(value:)` API
+public struct OUDSTabView<Content: TabContent>: View where Content.TabValue == Int {
+
+    // MARK: - Properties
+
+    /// To compute the location of the selected tab indicator if Liquid Glass missing
+    private let tabCount: Int
+
+    /// To send to user the selected tab index and to compute the location of the selected tab indicator if Liquid Glass missing
+    @Binding private var selectedTab: Int
+
+    /// The  `TabContentBuilder` to build the `Tab` views
+    private let content: () -> Content
+
+    // MARK: - Initializers
+
+    // NOTE: No use of #if os(iOS) to let OUDS maintainers on macOS compile the documentation.
+    /// Creates an `OUDSTabView` for iOS 18 and iOS 26 with Liquid Glass disabled.
+    ///
+    /// Pass `selectedTab` and `count` so the selected-tab indicator can be drawn above the correct column.
+    /// Each `Tab` must carry a matching `value`.
+    ///
+    /// ```swift
+    /// @State private var selectedTab = 0
+    ///
+    /// OUDSTabView(selectedTab: $selectedTab, count: 3) {
+    ///     Tab("Home", image: "house", value: 0) { HomePage() }
+    ///     Tab("Search", image: "magnifyingglass", value: 1) { SearchPage() }
+    ///     Tab("Profile", image: "person", value: 3) { ProfilePage() }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - selectedTab: A binding to the 0-based index of the currently selected tab. Must be between  in [0 ;  `count`[.
+    ///   - count: The total number of tabs. Must be a positive non-zero value.
+    ///   - content: A `@TabContentBuilder` closure producing `Tab` items.
+    public init(selectedTab: Binding<Int>,
+                count: UInt8,
+                @TabContentBuilder<Int> content: @escaping () -> Content)
+    {
+        if selectedTab.wrappedValue < 0 || selectedTab.wrappedValue >= count {
+            OL.warning("The selected tab binding for the OUDSTabView does not match the count of tabs")
+        }
+        _selectedTab = selectedTab
+        tabCount = Int(count)
+        self.content = content
+    }
+
+    // NOTE: No use of #if os(iOS) to let OUDS maintainers on macOS compile the documentation.
+    /// Creates an `OUDSTabView` for iOS 26+ (Liquid Glass enabled).
+    ///
+    /// ```swift
+    /// @State private var selectedTab = 0
+    ///
+    /// if #available(iOS 26, *) {
+    ///     OUDSTabView(selectedTab: $selectedTab) {
+    ///         Tab("Home", image: "house", value: 0) { HomePage() }
+    ///         Tab("Search", image: "magnifyingglass", value: 1) { SearchPage() }
+    ///         Tab("Profile", image: "person", value: 2) { ProfilePage() }
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - selectedTab: A binding to the currently selected tab index. Updated automatically.
+    ///   - content: A `@TabContentBuilder` closure producing `Tab` items, each with an explicit `value: Int`.
+    @available(iOS 26, *)
+    public init(selectedTab: Binding<Int>,
+                @TabContentBuilder<Int> content: @escaping () -> Content)
+    {
+        _selectedTab = selectedTab
+        tabCount = 0
+        self.content = content
+    }
+
+    public var body: some View {
+        OUDSTabViewBody(selectedTab: $selectedTab, tabCount: tabCount) {
+            TabView(selection: $selectedTab) {
+                content()
+            }
+        }
+    }
+}
+
+// MARK: - OUDS Liquid Glass Tab View
+
+/// A tab view component for iOS 26+ that accepts native SwiftUI `Tab` items including `Tab(role: .search)`,
+/// while applying the full OUDS tab bar appearance — colors, typography and top divider.
+///
+/// Use ``OUDSLiquidGlassTabView`` when you need role-based tabs (iOS 26+) or targeting iOS 26+ OS with Liquid Glass.
+/// For iOS 18 and iOS 26 without Liquid Glass, use ``OUDSTabView`` instead.
+/// For older iOS version use ``OUDSTabBar`` instead.
+///
+/// ## Platform considerations
+///
+/// - Requires iOS 26+ / macOS 26+ / visionOS 26+.
+/// - Not available on watchOS or tvOS.
+///
+/// ## Code samples
+///
+/// ```swift
+/// OUDSLiquidGlassTabView {
+///     Tab("Home", image: "house") { HomePage() }
+///     Tab("Search", image: "magnifyingglass") { SearchPage() }
+///     Tab("Profile", image: "person") { ProfilePage() }
+/// }
+/// ```
+///
+/// - Version: 1.0.0
+/// - Since: 3.0.0
+@available(iOS 26, macOS 26, visionOS 26, *)
+public struct OUDSLiquidGlassTabView<Content: TabContent>: View where Content.TabValue == Never {
+
+    /// The `TabContentBuilder` to build the `Tab` views
+    private let content: () -> Content
+
+    /// Creates an `OUDSLiquidGlassTabView` with `Tab` items
+    ///
+    /// ```swift
+    /// OUDSLiquidGlassTabView {
+    ///     Tab("Home", image: "house") { HomePage() }
+    ///     Tab("Search", image: "magnifyingglass") { SearchPage() }
+    ///     Tab("Profile", image: "person") { ProfilePage() }
+    /// }
+    /// ```
+    ///
+    /// - Parameter content: A `@TabContentBuilder` closure producing `Tab` items.
+    public init(@TabContentBuilder<Never> content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    public var body: some View {
+        // tabCount 0: indicator never shown (Liquid Glass always active on iOS 27+, asked to use this component for iOS 26 with Liquid Glass
+        OUDSTabViewBody(selectedTab: .constant(0), tabCount: 0) {
+            TabView {
+                content()
+            }
+        }
+    }
+}
+
+// MARK: - Internal shared decoration body
+
+/// Internal view that holds the full OUDS tab bar decoration logic shared by
+/// ``OUDSTabView`` and ``OUDSLiquidGlassTabView``:
+/// - ``OUDSTabBarViewModifier`` — UITabBarAppearance tokens
+/// - ``SelectedTabIndicator`` — selected-tab pill (iOS < 26, portrait iPhone)
+/// - ``TabBarTopDivider`` — top divider stroke (legacy layout)
+/// - ``DeviceModifier`` — injects `iPhoneInUse` into the environment
+///
+/// The `content` closure receives a fully-built `TabView` (already typed as `some View`),
+/// so this helper does not need to know about `TabContent` or `@TabContentBuilder`.
+@available(iOS 18, macOS 15, visionOS 2, *)
+private struct OUDSTabViewBody<TabViewContent: View>: View {
+
+    @Binding var selectedTab: Int
+    let tabCount: Int
+    @ViewBuilder let content: () -> TabViewContent
+
+    @State private var isLandscape: Bool = false
+
+    #if os(iOS)
+    @State private var isTabBarHidden: Bool = false
+    #endif
+
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
+    @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
+
+    var body: some View {
+        #if os(iOS)
+        ZStack(alignment: .bottom) {
+
+            // NOTE: Do not understand why, but if we do not have these SelectedTabIndicator TWICE
+            // the indicator will be never disabled if Liquid Glass unavailable or disabled
+            // for iOS 26+ with Liquid Glass disabled and Xcode 26.4.1
+            // (ノಠ益ಠ)ノ彡┻━┻
+            SelectedTabIndicator(selected: $selectedTab, count: tabCount, isTabBarHidden: $isTabBarHidden)
+                .opacity(shouldShowTabIndicator ? 1 : 0)
+                .ignoresSafeArea(.keyboard, edges: .bottom)
+
+            content()
+                .modifier(OUDSTabBarViewModifier())
+
+            SelectedTabIndicator(selected: $selectedTab, count: tabCount, isTabBarHidden: $isTabBarHidden)
+                .opacity(shouldShowTabIndicator ? 1 : 0)
+                .ignoresSafeArea(.keyboard, edges: .bottom)
+
+            TabBarTopDivider(isTabBarHidden: $isTabBarHidden)
+                .opacity(hasLegacyLayout ? 1 : 0)
+                .ignoresSafeArea(.keyboard, edges: .bottom)
+        }
+        .onAppear {
+            isLandscape = Self.isInLandscapeViewport()
+        }
+        // React to child views calling `.hideTabBar()`, which posts `TabBarHiddenPreferenceKey`.
+        .onPreferenceChange(TabBarHiddenPreferenceKey.self) { hidden in
+            isTabBarHidden = hidden
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIDevice.orientationDidChangeNotification)) { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + SelectedTabIndicator.asyncDelay) {
+                isLandscape = Self.isInLandscapeViewport()
+            }
+        }
+        .modifier(DeviceModifier())
+        #else
+        content()
+        #endif
+    }
+
+    private var shouldShowTabIndicator: Bool {
+        #if canImport(UIKit) && !os(watchOS)
+        if forceOUDSLegacyLayout { return true }
+        guard isLiquidGlassDisabled else { return false }
+        guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
+        return !isLandscape
+        #else
+        return false
+        #endif
+    }
+
+    private var hasLegacyLayout: Bool {
+        #if canImport(UIKit) && !os(watchOS)
+        if forceOUDSLegacyLayout { return true }
+        if isLiquidGlassDisabled {
+            if UIDevice.current.userInterfaceIdiom == .phone {
+                return true
+            } else if UIDevice.current.userInterfaceIdiom == .pad {
+                if #unavailable(iOS 18.0) {
+                    return true
+                }
+            }
+        }
+        return false
+        #else
+        return false
+        #endif
+    }
+}
+#endif

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabViews.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabViews.swift
@@ -108,7 +108,7 @@ public struct OUDSTabView<Content: TabContent>: View where Content.TabValue == I
     /// OUDSTabView(selectedTab: $selectedTab, count: 3) {
     ///     Tab("Home", image: "house", value: 0) { HomePage() }
     ///     Tab("Search", image: "magnifyingglass", value: 1) { SearchPage() }
-    ///     Tab("Profile", image: "person", value: 3) { ProfilePage() }
+    ///     Tab("Profile", image: "person", value: 2) { ProfilePage() }
     /// }
     /// ```
     ///
@@ -291,7 +291,8 @@ private struct OUDSTabViewBody<TabViewContent: View>: View {
 
     private var shouldShowTabIndicator: Bool {
         #if canImport(UIKit) && !os(watchOS)
-        if forceOUDSLegacyLayout { return true }
+        if forceOUDSLegacyLayout { return tabCount > 0 }
+        guard tabCount > 0 else { return false }
         guard isLiquidGlassDisabled else { return false }
         guard UIDevice.current.userInterfaceIdiom == .phone else { return false }
         return !isLandscape

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -114,6 +114,37 @@ OUDSTabBar(selectedTab: $selectedTab, count: 3) {
 }
 ```
 
+### Tab views
+
+The ``OUDSTabView`` and ``OUDSLiquidGlassTabView`` use the native SwiftUI `Tab` API with OUDS styles.
+They are complementary to ``OUDSTabBar``:
+
+- ``OUDSTabView`` — iOS 18+ / macOS 15+ / visionOS 2+, exposes a `Binding<Int>` for programmatic selection, requires an explicit `value: Int` on every `Tab`.
+- ``OUDSLiquidGlassTabView`` — iOS 26+ / macOS 26+ / visionOS 26+ only, accepts `Tab` without `value:` and `Tab(role: .search)`, selection is managed natively.
+
+```swift
+// OUDSTabView — iOS 18+
+// Every Tab must carry an explicit value: Int matching the selectedTab binding
+@State private var selectedTab = 0
+
+OUDSTabView(selectedTab: $selectedTab, count: 4) {
+    Tab("Label 1", image: "image_1", value: 0) { FirstView() }
+    Tab("Label 2", image: "image_2", value: 1) { SecondView() }
+    Tab("Label 3", image: "image_3", value: 2) { ThirdView() }
+    Tab(value: 3, role: .search) { SearchView() }
+}
+```
+
+```swift
+// OUDSLiquidGlassTabView — iOS 26+ only
+// Supports Tab without value: and Tab(role: .search), no selection binding
+OUDSLiquidGlassTabView {
+    Tab("Label 1", image: "image_1") { FirstView() }
+    Tab("Label 2", image: "image_2") { SecondView() }
+    Tab("Label 3", image: "image_3") { ThirdView() }
+    Tab(role: .search) { SearchView() }
+}
+```
 
 ### Toolbars
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -196,7 +196,7 @@ These patterns apply to Checkbox, Radio, Switch, TextInput, TextArea, PinCodeInp
 
 ## 7. Components
 
-**Index:** [Button](#actions--button) · [BulletList](#content-display--bullet-list) · [Checkbox](#controls--checkbox) · [Radio](#controls--radio-button) · [Switch](#controls--switch) · [PinCode](#controls--pin-code-input) · [Password](#controls--password-input) · [Chips](#controls--chips) · [TextInput](#controls--text-input) · [TextArea](#controls--text-area) · [AlertMessage](#dialogs--alert-message) · [InlineAlert](#dialogs--inline-alert) · [Badge](#indicators--badge) · [Tag](#indicators--tag) · [InputTag](#indicators--input-tag) · [ColoredSurface](#layouts--colored-surface) · [Divider](#layouts--divider) · [Link](#navigations--link) · [TabBar](#navigations--tab-bar) · [Toolbars](#navigations--toolbars)
+**Index:** [Button](#actions--button) · [BulletList](#content-display--bullet-list) · [Checkbox](#controls--checkbox) · [Radio](#controls--radio-button) · [Switch](#controls--switch) · [PinCode](#controls--pin-code-input) · [Password](#controls--password-input) · [Chips](#controls--chips) · [TextInput](#controls--text-input) · [TextArea](#controls--text-area) · [AlertMessage](#dialogs--alert-message) · [InlineAlert](#dialogs--inline-alert) · [Badge](#indicators--badge) · [Tag](#indicators--tag) · [InputTag](#indicators--input-tag) · [ColoredSurface](#layouts--colored-surface) · [Divider](#layouts--divider) · [Link](#navigations--link) · [TabBar](#navigations--tab-bar) · [TabView / LiquidGlassTabView](#navigations--tab-view--liquid-glass-tab-view) · [Toolbars](#navigations--toolbars)
 
 ---
 
@@ -521,6 +521,7 @@ OUDSLink(text: "Text", indicator: .back, isFullWidth: true, size: .default) {}
 ### Navigations — Tab Bar
 
 > Never combine with `OUDSToolBarBottom` on the same screen.
+> For iOS 18+ and `Tab`-based API, prefer `OUDSTabView` or `OUDSLiquidGlassTabView` instead.
 
 ```swift
 // iOS 15–25
@@ -538,6 +539,72 @@ OUDSTabBar {
 ```
 
 > Tab bar images: 26×26 pt. `OUDSTabBar(selected:count:content:)` (plain `Int`) is deprecated — use `selectedTab: Binding<Int>`.
+
+---
+
+### Navigations — Tab View / Liquid Glass Tab View
+
+> `OUDSTabView` requires iOS 18+ / macOS 15+ / visionOS 2+. For iOS 15–17, use `OUDSTabBar` instead.
+> `OUDSLiquidGlassTabView` requires iOS 26+ / macOS 26+ / visionOS 26+.
+> Never combine with `OUDSToolBarBottom` on the same screen.
+> Both apply the same OUDS appearance (colors, typography, divider, selected-tab indicator) as `OUDSTabBar`.
+
+Two components are provided because `Tab(role: .search)` and `Tab("…", image:) { }` without an explicit
+`value:` both have `TabValue == Never` in the SwiftUI type system, which is incompatible with
+`@TabContentBuilder<Int>` (required to expose a `Binding<Int>`).
+SwiftUI's own promotion from `Never` to `Int?` is only available through internal initialisers.
+
+**`OUDSTabView`** — iOS 18+, `Binding<Int>`, requires `value:` on every `Tab`
+
+```swift
+// iOS 18 and iOS 26 with Liquid Glass disabled:
+// binding + count required for the selected-tab indicator
+// Every Tab must carry an explicit value: Int
+@State private var selectedTab = 0
+
+OUDSTabView(selectedTab: $selectedTab, count: 4) {
+    Tab("first_tab_label", image: "first-tab-image", value: 0) { FirstView() }
+    Tab("second_tab_label", image: "second-tab-image", value: 1) { SecondView() }
+    Tab("third_tab_label", image: "third-tab-image", value: 2) { ThirdView() }
+    Tab(value: 3, role: .search) { SearchView() }
+}
+
+// iOS 26+ with Liquid Glass enabled: binding without count (no custom indicator)
+// Tab without value: is still not allowed — use OUDSLiquidGlassTabView instead
+@State private var selectedTab = 0
+if #available(iOS 26, *) {
+    OUDSTabView(selectedTab: $selectedTab) {
+        Tab("first_tab_label", image: "first-tab-image", value: 0) { FirstView() }
+        Tab("second_tab_label", image: "second-tab-image", value: 1) { SecondView() }
+        Tab("third_tab_label", image: "third-tab-image", value: 2) { ThirdView() }
+    }
+}
+```
+
+> Each `Tab` **must** carry `value: Int`. `Tab("…", image:) { }` without `value:` has `TabValue == Never`
+> and will not compile inside `OUDSTabView`. Tab bar images: 26×26 pt.
+
+**`OUDSLiquidGlassTabView`** — iOS 26+ only, no `value:` required, `Tab(role: .search)` supported, no selection binding
+
+```swift
+OUDSLiquidGlassTabView {
+    Tab("Tokens", image: "design-token") { TokensPage() }
+    Tab("Components", image: "component-atom") { ComponentsPage() }
+    Tab("About", image: "info-fill") { AboutPage() }
+    Tab(role: .search) { SearchPage() }
+}
+```
+
+| | `OUDSTabBar` | `OUDSTabView` | `OUDSLiquidGlassTabView` |
+|---|---|---|---|
+| iOS min | 15 | 18 | 26 |
+| macOS min | 13 | 15 | 26 |
+| visionOS min | 1 | 2 | 26 |
+| Tab API | `.tabItem { Label }.tag(n)` | `Tab(…, value: Int) { }` | `Tab("…", image:) { }` |
+| `Tab(role: .search)` | Non | Oui (avec `value:`) | Oui |
+| `selectedTab` binding | `Binding<Int>` | `Binding<Int>` | Aucun |
+| Indicateur sélection | Oui (portrait iPhone, iOS < 26) | Oui (même logique) | Non (iOS 26+ uniquement) |
+| Divider legacy | Oui | Oui | Oui (si Liquid Glass désactivé) |
 
 ---
 

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -601,10 +601,10 @@ OUDSLiquidGlassTabView {
 | macOS min | 13 | 15 | 26 |
 | visionOS min | 1 | 2 | 26 |
 | Tab API | `.tabItem { Label }.tag(n)` | `Tab(…, value: Int) { }` | `Tab("…", image:) { }` |
-| `Tab(role: .search)` | Non | Oui (avec `value:`) | Oui |
-| `selectedTab` binding | `Binding<Int>` | `Binding<Int>` | Aucun |
-| Indicateur sélection | Oui (portrait iPhone, iOS < 26) | Oui (même logique) | Non (iOS 26+ uniquement) |
-| Divider legacy | Oui | Oui | Oui (si Liquid Glass désactivé) |
+| `Tab(role: .search)` | No | Yes (with `value:`) | Yes |
+| `selectedTab` binding | `Binding<Int>` | `Binding<Int>` | None |
+| Selected-tab indicator | Yes (portrait iPhone, iOS < 26) | Yes (same logic) | No (iOS 26+ only) |
+| Legacy divider | Yes | Yes | Yes (if Liquid Glass is disabled) |
 
 ---
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1452 

### Description

<!-- Describe your changes in detail -->
Add tab view component only for Liquid Glass powered OS with lighter initializer.
Add tab view taking `Tab` objects for iOS 18+

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let peoples use iOS 18+ API and role like search.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
