### PR TITLE
[#1706] Add `OUDS Animated Image` API based on `ImageIO`, update `list item` API to use animated images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
 - Leading, trailing and bottom slots for `list item` components (Orange-OpenSource/ouds-ios#1568)
 - `OUDSAsyncImage` API for cached `AsyncImage` and use inside `list item` components (Orange-OpenSource/ouds-ios#1681)
 - Helpers to apply OUDS styles for rich text (Orange-OpenSource/ouds-ios#1682)

--- a/OUDS/Core/Components/Sources/Navigations/ListItem/Nested/OUDSListItemImage.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ListItem/Nested/OUDSListItemImage.swift
@@ -48,6 +48,10 @@ import SwiftUI
 ///     // Async image from URL
 ///     OUDSListItemImage(asyncImage: OUDSAsyncImage(url: URL(string: "https://example.com/image.png")), description: "A remote image")
 ///
+///     // Animated image (GIF or WebP) from URL
+///     OUDSListItemImage(animatedImage: OUDSAnimatedImage(url: URL(string: "https://example.com/animation.gif")),
+///                       description: "An animated image")
+///
 ///     // Usage as leading element in a list item
 ///     OUDSStaticListItem(
 ///         data: OUDSListItemData(label: "Information"),
@@ -173,17 +177,52 @@ public struct OUDSListItemImage: View {
         self.description = description
     }
 
+    /// Creates an image element for use in a list item at the leading or trailing position with an animated
+    /// image (GIF or WebP).
+    ///
+    /// ```swift
+    ///     // Animated image from a remote URL
+    ///     OUDSListItemImage(animatedImage: OUDSAnimatedImage(url: URL(string: "https://example.com/animation.gif")),
+    ///                       description: "An animated image")
+    ///
+    ///     // Animated image from a local file bundled with the app (not an .xcassets entry)
+    ///     OUDSListItemImage(animatedImage: OUDSAnimatedImage(named: "loading_spinner", withExtension: "gif"),
+    ///                       description: "An animated image")
+    ///
+    ///     // Animated image from local data (e.g. already downloaded and cached by the caller)
+    ///     OUDSListItemImage(animatedImage: OUDSAnimatedImage(data: myWebPData),
+    ///                       description: "An animated image",
+    ///                       size: .large)
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - animatedImage: The animated image to play (created with ``OUDSAnimatedImage``)
+    ///   - description: The description of the image for accessibility
+    ///   - size: The size of the icon. Defaults to `.medium`.
+    ///     **Note:** Ignored when the icon is embedded in a list item with small size
+    ///     (via ``SwiftUICore/View/oudsListItemSize(_:)``), where the smallest size is always applied.
+    ///   - ratio: Ratio of the image. By default a `square` image.
+    ///   - contentMode: A flag indicating whether this view should fit or fill the parent context. Default set to `.fit`.
+    public init(animatedImage: OUDSAnimatedImage, description: String? = nil, size: Size = .medium, ratio: Ratio = .square, contentMode: ContentMode = .fit) {
+        imageType = .animated(AnyView(animatedImage))
+        self.size = size
+        self.ratio = ratio
+        self.contentMode = contentMode
+        self.description = description
+    }
+
     // MARK: Image Type
 
     /// Defines the type of image displayed in the list item.
-    ///
-    /// - Since: 3.0.0
-    @frozen public enum ImageType {
+    enum ImageType {
         /// A static image asset.
         case asset(Image)
 
         /// An async image loaded from a URL.
         case asyncImage(AnyView)
+
+        /// An animated image (GIF or WebP).
+        case animated(AnyView)
     }
 
     // MARK: Body
@@ -207,6 +246,9 @@ public struct OUDSListItemImage: View {
                 .resizable()
                 .aspectRatio(contentMode: contentMode)
         case let .asyncImage(anyView):
+            anyView
+                .aspectRatio(contentMode: contentMode)
+        case let .animated(anyView):
             anyView
                 .aspectRatio(contentMode: contentMode)
         }

--- a/OUDS/Core/Components/Sources/_/Internal/Utils/AnimatedImageDecoder.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/Utils/AnimatedImageDecoder.swift
@@ -11,8 +11,8 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
+import Foundation
 import ImageIO
-import UniformTypeIdentifiers
 
 // MARK: - Animated Image Frame
 

--- a/OUDS/Core/Components/Sources/_/Internal/Utils/AnimatedImageDecoder.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/Utils/AnimatedImageDecoder.swift
@@ -1,0 +1,153 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import ImageIO
+import UniformTypeIdentifiers
+
+// MARK: - Animated Image Frame
+
+/// A single decoded frame of an animated image.
+struct AnimatedImageFrame: Sendable {
+
+    /// The decoded frame image.
+    let image: CGImage
+
+    /// The duration, in seconds, this frame must be displayed before moving to the next one.
+    let duration: TimeInterval
+}
+
+// MARK: - Animated Image Content
+
+/// The result of decoding an animated image (GIF or WebP).
+struct AnimatedImageContent: Sendable {
+
+    /// The ordered list of decoded frames.
+    let frames: [AnimatedImageFrame]
+
+    /// The number of times the animation must loop, `0` meaning infinite.
+    let loopCount: Int
+
+    /// The total duration, in seconds, of one animation loop.
+    var totalDuration: TimeInterval {
+        frames.reduce(0) { $0 + $1.duration }
+    }
+}
+
+// MARK: - Animated Image Decoder
+
+/// ``AnimatedImageDecoder`` decodes animated GIF and WebP images using only Apple's native
+/// `ImageIO` framework: no third-party library (such as `libwebp` or `SDWebImage`) nor external dependency is used.
+enum AnimatedImageDecoder {
+
+    // MARK: Duration
+
+    /// Fallback duration applied to a frame if `ImageIO` does not report any (some encoders omit it).
+    private static let defaultFrameDuration: TimeInterval = 0.1
+
+    /// Minimal accepted duration for a frame, protects against a too fast (near 0) advertised delay.
+    private static let minimalFrameDuration: TimeInterval = 0.02
+
+    // MARK: Decoding
+
+    /// Decodes the given `data` as an animated image (GIF or WebP).
+    ///
+    /// - Parameter data: The raw bytes of the image to decode
+    /// - Returns: The decoded ``AnimatedImageContent`` if `data` contains at least one frame,
+    ///   or `nil` if the data cannot be decoded at all.
+    static func decode(data: Data) -> AnimatedImageContent? {
+        guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return nil }
+
+        let frameCount = CGImageSourceGetCount(source)
+        guard frameCount > 0 else { return nil }
+
+        var frames: [AnimatedImageFrame] = []
+        frames.reserveCapacity(frameCount)
+
+        for index in 0 ..< frameCount {
+            guard let cgImage = CGImageSourceCreateImageAtIndex(source, index, nil) else { continue }
+            let duration = frameDuration(source: source, index: index)
+            frames.append(AnimatedImageFrame(image: cgImage, duration: duration))
+        }
+
+        guard !frames.isEmpty else { return nil }
+
+        return AnimatedImageContent(frames: frames, loopCount: loopCount(source: source))
+    }
+
+    // MARK: Helpers
+
+    /// Reads the display duration of the frame at `index`, looking successively at the GIF and WebP
+    /// `ImageIO` dictionaries (unanimated / single-frame images fall back to a default duration).
+    private static func frameDuration(source: CGImageSource, index: Int) -> TimeInterval {
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, index, nil) as? [CFString: Any] else {
+            return defaultFrameDuration
+        }
+
+        if let gifProperties = properties[kCGImagePropertyGIFDictionary] as? [CFString: Any] {
+            if let unclamped = gifProperties[kCGImagePropertyGIFUnclampedDelayTime] as? Double {
+                return max(unclamped, minimalFrameDuration)
+            }
+            if let delay = gifProperties[kCGImagePropertyGIFDelayTime] as? Double {
+                return max(delay, minimalFrameDuration)
+            }
+        }
+
+        if let webpProperties = properties[kCGImagePropertyWebPDictionary] as? [CFString: Any],
+           let delay = webpProperties[kCGImagePropertyWebPDelayTime] as? Double
+        {
+            return max(delay, minimalFrameDuration)
+        }
+
+        return defaultFrameDuration
+    }
+
+    /// Reads the loop count of the animation from the first frame's properties (`0` means infinite).
+    private static func loopCount(source: CGImageSource) -> Int {
+        guard let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] else {
+            return 0
+        }
+
+        if let gifProperties = properties[kCGImagePropertyGIFDictionary] as? [CFString: Any],
+           let loopCount = gifProperties[kCGImagePropertyGIFLoopCount] as? Int
+        {
+            return loopCount
+        }
+
+        if let webpProperties = properties[kCGImagePropertyWebPDictionary] as? [CFString: Any],
+           let loopCount = webpProperties[kCGImagePropertyWebPLoopCount] as? Int
+        {
+            return loopCount
+        }
+
+        return 0
+    }
+}
+
+// MARK: - Animated Image Bundle Resource Loader
+
+/// Resolves and reads the raw bytes of a `.gif`/`.webp` file added to a `Bundle` as a plain resource
+/// (not inside an `.xcassets` catalog).
+enum AnimatedImageBundleResourceLoader {
+
+    /// Reads the bytes of the resource `name` (with optional `extension`) in `bundle`.
+    ///
+    /// - Parameters:
+    ///   - name: The file name of the resource, without its extension
+    ///   - extension: The file extension, or `nil` to match the first resource found for `name`
+    ///   - bundle: The bundle to look the resource up into
+    /// - Returns: The content of the file, or `nil` if the resource cannot be found or read
+    static func data(name: String, extension: String?, bundle: Bundle) -> Data? {
+        guard let url = bundle.url(forResource: name, withExtension: `extension`) else { return nil }
+        return try? Data(contentsOf: url)
+    }
+}

--- a/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
+++ b/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
@@ -11,6 +11,7 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
+import OUDSFoundations
 import SwiftUI
 
 /// ``OUDSAnimatedImage`` is a SwiftUI view able to play animated **GIF** and **WebP** images.
@@ -33,6 +34,10 @@ import SwiftUI
 /// frame when:
 /// - "Reduce Motion" accessibility setting is enabled, or
 /// - Low Power Mode is enabled.
+///
+/// > Note: Low Power Mode detection relies on ``OUDSLowPowerModeObserver``, injected as an environment
+/// > object by ``OUDSThemeableView``. Make sure ``OUDSAnimatedImage`` is used inside a view hierarchy
+/// > rooted by ``OUDSThemeableView`` for this behavior to work.
 ///
 /// ## Code samples
 ///
@@ -187,6 +192,7 @@ private struct DecodedAnimatedImageView: View {
     @State private var content: AnimatedImageContent?
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @EnvironmentObject private var lowPowerModeObserver: OUDSLowPowerModeObserver
 
     var body: some View {
         Group {
@@ -211,7 +217,7 @@ private struct DecodedAnimatedImageView: View {
     /// The animation must be paused (first frame only) when the user asked for reduced motion,
     /// or when the device is in Low Power Mode, to save battery.
     private var shouldAnimate: Bool {
-        !reduceMotion && !ProcessInfo.processInfo.isLowPowerModeEnabled
+        !reduceMotion && !lowPowerModeObserver.isLowPowerModeEnabled
     }
 
     @ViewBuilder

--- a/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
+++ b/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
@@ -1,0 +1,242 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import SwiftUI
+
+/// ``OUDSAnimatedImage`` is a SwiftUI view able to play animated **GIF** and **WebP** images.
+///
+/// Remote animated images are downloaded and cached (memory + disk) using ``OUDSAsyncImageCache``.
+///
+/// ## Providing a local GIF or WebP file
+///
+/// Animated images **must not** be added to an `.xcassets` catalog: Asset Catalogs only keep the first
+/// frame of an animated GIF or WebP, discarding the animation. Instead, add the `.gif`/`.webp` file to
+/// the app (or module) target as a plain bundle resource:
+/// 1. Drag & drop the file into the Xcode project navigator.
+/// 2. In the dialog, check **"Copy items if needed"**.
+/// 3. Make sure the file's **Target Membership** includes your app/module target.
+/// 4. Load it with ``init(named:withExtension:bundle:)``, see below.
+///
+/// ## Accessibility and ecodesign
+///
+/// To respect the user's preferences and save battery, the animation automatically pauses on its first
+/// frame when:
+/// - "Reduce Motion" accessibility setting is enabled, or
+/// - Low Power Mode is enabled.
+///
+/// ## Code samples
+///
+/// ```swift
+///     // From a remote URL (downloaded once, then cached)
+///     OUDSAnimatedImage(url: URL(string: "https://example.com/animation.gif"))
+///
+///     // From a local file bundled with the app ("loading_spinner.gif" in the main bundle)
+///     OUDSAnimatedImage(named: "loading_spinner", withExtension: "gif")
+///
+///     // From a local file bundled with a Swift Package module ("product_teaser.webp" in .module)
+///     OUDSAnimatedImage(named: "product_teaser", withExtension: "webp", bundle: .module)
+///
+///     // From local data already loaded by the caller (e.g. downloaded and cached elsewhere)
+///     OUDSAnimatedImage(data: myWebPData)
+/// ```
+///
+/// - Since: 3.0.0
+@available(iOS 15, macOS 13, visionOS 1, watchOS 11, tvOS 16, *)
+public struct OUDSAnimatedImage: View {
+
+    // MARK: - Properties
+
+    private let source: Source
+
+    private enum Source {
+        case url(URL?)
+        case data(Data)
+        case bundleResource(name: String, extension: String?, bundle: Bundle)
+    }
+
+    // MARK: - Initializers
+
+    /// Creates an animated image loaded and cached from the given `url`.
+    ///
+    /// - Parameter url: The URL of the animated (GIF or WebP) image to load
+    public init(url: URL?) {
+        source = .url(url)
+    }
+
+    /// Creates an animated image from local `data` (e.g. bytes already downloaded and cached by the caller).
+    ///
+    /// - Parameter data: The raw bytes of the animated (GIF or WebP) image
+    public init(data: Data) {
+        source = .data(data)
+    }
+
+    /// Creates an animated image loaded from a local **GIF** or **WebP** file bundled with the application
+    /// (or a Swift Package module).
+    ///
+    /// The file **must not** be added inside an `.xcassets` catalog: Asset Catalogs only keep the first
+    /// frame of an animated image, discarding the animation. Instead, add it to the target as a plain
+    /// bundle resource (drag & drop into the Xcode target, checking "Copy items if needed" and the
+    /// target membership).
+    ///
+    /// ```swift
+    ///     // "loading_spinner.gif" added as a bundle resource of the main target
+    ///     OUDSAnimatedImage(named: "loading_spinner", withExtension: "gif")
+    ///
+    ///     // "product_teaser.webp" bundled in a Swift Package module resource
+    ///     OUDSAnimatedImage(named: "product_teaser", withExtension: "webp", bundle: .module)
+    ///
+    ///     // Extension omitted: the first resource matching the name, whatever its extension, is used
+    ///     OUDSAnimatedImage(named: "loading_spinner")
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - name: The file name of the animated image, without its extension (e.g. `"loading_spinner"`)
+    ///   - extension: The file extension, e.g. `"gif"` or `"webp"`. Pass `nil` to let the system pick
+    ///     the first resource matching `name` regardless of its extension. Defaults to `nil`.
+    ///   - bundle: The bundle containing the resource. Defaults to `.main`.
+    public init(named name: String, withExtension extension: String? = nil, bundle: Bundle = .main) {
+        source = .bundleResource(name: name, extension: `extension`, bundle: bundle)
+    }
+
+    // MARK: Body
+
+    public var body: some View {
+        switch source {
+        case let .url(url):
+            RemoteAnimatedImageView(url: url)
+        case let .data(data):
+            DecodedAnimatedImageView(data: data)
+        case let .bundleResource(name, fileExtension, bundle):
+            BundleResourceAnimatedImageView(name: name, extension: fileExtension, bundle: bundle)
+        }
+    }
+}
+
+// MARK: - Bundle Resource Animated Image View
+
+@available(iOS 15, macOS 13, visionOS 1, watchOS 11, tvOS 16, *)
+private struct BundleResourceAnimatedImageView: View {
+
+    let name: String
+    let `extension`: String?
+    let bundle: Bundle
+
+    @State private var data: Data?
+
+    var body: some View {
+        Group {
+            if let data {
+                DecodedAnimatedImageView(data: data)
+            } else {
+                Color.clear
+            }
+        }
+        .task(id: name) {
+            data = await Self.loadData(name: name, extension: `extension`, bundle: bundle)
+        }
+    }
+
+    /// Reads the bytes of the bundle resource matching `name`/`extension`, off the main actor to avoid
+    /// blocking the UI while reading a potentially large file.
+    private static func loadData(name: String, extension: String?, bundle: Bundle) async -> Data? {
+        await Task.detached(priority: .utility) {
+            AnimatedImageBundleResourceLoader.data(name: name, extension: `extension`, bundle: bundle)
+        }.value
+    }
+}
+
+// MARK: - Remote Animated Image View
+
+private struct RemoteAnimatedImageView: View {
+
+    let url: URL?
+
+    @State private var data: Data?
+
+    var body: some View {
+        Group {
+            if let data {
+                DecodedAnimatedImageView(data: data)
+            } else {
+                Color.clear
+            }
+        }
+        .task(id: url) {
+            guard let url else { return }
+            data = await OUDSAsyncImageCache.shared.loadData(from: url)
+        }
+    }
+}
+
+// MARK: - Decoded Animated Image View
+
+private struct DecodedAnimatedImageView: View {
+
+    let data: Data
+
+    @State private var content: AnimatedImageContent?
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        Group {
+            if let content, !content.frames.isEmpty {
+                if shouldAnimate, content.frames.count > 1 {
+                    TimelineView(.animation) { timeline in
+                        frame(for: timeline.date, content: content)
+                    }
+                } else {
+                    Image(decorative: content.frames[0].image, scale: 1)
+                        .resizable()
+                }
+            } else {
+                Color.clear
+            }
+        }
+        .task(id: data) {
+            content = AnimatedImageDecoder.decode(data: data)
+        }
+    }
+
+    /// The animation must be paused (first frame only) when the user asked for reduced motion,
+    /// or when the device is in Low Power Mode, to save battery.
+    private var shouldAnimate: Bool {
+        !reduceMotion && !ProcessInfo.processInfo.isLowPowerModeEnabled
+    }
+
+    @ViewBuilder
+    private func frame(for date: Date, content: AnimatedImageContent) -> some View {
+        let index = frameIndex(at: date, content: content)
+        Image(decorative: content.frames[index].image, scale: 1)
+            .resizable()
+    }
+
+    /// Computes the index of the frame that must be displayed at the given `date`, looping over the
+    /// whole animation duration.
+    private func frameIndex(at date: Date, content: AnimatedImageContent) -> Int {
+        let totalDuration = content.totalDuration
+        guard totalDuration > 0 else { return 0 }
+
+        let elapsed = date.timeIntervalSinceReferenceDate.truncatingRemainder(dividingBy: totalDuration)
+
+        var cumulated: TimeInterval = 0
+        for (index, frame) in content.frames.enumerated() {
+            cumulated += frame.duration
+            if elapsed < cumulated {
+                return index
+            }
+        }
+
+        return content.frames.count - 1
+    }
+}

--- a/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
+++ b/OUDS/Core/Components/Sources/_/Public/Views/OUDSAnimatedImage.swift
@@ -14,9 +14,9 @@
 import OUDSFoundations
 import SwiftUI
 
-/// ``OUDSAnimatedImage`` is a SwiftUI view able to play animated **GIF** and **WebP** images.
+/// `OUDSAnimatedImage` is a SwiftUI view able to play animated **GIF** and **WebP** images.
 ///
-/// Remote animated images are downloaded and cached (memory + disk) using ``OUDSAsyncImageCache``.
+/// Remote animated images are downloaded and cached (memory + disk) using `OUDSAsyncImageCache`.
 ///
 /// ## Providing a local GIF or WebP file
 ///
@@ -35,9 +35,9 @@ import SwiftUI
 /// - "Reduce Motion" accessibility setting is enabled, or
 /// - Low Power Mode is enabled.
 ///
-/// > Note: Low Power Mode detection relies on ``OUDSLowPowerModeObserver``, injected as an environment
-/// > object by ``OUDSThemeableView``. Make sure ``OUDSAnimatedImage`` is used inside a view hierarchy
-/// > rooted by ``OUDSThemeableView`` for this behavior to work.
+/// > Note: Low Power Mode detection relies on `OUDSLowPowerModeObserver`, injected as an environment
+/// > object by `OUDSThemeableView`. Make sure `OUDSAnimatedImage` is used inside a view hierarchy
+/// > rooted by `OUDSThemeableView` for this behavior to work.
 ///
 /// ## Code samples
 ///
@@ -210,7 +210,9 @@ private struct DecodedAnimatedImageView: View {
             }
         }
         .task(id: data) {
-            content = AnimatedImageDecoder.decode(data: data)
+            content = await Task.detached(priority: .userInitiated) {
+                AnimatedImageDecoder.decode(data: data)
+            }.value
         }
     }
 

--- a/OUDS/Core/Components/Tests/Navigations/ListItem/OUDSListItemImageTests.swift
+++ b/OUDS/Core/Components/Tests/Navigations/ListItem/OUDSListItemImageTests.swift
@@ -1,0 +1,42 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+@testable import OUDSComponents
+import SwiftUI
+import Testing
+
+/// Tests the `OUDSListItemImage.ImageType` cases, in particular the `.animated` case
+/// used to display GIF/WebP animated images (see ``AnimatedImage``).
+@MainActor
+struct OUDSListItemImageTests {
+
+    // MARK: - init(asset:) builds a .asset case
+
+    @Test func assetInitializerBuildsAssetCase() {
+        let image = OUDSListItemImage(asset: Image(systemName: "star"))
+        guard case .asset = image.imageType else {
+            Issue.record("Expected .asset case")
+            return
+        }
+    }
+
+    // MARK: - init(animatedImage:) builds a .animated case
+
+    @Test func animatedImageInitializerBuildsAnimatedCase() {
+        let image = OUDSListItemImage(animatedImage: OUDSAnimatedImage(url: nil))
+        guard case .animated = image.imageType else {
+            Issue.record("Expected .animated case")
+            return
+        }
+    }
+}

--- a/OUDS/Core/Components/Tests/_/AnimatedImageBundleResourceLoaderTests.swift
+++ b/OUDS/Core/Components/Tests/_/AnimatedImageBundleResourceLoaderTests.swift
@@ -1,0 +1,68 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+@testable import OUDSComponents
+import Testing
+
+/// Tests on ``AnimatedImageBundleResourceLoader``, used by ``OUDSAnimatedImage/init(named:withExtension:bundle:)``
+/// to read a local GIF/WebP file bundled as a plain resource (not an `.xcassets` entry).
+struct AnimatedImageBundleResourceLoaderTests {
+
+    // MARK: - Existing resource
+
+    @Test
+    func `data returns the bytes of an existing resource with matching extension`() {
+        let (bundle, name, fileExtension) = Self.makeTemporaryBundle(fileName: "sample", fileExtension: "gif", content: Data([0x01, 0x02, 0x03]))
+
+        let data = AnimatedImageBundleResourceLoader.data(name: name, extension: fileExtension, bundle: bundle)
+
+        #expect(data == Data([0x01, 0x02, 0x03]))
+    }
+
+    @Test
+    func `data returns the bytes of an existing WebP resource`() {
+        let (bundle, name, fileExtension) = Self.makeTemporaryBundle(fileName: "sample", fileExtension: "webp", content: Data([0x04, 0x05]))
+
+        let data = AnimatedImageBundleResourceLoader.data(name: name, extension: fileExtension, bundle: bundle)
+
+        #expect(data == Data([0x04, 0x05]))
+    }
+
+    // MARK: - Missing resource
+
+    @Test
+    func `data returns nil when the resource does not exist`() {
+        let bundle = Bundle.main
+
+        let data = AnimatedImageBundleResourceLoader.data(name: "does_not_exist", extension: "gif", bundle: bundle)
+
+        #expect(data == nil)
+    }
+
+    // MARK: - Helpers
+
+    /// Creates a temporary directory containing a single file, and wraps it in a `Bundle` so
+    /// `Bundle.url(forResource:withExtension:)` can resolve it, mimicking a plain bundle resource.
+    private static func makeTemporaryBundle(fileName: String, fileExtension: String, content: Data) -> (bundle: Bundle, name: String, extension: String) {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let fileURL = directory.appendingPathComponent(fileName).appendingPathExtension(fileExtension)
+        try? content.write(to: fileURL)
+
+        // swiftlint:disable:next force_unwrapping
+        let bundle = Bundle(url: directory)!
+        return (bundle, fileName, fileExtension)
+    }
+}

--- a/OUDS/Core/Components/Tests/_/OUDSAnimatedImageDecoderTests.swift
+++ b/OUDS/Core/Components/Tests/_/OUDSAnimatedImageDecoderTests.swift
@@ -1,0 +1,122 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import CoreGraphics
+import Foundation
+import ImageIO
+@testable import OUDSComponents
+import Testing
+import UniformTypeIdentifiers
+
+/// Tests on ``AnimatedImageDecoder``, decoding animated GIF images with pure `ImageIO`
+/// (no third-party dependency).
+struct OUDSAnimatedImageDecoderTests {
+
+    // MARK: - Decoding a valid animated GIF
+
+    @Test
+    func `decode returns one frame per image in an animated GIF`() {
+        let data = Self.makeAnimatedGIFData(frameCount: 3, delay: 0.2, loopCount: 0)
+
+        let content = AnimatedImageDecoder.decode(data: data)
+
+        #expect(content?.frames.count == 3)
+    }
+
+    @Test
+    func `decode reads the delay time of each frame`() {
+        let data = Self.makeAnimatedGIFData(frameCount: 2, delay: 0.25, loopCount: 0)
+
+        let content = AnimatedImageDecoder.decode(data: data)
+
+        #expect(content?.frames.allSatisfy { abs($0.duration - 0.25) < 0.01 } == true)
+    }
+
+    @Test
+    func `decode computes the total duration of one loop`() {
+        let data = Self.makeAnimatedGIFData(frameCount: 4, delay: 0.1, loopCount: 0)
+
+        let content = AnimatedImageDecoder.decode(data: data)
+
+        #expect(content.map { abs($0.totalDuration - 0.4) < 0.01 } == true)
+    }
+
+    // MARK: - Decoding invalid data
+
+    @Test
+    func `decode returns nil for invalid data`() {
+        let data = Data([0x00, 0x01, 0x02, 0x03])
+
+        let content = AnimatedImageDecoder.decode(data: data)
+
+        #expect(content == nil)
+    }
+
+    @Test
+    func `decode returns a single frame for a static (non-animated) image`() {
+        let data = Self.makeAnimatedGIFData(frameCount: 1, delay: 0.1, loopCount: 0)
+
+        let content = AnimatedImageDecoder.decode(data: data)
+
+        #expect(content?.frames.count == 1)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds, in memory, the raw bytes of an animated GIF with `frameCount` solid-color frames,
+    /// each displayed for `delay` seconds, looping `loopCount` times (`0` meaning infinite).
+    private static func makeAnimatedGIFData(frameCount: Int, delay: Double, loopCount: Int) -> Data {
+        let data = NSMutableData()
+
+        guard let destination = CGImageDestinationCreateWithData(data, UTType.gif.identifier as CFString, frameCount, nil) else {
+            return Data()
+        }
+
+        let gifProperties = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFLoopCount: loopCount]] as CFDictionary
+        CGImageDestinationSetProperties(destination, gifProperties)
+
+        let frameProperties = [kCGImagePropertyGIFDictionary: [kCGImagePropertyGIFDelayTime: delay]] as CFDictionary
+
+        for _ in 0 ..< frameCount {
+            let image = Self.makeSolidColorImage()
+            CGImageDestinationAddImage(destination, image, frameProperties)
+        }
+
+        guard CGImageDestinationFinalize(destination) else { return Data() }
+
+        return data as Data
+    }
+
+    /// Builds a tiny 4x4 solid color `CGImage`, sufficient to be encoded/decoded as a GIF frame.
+    private static func makeSolidColorImage() -> CGImage {
+        let width = 4
+        let height = 4
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGImageAlphaInfo.noneSkipLast.rawValue
+        guard let context = CGContext(data: nil, width: width, height: height, bitsPerComponent: 8, bytesPerRow: 0, space: colorSpace, bitmapInfo: bitmapInfo)
+        else {
+            Issue.record("Failed to build test CGContext")
+            fatalError("Failed to build test CGContext")
+        }
+
+        context.setFillColor(red: 1, green: 0, blue: 0, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+
+        guard let image = context.makeImage() else {
+            Issue.record("Failed to build test CGImage")
+            fatalError("Failed to build test CGImage")
+        }
+
+        return image
+    }
+}


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1706

### Description

<!-- Describe your changes in detail -->
Using `ImageIO` native library, manage GIF and WebP animated images through dedicated API.
Update `list item` API to use this new feature.

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let people display animated images in list item components.

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
