### PR TITLE
[#1641] Fix truncated `tab bar item` text on focused elements with FKA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Truncated title on `tab bar` focused item when using *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1641)
 - `Voice Over` announcement of displayed `alert` component (Orange-OpenSource/ouds-ios#1491)
 - Usage of `PIN code input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1631)
 - Usage of `password input` with *Full Keyboard Access* (Orange-OpenSource/ouds-ios#1533)

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/PhysicalKeyboardDetector.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/Internal/PhysicalKeyboardDetector.swift
@@ -1,0 +1,35 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+#if os(iOS)
+
+import GameController
+
+/// Internal utility used by the `OUDSTabBar` to detect the presence of a physical keyboard connected to the device.
+///
+/// This is used as a proxy for detecting Full Keyboard Access (FKA), because iOS does not expose any public API
+/// to read the FKA setting (unlike VoiceOver, Switch Control, etc.).
+///
+/// The rationale is UX-oriented: when a physical keyboard is connected, a tab bar item can enter the `focused`
+/// state (via keyboard navigation / FKA). In this state the default OUDS style applies the bold `selectedFont`,
+/// which at the fixed small font size used by `UITabBar` (10pt on iPhone, 13pt on iPad) can cause the title
+/// text to be truncated. Falling back to the regular-weight font in this situation prevents the truncation.
+enum PhysicalKeyboardDetector {
+
+    /// `true` when a hardware keyboard is currently connected to the device, `false` otherwise.
+    static var isPhysicalKeyboardConnected: Bool {
+        GCKeyboard.coalesced != nil
+    }
+}
+
+#endif

--- a/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/TabBar/OUDSTabBarViewModifier.swift
@@ -17,6 +17,10 @@ import OUDSFoundations
 import OUDSThemesContract
 import SwiftUI
 
+#if os(iOS)
+import GameController
+#endif
+
 /// Defines the look and feel the tab bar must have by applying the OUDS tokens.
 /// Changes only colors and typgraphies, and does not add additional items like indicator of selected tab or divider.
 /// To use these elements in your tab view, use instead ``OUDSTabBar``.
@@ -80,6 +84,15 @@ public struct OUDSTabBarViewModifier: ViewModifier {
             }
             .onChange(of: theme) { newTheme in
                 setupTabBarAppearance(andTheme: newTheme)
+            }
+            // React to physical keyboard connect/disconnect so the focused tab bar item font
+            // (regular vs bold) is refreshed accordingly. Used as a proxy for Full Keyboard Access, since
+            // iOS does not expose a public API to read the FKA setting.
+            .onReceive(NotificationCenter.default.publisher(for: .GCKeyboardDidConnect)) { _ in
+                setupTabBarAppearance(withColor: colorScheme)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .GCKeyboardDidDisconnect)) { _ in
+                setupTabBarAppearance(withColor: colorScheme)
             }
         #endif
         // Color scheme changes can rise a bit later after onAppear()
@@ -189,9 +202,19 @@ public struct OUDSTabBarViewModifier: ViewModifier {
 
         let focusedUIColor = themeToApply.bar.colorContentSelectedFocus.color(for: colorSchemeToApply).uiColor
         tabBarItemAppearance.focused.iconColor = focusedUIColor
+        // When a physical keyboard is connected (proxy for Full Keyboard Access, since iOS
+        // does not expose a public API to read the FKA setting), use the regular-weight font instead of the
+        // bold one for the focused state. The bold weight at the fixed small font size used by UITabBar
+        // (10pt on iPhone, 13pt on iPad) causes tab item titles to be truncated when navigating with the
+        // keyboard. See PhysicalKeyboardDetector for details.
+        #if os(iOS)
+        let focusedFont: UIFont = PhysicalKeyboardDetector.isPhysicalKeyboardConnected ? normalFont : selectedFont
+        #else
+        let focusedFont: UIFont = selectedFont
+        #endif
         tabBarItemAppearance.focused.titleTextAttributes = [
             .foregroundColor: focusedUIColor,
-            .font: selectedFont,
+            .font: focusedFont,
         ]
 
         // MARK: - Tab bar appearance


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1641 

### Description

<!-- Describe your changes in detail -->
If keyboard is connected, supposing it's for Full Keyboard Access, on iOS, use the normal font for focused tab bar item instead of the selected fond so as to prevent the text to be truncated because of the weight.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Improve readability of tab bar items with texts not truncated

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
