### PR TITLE
[#1589] Refactor management of `density` property for `OUDSLink`

### DIFF
--- a/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/Internal/LinkButtonStyle.swift
@@ -23,19 +23,20 @@ struct LinkButtonStyle: ButtonStyle {
 
     let layout: OUDSLink.Layout
     let size: OUDSLink.Size
+    let density: OUDSLink.Density
     let isFullWidth: Bool
 
     @State private var isHover: Bool
 
     @Environment(\.theme) private var theme
     @Environment(\.isEnabled) private var isEnabled
-    @Environment(\.oudsHorizontalSizeClass) private var oudsHorizontalSizeClass
 
     // MARK: Initializer
 
-    init(layout: OUDSLink.Layout, size: OUDSLink.Size, isFullWidth: Bool) {
+    init(layout: OUDSLink.Layout, size: OUDSLink.Size, density: OUDSLink.Density, isFullWidth: Bool) {
         self.layout = layout
         self.size = size
+        self.density = density
         self.isFullWidth = isFullWidth
         isHover = false
     }
@@ -76,17 +77,19 @@ struct LinkButtonStyle: ButtonStyle {
     }
 
     private var minHeight: Double {
-        if oudsHorizontalSizeClass == .regular {
+        switch density {
+        case .default:
             size == .small ? theme.link.sizeMinHeightSmall : theme.link.sizeMinHeightDefault
-        } else { // .compact, .extraCompact
+        case .compact:
             theme.link.sizeMinHeightCompactDensity
         }
     }
 
     private var verticalPadding: Double {
-        if oudsHorizontalSizeClass == .regular {
+        switch density {
+        case .default:
             size == .small ? theme.link.spacePaddingBlockSmall : theme.link.spacePaddingBlockDefault
-        } else { // .compact, .extraCompact
+        case .compact:
             size == .small ? theme.link.spacePaddingBlockCompactDensitySmall : theme.link.spacePaddingBlockCompactDensityDefault
         }
     }

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -25,8 +25,8 @@ import SwiftUI
 /// This layout is used to open a link or to display a specific feature (like send feedbacks, show more, ...)
 ///
 /// ```swift
-///     // Text only in small size
-///     OUDSLink(text: "Feedback", size: .small) { /* the action to process */ }
+///     // Text only in small size, in compact density
+///     OUDSLink(text: "Feedback", size: .small, density: .compact) { /* the action to process */ }
 ///
 ///     // From a localizable and a bundle
 ///     OUDSLink(LocalizedStringKey("feedback_link"), bundle: Bundle.module, size: .small) { }
@@ -44,7 +44,7 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Navigate to next page with link in a small size
-///     OUDSLink(text: "Feedback", indicator: .next, size: .small) { /* the action to process */ }
+///     OUDSLink(text: "Feedback", indicator: .next, size: .small, density: .compac) { /* the action to process */ }
 ///
 ///     // Navigate to previous page with link in a default size
 ///     OUDSLink(text: "Back", indicator: .previous, size: .default) { /* the action to process */ }
@@ -92,6 +92,7 @@ public struct OUDSLink: View {
     private let layout: Layout
     private let text: String
     private let size: Size
+    private let density: Density
     private let isFullWidth: Bool
     private let action: () -> Void
 
@@ -102,6 +103,13 @@ public struct OUDSLink: View {
     /// - Since: 0.11.0
     @frozen public enum Size {
         case small, `default`
+    }
+
+    /// Represents the type of density for an `OUDSLink`.
+    /// `.compact` can be used for interfaces with a lot of content to display.
+    /// - Since: 3.0.0
+    @frozen public enum Density {
+        case `default`, compact
     }
 
     /// Represents the arrow / chevron / indicator of an `OUDSLink`.
@@ -134,15 +142,18 @@ public struct OUDSLink: View {
     ///   - text: Text displayed in the link
     ///   - image: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
     ///   - size: Size of the link
+    ///   - density: The density to apply to the link defining some spaces, default set to `.default`
     ///   - action: The action to perform when the user triggers the link
     public init(text: String,
                 image: OUDSImage? = nil,
                 size: Size = .default,
+                density: Density = .default,
                 action: @escaping () -> Void)
     {
         layout = image.map { .textAndIcon($0) } ?? .textOnly
         self.text = text
         self.size = size
+        self.density = density
         isFullWidth = false
         self.action = action
     }
@@ -166,17 +177,20 @@ public struct OUDSLink: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - image: An optional ``OUDSImage`` encapsulating the asset and its rendering mode. Default set to `nil` (text-only layout).
     ///   - size: Size of the link
+    ///   - density: The density to apply to the link defining some spaces, default set to `.default`
     ///   - action: The action to perform when the user triggers the link
     public init(_ key: LocalizedStringKey,
                 tableName: String? = nil,
                 bundle: Bundle = .main,
                 image: OUDSImage? = nil,
                 size: Size = .default,
+                density: Density = .default,
                 action: @escaping () -> Void)
     {
         layout = image.map { .textAndIcon($0) } ?? .textOnly
         text = key.resolved(tableName: tableName, bundle: bundle)
         self.size = size
+        self.density = density
         isFullWidth = false
         self.action = action
     }
@@ -200,14 +214,22 @@ public struct OUDSLink: View {
     ///   When `OUDSLink.Indicator.previous`, the indicator is displayed before the text.
     ///   When `OUDSLink.Indicator.next`, the indicator is displayed after the text.
     ///   - size: Size of the link
+    ///   - density: The density to apply to the link defining some spaces, default set to `.default`
     ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
     ///   The label stays anchored to the an edge and the indicator to the other edge.
     ///   Defaults to `false` (intrinsic sizing).
     ///   - action: The action to perform when the user triggers the link
-    public init(text: String, indicator: Indicator, size: Size = .default, isFullWidth: Bool = false, action: @escaping () -> Void) {
+    public init(text: String,
+                indicator: Indicator,
+                size: Size = .default,
+                density: Density = .default,
+                isFullWidth: Bool = false,
+                action: @escaping () -> Void)
+    {
         layout = .indicator(indicator)
         self.text = text
         self.size = size
+        self.density = density
         self.isFullWidth = isFullWidth
         self.action = action
     }
@@ -227,6 +249,7 @@ public struct OUDSLink: View {
     ///   - bundle: The bundle in which to look up the localized string. Defaults to `Bundle.main`.
     ///   - indicator: Indicator displayed in the link
     ///   - size: Size of the link
+    ///   - density: The density to apply to the link defining some spaces, default set to `.default`
     ///   - isFullWidth: When `true`, the link stretches to fill all available horizontal width.
     ///   The label stays anchored to one edge and the indicator to the other edge.
     ///   Defaults to `false` (intrinsic sizing).
@@ -236,12 +259,14 @@ public struct OUDSLink: View {
                 bundle: Bundle = .main,
                 indicator: Indicator,
                 size: Size = .default,
+                density: Density = .default,
                 isFullWidth: Bool = false,
                 action: @escaping () -> Void)
     {
         layout = .indicator(indicator)
         text = key.resolved(tableName: tableName, bundle: bundle)
         self.size = size
+        self.density = density
         self.isFullWidth = isFullWidth
         self.action = action
     }
@@ -280,7 +305,7 @@ public struct OUDSLink: View {
                 }
             }
         }
-        .buttonStyle(LinkButtonStyle(layout: layout, size: size, isFullWidth: isFullWidth))
+        .buttonStyle(LinkButtonStyle(layout: layout, size: size, density: density, isFullWidth: isFullWidth))
         .accessibilityRemoveTraits(.isButton)
         .accessibilityAddTraits(.isLink)
     }

--- a/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
+++ b/OUDS/Core/Components/Sources/Navigations/Link/OUDSLink.swift
@@ -44,7 +44,7 @@ import SwiftUI
 ///
 /// ```swift
 ///     // Navigate to next page with link in a small size
-///     OUDSLink(text: "Feedback", indicator: .next, size: .small, density: .compac) { /* the action to process */ }
+///     OUDSLink(text: "Feedback", indicator: .next, size: .small, density: .compact) { /* the action to process */ }
 ///
 ///     // Navigate to previous page with link in a default size
 ///     OUDSLink(text: "Back", indicator: .previous, size: .default) { /* the action to process */ }

--- a/skills/ouds-ios-framework-usage/SKILL.md
+++ b/skills/ouds-ios-framework-usage/SKILL.md
@@ -505,8 +505,9 @@ OUDSVerticalDivider(color: .brandPrimary)
 ### Navigations — Link
 
 ```swift
-OUDSLink(text: "Text", size: .default) {}
-OUDSLink(text: "Text", indicator: .previous, size: .default) {}
+OUDSLink(text: "Text", size: .small) {}
+OUDSLink(text: "Text", indicator: .previous, size: .small) {}
+OUDSLink(text: "Text", indicator: .previous, size: .small, density: .compact) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic")), size: .default) {}
 OUDSLink(text: "Text", image: OUDSImage(asset: Image("ic"), renderingMode: .original), size: .default) {} // raw image (not tinted)
 // Full-width indicator: label in one edge, indicator in the other edge, entire width is tappable
@@ -516,6 +517,8 @@ OUDSLink(text: "Text", indicator: .external, isFullWidth: true, size: .default) 
 ```
 
 > `isFullWidth` is only available on `indicator` layouts (`.previous` / `.next` / `.external`). When `true`, the link stretches to fill all available horizontal width — the label anchors to the leading/trailing edge and the indicator to the trailing/leading edge. The entire width between them is tappable. Defaults to `false` (intrinsic sizing).
+>
+> `density` parameter (since v3.0.0) is available as `.default` (standard spacing) or `.compact` (reduced spacing for interfaces with limited space). Applies to all layout types. Defaults to `.default`.
 
 ---
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1589

### Description

<!-- Describe your changes in detail -->
_Density_ was supposed to be a property.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Implement v2.3 "density" notion as property

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- (NA) My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
