### PR TITLE
[#1631] Fix use of `pin code input` component with `Full Keyboard Access`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Usage of `PIN code input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1631)
 - Usage of `text input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1562)
 - Vocalization priority for `alert message` components and usage with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1564)
 - `PIN code input` component usage with Voice Over (Orange-OpenSource/ouds-ios#1529)

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
@@ -30,6 +30,8 @@ import SwiftUI
 /// - BackspaceTextField (UITextField): Custom UITextField that detects backspace
 struct BackspaceDetectingTextField: UIViewRepresentable {
 
+    // MARK: - Properties
+
     @Binding var text: String
     @Binding var displayText: String
 
@@ -37,8 +39,22 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
     let index: Int
     let a11yLabel: String
     let a11yValue: String
+    /// Whether this field is the one currently expected to be the first responder.
+    ///
+    /// SwiftUI's `@FocusState` does not always reliably drive `becomeFirstResponder()` on a
+    /// `UITextField` hosted through `UIViewRepresentable`, especially when the focus change is
+    /// programmatic (e.g. autofocus on appear, or moving to the next digit after a keystroke).
+    ///
+    /// This flag lets `updateUIView` explicitly call `becomeFirstResponder()` on the underlying
+    /// `UITextField` when it should be focused. We deliberately do NOT call
+    /// `resignFirstResponder()` when this flag is `false`: on iOS/FKA the focus loss is driven by
+    /// the user (Tab, tap on another view…) and forcing `resignFirstResponder()` here would fight
+    /// against the system.
+    let isFocused: Bool
     let onBackspace: () -> Void
     let onTextInserted: (String) -> Void
+
+    // MARK: - UI View Representable
 
     /// Creates the UITextField instance.
     ///
@@ -89,6 +105,26 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         // changes and the value string switches between "Empty" and the actual digit)
         uiView.accessibilityLabel = a11yLabel
         uiView.accessibilityValue = a11yValue
+
+        // Explicit first responder acquisition.
+        //
+        // Required because SwiftUI's `@FocusState` bound via `.focused($focusedIndex, equals:)`
+        // does not always relay focus changes down to a `UITextField` hosted inside a
+        // `UIViewRepresentable`. This is particularly noticeable for:
+        // - the initial autofocus on appear,
+        // - the auto-advance to the next digit after a keystroke,
+        // - the auto-recede to the previous digit after a backspace.
+        //
+        // We do NOT force `resignFirstResponder()` on `isFocused == false`: focus loss is driven
+        // by the user (Tab in Full Keyboard Access, tap on another view…) and forcing resignation
+        // would fight against the system.
+        //
+        // Dispatch async to avoid mutating focus during a SwiftUI layout pass.
+        if isFocused, !uiView.isFirstResponder {
+            DispatchQueue.main.async {
+                _ = uiView.becomeFirstResponder()
+            }
+        }
     }
 
     /// Creates the coordinator that acts as the `UITextFieldDelegate`.

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -112,11 +112,17 @@ struct PinCodeInputContainer: View {
                 // The label and value are set directly on the UITextField inside BackspaceDetectingTextField.
             }
         }
-        // .contain keeps each digit field individually reachable by VoiceOver swipe gestures inside the group.
-        // VoiceOver first announces the group label (groupAccessibilityLabel), then the user can swipe
-        // into the container to reach and vocalize each individual digit field.
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(groupAccessibilityLabel)
+        // Accessibility grouping is applied conditionally:
+        // - When VoiceOver is active, we wrap the row in a `.contain` group with a global label
+        //   ("Enter the code with N digits"), so VoiceOver announces the group and lets the user
+        //   swipe into it to reach each digit individually.
+        // - When VoiceOver is NOT active (typical Full Keyboard Access scenario), we deliberately
+        //   avoid `.accessibilityElement(children: .contain)`. That modifier creates a
+        //   UIAccessibilityContainer barrier that hides the underlying UITextField children from
+        //   UIKit's focus system, making the whole component unreachable by Tab/Shift+Tab in FKA.
+        //   Without the container, each `UITextField` inside `BackspaceDetectingTextField` is a
+        //   native `UIFocusItem` and can be reached natively by FKA Tab navigation.
+        .modifier(PinCodeInputVoiceOverGroupModifier(groupLabel: groupAccessibilityLabel))
         .onAppear {
             // Focus on the first empty field if:
             // - autofocus is enabled (empty value case)
@@ -223,6 +229,7 @@ struct PinCodeInputContainer: View {
             index: index,
             a11yLabel: accessibilityLabel(for: index),
             a11yValue: accessibilityValue(for: index),
+            isFocused: focusedIndex == index,
             onBackspace: {
                 handleBackspace(at: index)
             },
@@ -398,5 +405,44 @@ struct PinCodeInputContainer: View {
 }
 
 // swiftlint:enable type_body_length
+
+// MARK: - VoiceOver-only Grouping Modifier
+
+/// Applies `.accessibilityElement(children: .contain)` and a group label ONLY when VoiceOver is running.
+///
+/// The PIN code component is a row of `BackspaceDetectingTextField` (a `UIViewRepresentable` wrapping
+/// a custom `UITextField`). We want two different accessibility behaviours:
+///
+/// - **VoiceOver ON**: expose the whole row as a single container with a spoken group label
+///   ("Enter the code with N digits"). The user can then swipe inside the container to reach and
+///   vocalize each digit individually.
+///
+/// - **VoiceOver OFF (typical Full Keyboard Access scenario)**: do **not** apply `.contain`.
+///   That modifier creates a `UIAccessibilityContainer` barrier which hides every underlying
+///   `UITextField` from UIKit's focus system, making the whole component unreachable by Tab in FKA.
+///   Without it, each `UITextField` remains a native `UIFocusItem` and is reached directly by
+///   FKA navigation, one digit at a time.
+struct PinCodeInputVoiceOverGroupModifier: ViewModifier {
+
+    // NOTE: People needing both Full Keyboard Access and VoiceOver simultaneously will get the
+    // VoiceOver behaviour (grouped container). See https://github.com/Orange-OpenSource/ouds-ios/issues/1631
+
+    let groupLabel: String
+
+    @Environment(\.accessibilityVoiceOverEnabled) private var isVoiceOverEnabled
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if isVoiceOverEnabled {
+            content
+                .accessibilityElement(children: .contain)
+                .accessibilityLabel(groupLabel)
+        } else {
+            // Do not add a container: keep each UITextField natively focusable by FKA.
+            // (┛ಠ_ಠ)┛彡┻━┻
+            content
+        }
+    }
+}
 
 #endif


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1631 

### Description

<!-- Describe your changes in detail -->
Change a11y hierarchy with Voice Over state: add or not rules to let FKA find and focus the items

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let people with FKA use the component

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [x] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
