### PR TITLE
[#1562] Fix usage of `text input` component with `Full Keyboard Access`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Usage of `text input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1562)
 - Vocalization priority for `alert message` components and usage with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1564)
 - `PIN code input` component usage with Voice Over (Orange-OpenSource/ouds-ios#1529)
 - Missing `badges` on `toolbar top` component for app on iOS 27 with Xcode 26.5 and disabled Liquid Glass configuration (Orange-OpenSource/ouds-ios#1623)

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/InputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/InputContainer.swift
@@ -24,6 +24,9 @@ struct InputContainer: View {
     let suffix: String?
     let status: OUDSTextInput.Status
     let interactionState: TextInputInteractionState
+    let accessibilityLabel: String
+    let accessibilityValue: String
+    let accessibilityHint: String
 
     @Environment(\.theme) private var theme
 
@@ -45,7 +48,10 @@ struct InputContainer: View {
             // Input text container
             InputText(label: placeholder ?? label,
                       text: text,
-                      status: status)
+                      status: status,
+                      accessibilityLabel: accessibilityLabel,
+                      accessibilityValue: accessibilityValue,
+                      accessibilityHint: accessibilityHint)
 
             // Suffix container
             if let placeholder,

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/InputText.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/InputText.swift
@@ -22,6 +22,9 @@ struct InputText: View {
     let label: String
     let text: Binding<String>
     let status: OUDSTextInput.Status
+    let accessibilityLabel: String
+    let accessibilityValue: String
+    let accessibilityHint: String
 
     @Environment(\.theme) private var theme
     @Environment(\.colorScheme) private var colorScheme
@@ -36,9 +39,15 @@ struct InputText: View {
             if textInputAsSecureField {
                 SecureField(text: text, label: textFieldLabel)
                     .labelModerateLarge(theme)
+                    .accessibilityLabel(accessibilityLabel)
+                    .accessibilityValue(accessibilityValue)
+                    .accessibilityHint(accessibilityHint)
             } else {
                 TextField(text: text, label: textFieldLabel)
                     .labelModerateLarge(theme)
+                    .accessibilityLabel(accessibilityLabel)
+                    .accessibilityValue(accessibilityValue)
+                    .accessibilityHint(accessibilityHint)
             }
         }
         .modifier(SecureTextFieldModifier(isSecureTextField: textInputAsSecureField))

--- a/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/Internal/TextInputContainer.swift
@@ -69,7 +69,10 @@ struct TextInputContainer: View {
                                        prefix: prefix,
                                        suffix: suffix,
                                        status: status,
-                                       interactionState: interactionState)
+                                       interactionState: interactionState,
+                                       accessibilityLabel: accessibilityLabel,
+                                       accessibilityValue: accessibilityValue,
+                                       accessibilityHint: accessibilityHint?.rawValue ?? "")
                             .focused($focused, equals: true)
                     }
                 }
@@ -77,9 +80,6 @@ struct TextInputContainer: View {
                     focused = true
                 }
             }
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityValue(accessibilityValue)
-            .accessibilityHint(accessibilityHint?.rawValue ?? "")
 
             // Trailing action container
             TrailingActionContainer(trailingAction: trailingAction, status: status, interactionState: interactionState)

--- a/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/TextInput/OUDSTextInput.swift
@@ -583,7 +583,11 @@ public struct OUDSTextInput: View {
                 HelperErrorTextContainer(helperText: helperText, status: status)
                     .accessibilityHidden(true)
             }
-            .accessibilityElement(children: .contain)
+            // NOTE: .accessibilityElement(children: .contain) is intentionally absent here.
+            // It created a UIAccessibilityContainer barrier that prevented Full Keyboard Access
+            // (FKA) from reaching the UITextField via the UIKit view hierarchy. All a11y
+            // attributes (label, value, hint) are set directly on the TextField in InputText.swift,
+            // so VoiceOver behaviour is unaffected by this removal.
 
             if let helperLink, !helperLink.text.isEmpty {
                 OUDSLink(text: helperLink.text, size: .small, action: helperLink.action)


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1562 

### Description

<!-- Describe your changes in detail -->
Change accessibility hierarchies to let Full Keyboard Access reach the input field.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Make FKA users able to focus the text input component, and to focus before its field if a trailing action is defined.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
