### PR TITLE
[#1589] Update `link` component to v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `link` component to v2.3.0 (Orange-OpenSource/ouds-ios#1589)
 - Detection of forced legacy layout for navigation elements
 - **BREAKING**: `.neutral` and `.accent` `badge icon status` signatures
 - **BREAKING**: `.neutral` and `.accent` `alert status` parameter name

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -26,8 +26,10 @@ struct LinkButtonStyle: ButtonStyle {
     let isFullWidth: Bool
 
     @State private var isHover: Bool
+
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.oudsHorizontalSizeClass) private var oudsHorizontalSizeClass
 
     // MARK: Initializer
 
@@ -74,11 +76,19 @@ struct LinkButtonStyle: ButtonStyle {
     }
 
     private var minHeight: Double {
-        size == .small ? theme.link.sizeMinHeightSmall : theme.link.sizeMinHeightDefault
+        if oudsHorizontalSizeClass == .regular {
+            size == .small ? theme.link.sizeMinHeightSmall : theme.link.sizeMinHeightDefault
+        } else { // .compact, .extraCompact
+            theme.link.sizeMinHeightCompactDensity
+        }
     }
 
     private var verticalPadding: Double {
-        size == .small ? theme.link.spacePaddingBlockSmall : theme.link.spacePaddingBlockDefault
+        if oudsHorizontalSizeClass == .regular {
+            size == .small ? theme.link.spacePaddingBlockSmall : theme.link.spacePaddingBlockDefault
+        } else { // .compact, .extraCompact
+            size == .small ? theme.link.spacePaddingBlockCompactDensitySmall : theme.link.spacePaddingBlockCompactDensityDefault
+        }
     }
 }
 

--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -56,7 +56,7 @@ struct LinkButtonStyle: ButtonStyle {
             }
         }
         .padding(.horizontal, theme.link.spacePaddingInline)
-        .padding(.vertical, theme.link.spacePaddingBlockDefault)
+        .padding(.vertical, verticalPadding)
         .frame(minWidth: minWidth, minHeight: minHeight)
         .frame(maxWidth: isFullWidth ? .infinity : nil)
         .contentShape(Rectangle())
@@ -75,6 +75,10 @@ struct LinkButtonStyle: ButtonStyle {
 
     private var minHeight: Double {
         size == .small ? theme.link.sizeMinHeightSmall : theme.link.sizeMinHeightDefault
+    }
+
+    private var verticalPadding: Double {
+        size == .small ? theme.link.spacePaddingBlockSmall : theme.link.spacePaddingBlockDefault
     }
 }
 

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -79,7 +79,7 @@ import SwiftUI
 ///
 /// ![A link component in light and dark modes with Wireframe theme](component_link_Wireframe)
 ///
-/// - Version: 2.2.0 (Figma component design version)
+/// - Version: 2.3.0 (Figma component design version)
 /// - Since: 0.11.0
 @available(iOS 15, macOS 13, visionOS 1, watchOS 11, tvOS 16, *)
 public struct OUDSLink: View {

--- a/OUDS/Core/Themes/Orange/Tests/Values/ComponentTokens/MockTheme/MockTheme+AllLinkComponentTokens.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/ComponentTokens/MockTheme/MockTheme+AllLinkComponentTokens.swift
@@ -58,6 +58,7 @@ final class MockThemeLinkComponentTokenProvider: OrangeThemeLinkComponentTokensP
     override var spaceColumnGapChevronSmall: SpaceSemanticToken { Self.mockThemeLinkSpace }
     override var sizeIconDefault: SizeSemanticToken { Self.mockThemeLinkSize }
     override var sizeIconSmall: SizeSemanticToken { Self.mockThemeLinkSize }
+    override var sizeMinHeightCompactDensity: SizeSemanticToken { Self.mockThemeLinkSize }
     override var colorContentEnabled: MultipleColorSemanticToken { Self.mockThemeLinkColor }
     override var colorContentHover: MultipleColorSemanticToken { Self.mockThemeLinkColor }
     override var colorContentPressed: MultipleColorSemanticToken { Self.mockThemeLinkColor }

--- a/OUDS/Core/Themes/Orange/Tests/Values/ComponentTokens/ThemeOverrideOfLinkComponentTokensTests.swift
+++ b/OUDS/Core/Themes/Orange/Tests/Values/ComponentTokens/ThemeOverrideOfLinkComponentTokensTests.swift
@@ -57,6 +57,11 @@ struct ThemeOverrideOfLinkComponentTokensTests {
         #expect(inheritedTheme.link.sizeIconSmall == MockThemeLinkComponentTokenProvider.mockThemeLinkSize)
     }
 
+    @Test func inheritedThemeCanOverrideLinkComponentTokenSizeMinHeightCompactDensity() throws {
+        #expect(inheritedTheme.link.sizeMinHeightCompactDensity != abstractTheme.link.sizeMinHeightCompactDensity)
+        #expect(inheritedTheme.link.sizeMinHeightCompactDensity == MockThemeLinkComponentTokenProvider.mockThemeLinkSize)
+    }
+
     // MARK: - Colors
 
     @Test func inheritedThemeCanOverrideLinkMonoComponentTokenColorContentEnabled() throws {

--- a/OUDS/Core/Tokens/ComponentTokens/Sources/Values/LinkComponentTokens.swift
+++ b/OUDS/Core/Tokens/ComponentTokens/Sources/Values/LinkComponentTokens.swift
@@ -29,6 +29,7 @@ public protocol LinkComponentTokens {
 
     var sizeMinHeightSmall: SizeSemanticToken { get }
     var sizeMinHeightDefault: SizeSemanticToken { get }
+    var sizeMinHeightCompactDensity: SizeSemanticToken { get }
     var sizeMinWidthSmall: SizeSemanticToken { get }
     var sizeMinWidth: SizeSemanticToken { get }
     var sizeIconSmall: SizeSemanticToken { get }


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1589

### Description

<!-- Describe your changes in detail -->
Manage density / size class to apply tokens

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Be aligned with v2.3.0 of specifications

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->
- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [ ] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
