### PR TITLE
[#1491] Fix missing vocalization of `alert` components with `Voice Over` announcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Voice Over` announcement of displayed `alert` component (Orange-OpenSource/ouds-ios#1491)
 - Usage of `PIN code input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1631)
 - Usage of `password input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1533)
 - Usage of `text input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1562)

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -16,8 +16,6 @@ import OUDSFoundations
 import OUDSTokensSemantic
 import SwiftUI
 
-// swiftlint:disable type_body_length
-
 struct PinCodeInputContainer: View {
 
     // MARK: - Properties
@@ -386,25 +384,10 @@ struct PinCodeInputContainer: View {
     }
 
     private func announceFocusChanged(forInputAt index: Int) {
-        #if canImport(UIKit)
-        guard UIAccessibility.isVoiceOverRunning else { return }
-        #endif
         let message = "core_pinCodeInput_digitLabel_a11y_\(index + 1)".localized()
-        if #available(iOS 17, visionOS 1, macOS 14, *) {
-            var announcement = AttributedString(message)
-            announcement.accessibilitySpeechAnnouncementPriority = .high
-            AccessibilityNotification.Announcement(announcement).post()
-        } else {
-            #if canImport(UIKit)
-            UIAccessibility.post(
-                notification: .announcement,
-                argument: message)
-            #endif
-        }
+        VoiceOverUtils.announce(message)
     }
 }
-
-// swiftlint:enable type_body_length
 
 // MARK: - VoiceOver-only Grouping Modifier
 

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/AlertMessage/AlertMessageContent.swift
@@ -67,6 +67,9 @@ struct AlertMessageContent: View {
         }
         .padding(.vertical, theme.alert.spacePaddingBlock)
         .fixedSize(horizontal: false, vertical: true)
+        .onAppear {
+            VoiceOverUtils.announce(accessibilityLabel)
+        }
     }
 
     // MARK: - Helpers

--- a/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/InlineAlert/InlineAlertLabel.swift
+++ b/OUDS/Core/Components/Sources/Dialogs/Alert/Internal/InlineAlert/InlineAlertLabel.swift
@@ -30,6 +30,9 @@ struct InlineAlertLabel: View {
             .foregroundColor(contentColor)
             .frame(maxWidth: theme.sizes.maxWidthLabelLarge.dimension(for: horizontalSizeClass ?? .regular), alignment: .leading)
             .accessibilityLabel(accessibilityLabel)
+            .onAppear {
+                VoiceOverUtils.announce(accessibilityLabel)
+            }
     }
 
     // MARK: - Private helper

--- a/OUDS/Core/Components/Sources/_/Utils/VoiceOverUtils.swift
+++ b/OUDS/Core/Components/Sources/_/Utils/VoiceOverUtils.swift
@@ -1,0 +1,38 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// To wrap some utility methods for accessibility uses and Voice Over
+enum VoiceOverUtils {
+
+    /// Makes a Voice Over vocalization / announcement of the given message
+    ///
+    /// - Parameter message: The message to vocalize as is
+    @MainActor static func announce(_ message: String) {
+        #if canImport(UIKit)
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        #endif
+        if #available(iOS 17, visionOS 1, macOS 14, *) {
+            var announcement = AttributedString(message)
+            announcement.accessibilitySpeechAnnouncementPriority = .high
+            AccessibilityNotification.Announcement(announcement).post()
+        } else {
+            #if canImport(UIKit)
+            UIAccessibility.post(
+                notification: .announcement,
+                argument: message)
+            #endif
+        }
+    }
+}


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1491 

### Description

<!-- Describe your changes in detail -->
If Voice Over enabled, make annoucement of the `alert` component

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Helper Voice Over users to get the important content of the alert, first.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
