### PR TITLE
[#1696] Add `subtitle` on `toolbar top` for iOS < 26 or with Liquid Glass disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `subtitle` on `toolbar top` for iOS < 26 or with Liquid Glass disabled (Orange-OpenSource/ouds-ios#1696)
+- `subtitle` on `toolbar top` for iOS lower than 26 or with Liquid Glass disabled (Orange-OpenSource/ouds-ios#1696)
 - Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
 - Leading, trailing and bottom slots for `list item` components (Orange-OpenSource/ouds-ios#1568)
 - `OUDSAsyncImage` API for cached `AsyncImage` and use inside `list item` components (Orange-OpenSource/ouds-ios#1681)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
 - `subtitle` on `toolbar top` for iOS < 26 or with Liquid Glass disabled (Orange-OpenSource/ouds-ios#1696)
+- Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
 - Leading, trailing and bottom slots for `list item` components (Orange-OpenSource/ouds-ios#1568)
 - `OUDSAsyncImage` API for cached `AsyncImage` and use inside `list item` components (Orange-OpenSource/ouds-ios#1681)
 - Helpers to apply OUDS styles for rich text (Orange-OpenSource/ouds-ios#1682)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
+- `subtitle` on `toolbar top` for iOS < 26 or with Liquid Glass disabled (Orange-OpenSource/ouds-ios#1696)
 - Leading, trailing and bottom slots for `list item` components (Orange-OpenSource/ouds-ios#1568)
 - `OUDSAsyncImage` API for cached `AsyncImage` and use inside `list item` components (Orange-OpenSource/ouds-ios#1681)
 - Helpers to apply OUDS styles for rich text (Orange-OpenSource/ouds-ios#1682)

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarBottomModifier.swift
@@ -24,8 +24,6 @@ struct ToolBarBottomModifier: ViewModifier {
     private let trailingItems: [OUDSToolBarItem]
     private let groupedItems: [OUDSToolBarItem]
 
-    @Environment(\.theme) private var theme
-
     // MARK: - Initializer
 
     /// Creates a bottom toolbar with leading and trailing items, and a space between them.

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -14,6 +14,7 @@
 #if !os(watchOS) && !os(tvOS)
 import OUDSFoundations
 import OUDSThemesContract
+import OUDSTokensSemantic
 import SwiftUI
 
 // MARK: - ToolBar Top Modifier
@@ -34,7 +35,7 @@ struct ToolBarTopModifier: ViewModifier {
     ///
     /// - Parameters:
     ///   - title: The toobar title. Prefer a non-empty string.
-    ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed.
+    ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for ios < 26.
     ///   - subtitle: Optional subtitle displayed below the title, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side
     ///   - trailingItems: The items displayed on the trailing side
@@ -63,10 +64,7 @@ struct ToolBarTopModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .oudsNavigationTitle(title, subtitle: subtitle)
-        #if os(iOS) || os(visionOS)
-            .navigationBarTitleDisplayMode(hasLargeTitle ? .large : .inline)
-        #endif
+            .oudsNavigationTitle(title, subtitle: subtitle, hasLargeTitle: hasLargeTitle)
             .toolbar {
                 ToolbarItemGroup(placement: leadingPlacement) {
                     itemsView(leadingItems)

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -14,7 +14,6 @@
 #if !os(watchOS) && !os(tvOS)
 import OUDSFoundations
 import OUDSThemesContract
-import OUDSTokensSemantic
 import SwiftUI
 
 // MARK: - ToolBar Top Modifier
@@ -35,7 +34,7 @@ struct ToolBarTopModifier: ViewModifier {
     ///
     /// - Parameters:
     ///   - title: The toobar title. Prefer a non-empty string.
-    ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for ios < 26.
+    ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for iOS lower than 26.
     ///   - subtitle: Optional subtitle displayed below the title, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side
     ///   - trailingItems: The items displayed on the trailing side
@@ -47,10 +46,10 @@ struct ToolBarTopModifier: ViewModifier {
          @OUDSToolBarItemsBuilder trailingItems: @escaping () -> [OUDSToolBarItem])
     {
         if title.isEmpty {
-            OL.warning("The title of OUDSToolBarTopModifier is empty, prefer a non-empty title")
+            OL.warning("The title of ToolBarTopModifier is empty, prefer a non-empty title")
         }
         if let subtitle, subtitle.isEmpty {
-            OL.warning("The subtitle of OUDSToolBarTopModifier is empty, prefer nil instead")
+            OL.warning("The subtitle of ToolBarTopModifier is empty, prefer nil instead")
         }
 
         self.title = title

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -128,7 +128,7 @@ import SwiftUI
 /// ![A top toolbar component in light mode without Liquid Glass effect and Wireframe theme](component_toolBarTop_Wireframe_light)
 /// ![A top toolbar component in dark mode without Liquid Glass effect and Wireframe theme](component_toolBarTop_Wireframe_dark)
 ///
-/// - Version: 1.0.0 (Figma component design version)
+/// - Version: 1.1.0 (Figma component design version)
 /// - Since: 1.4.0
 @available(iOS 15, visionOS 1, *)
 public struct OUDSToolBarTop: ViewModifier {

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -205,7 +205,7 @@ extension View {
     ///
     /// - Parameters:
     ///   - title: The toolbar title. Prefer a non-empty string.
-    ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed
+    ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed for iOS < 26.
     ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.

--- a/OUDS/Core/Components/Sources/_/Internal/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/Internal/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -11,13 +11,9 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
-// Conditional import and use of UIKit for documentation generation (see #628 #626)
-
-#if canImport(UIKit)
 import OUDSFoundations
-#endif
 import SwiftUI
-#if canImport(UIKit)
+#if canImport(UIKit) // Conditional import and use of UIKit for documentation generation (see #628 #626)
 import UIKit
 #endif
 
@@ -33,10 +29,10 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
     let subtitle: String?
     let hasLargeTitle: Bool
 
-#if canImport(UIKit)
+    #if canImport(UIKit)
     /// Elapsed time to wait before sending an accessibility notification of a screen change with the `title` in argument
     let deadline: DispatchTime
-#endif
+    #endif
 
     @Environment(\.theme) private var theme
     @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
@@ -45,7 +41,7 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
     // MARK: Body
 
     func body(content: Content) -> some View {
-        #if os(macOS) || os(watchOS)
+        #if os(macOS) || os(watchOS) || os(tvOS)
         content
             .navigationTitle(LocalizedStringKey(title))
             .oudsNavigationSubtitle(subtitle)
@@ -82,17 +78,17 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
         }
         .navigationBarTitleDisplayMode(hasLargeTitle ? .large : .inline)
         .onAppear {
-#if canImport(UIKit) && !os(watchOS)
+            #if canImport(UIKit) && !os(watchOS)
             DispatchQueue.main.asyncAfter(deadline: deadline) {
                 UIAccessibility.post(notification: .screenChanged, argument: title)
             }
-#endif
+            #endif
         }
         #endif
     }
 
     // MARK: Font helpers
-    #if !os(macOS)
+
     private var fonts: (title: Font, subtitle: Font)? {
         guard let fontFamily = theme.fontFamily else {
             return nil
@@ -100,31 +96,15 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
 
         let titleFontName = kApplePostScriptFontNames[orKey: PSFNMK(fontFamily, Font.Weight.medium)]
 
-        guard let uiTitleFont = UIFont(name: titleFontName, size: 17) else {
+        guard let nativeTitleFont = NativeFont(name: titleFontName, size: 17) else {
             return nil
         }
 
-        guard let uiSubtitleFont = UIFont(name: titleFontName, size: 12) else {
+        guard let nativeSubtitleFont = NativeFont(name: titleFontName, size: 12) else {
             return nil
         }
 
-        return (Font(uiTitleFont), Font(uiSubtitleFont))
-    }
-    #endif
-}
-
-extension View {
-    @ViewBuilder
-    func oudsNavigationSubtitle(_ subtitle: String? = nil) -> some View {
-        #if os(iOS) || os(macOS)
-        if #available(iOS 26.0, *), let subtitle {
-            navigationSubtitle(Text(LocalizedStringKey(subtitle)))
-        } else {
-            self
-        }
-        #else
-        self
-        #endif
+        return (Font(nativeTitleFont), Font(nativeSubtitleFont))
     }
 }
 
@@ -191,5 +171,23 @@ struct RestrictedRequestAccessibleFocusModifier: ViewModifier {
                 requestFocus = target
             }
         }
+    }
+}
+
+// MARK: - Extension of View
+
+extension View {
+
+    @ViewBuilder
+    func oudsNavigationSubtitle(_ subtitle: String? = nil) -> some View {
+        #if os(iOS) || os(macOS)
+        if #available(iOS 26.0, *), let subtitle {
+            navigationSubtitle(Text(LocalizedStringKey(subtitle)))
+        } else {
+            self
+        }
+        #else
+        self
+        #endif
     }
 }

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -36,6 +36,8 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
 #endif
 
     @Environment(\.theme) private var theme
+    @Environment(\.forceOUDSLegacyLayout) private var forceOUDSLegacyLayout
+    @Environment(\.isLiquidGlassDisabled) private var isLiquidGlassDisabled
 
     // MARK: Body
 
@@ -47,7 +49,7 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
         #else
         Group {
             if let subtitle {
-                if #available(iOS 26.0, *) {
+                if #available(iOS 26.0, *), !(forceOUDSLegacyLayout || isLiquidGlassDisabled) {
                     content
                         .navigationTitle(LocalizedStringKey(title))
                         .oudsNavigationSubtitle(subtitle)
@@ -63,7 +65,7 @@ struct AccessibleNavigationTitleModifier: ViewModifier {
 
                                         Text(subtitle.localized())
                                             .font(fonts.1)
-                                            .foregroundColor(theme.colors.contentDefault)
+                                            .foregroundColor(theme.colors.contentMuted)
                                     }
                                 }
                             }

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -12,9 +12,12 @@
 //
 
 // Conditional import and use of UIKit for documentation generation (see #628 #626)
-import SwiftUI
+
 #if canImport(UIKit)
 import OUDSFoundations
+#endif
+import SwiftUI
+#if canImport(UIKit)
 import UIKit
 #endif
 

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -14,8 +14,8 @@
 // Conditional import and use of UIKit for documentation generation (see #628 #626)
 import SwiftUI
 #if canImport(UIKit)
-import UIKit
 import OUDSFoundations
+import UIKit
 #endif
 
 // MARK: - Accessible Navigation Title Modifier

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/AccessibleModifiers.swift
@@ -15,6 +15,7 @@
 import SwiftUI
 #if canImport(UIKit)
 import UIKit
+import OUDSFoundations
 #endif
 
 // MARK: - Accessible Navigation Title Modifier
@@ -22,27 +23,89 @@ import UIKit
 /// `ViewModifier` which defines a navigation title for the calling `View` and also uses `UIAccessibility` to notify for screen changed.
 struct AccessibleNavigationTitleModifier: ViewModifier {
 
+    // MARK: Properties
+
     /// The title used as a `LocalizedStringKey` to add as navigation title
     let title: String
     let subtitle: String?
+    let hasLargeTitle: Bool
 
-    #if canImport(UIKit)
+#if canImport(UIKit)
     /// Elapsed time to wait before sending an accessibility notification of a screen change with the `title` in argument
     let deadline: DispatchTime
-    #endif
+#endif
+
+    @Environment(\.theme) private var theme
+
+    // MARK: Body
 
     func body(content: Content) -> some View {
+        #if os(macOS) || os(watchOS)
         content
             .navigationTitle(LocalizedStringKey(title))
             .oudsNavigationSubtitle(subtitle)
-            .onAppear {
-                #if canImport(UIKit) && !os(watchOS)
-                DispatchQueue.main.asyncAfter(deadline: deadline) {
-                    UIAccessibility.post(notification: .screenChanged, argument: title)
+        #else
+        Group {
+            if let subtitle {
+                if #available(iOS 26.0, *) {
+                    content
+                        .navigationTitle(LocalizedStringKey(title))
+                        .oudsNavigationSubtitle(subtitle)
+                } else {
+                    if let fonts, !hasLargeTitle {
+                        content
+                            .toolbar {
+                                ToolbarItem(placement: .principal) {
+                                    VStack(alignment: .center, spacing: 0) {
+                                        Text(title.localized())
+                                            .font(fonts.0)
+                                            .foregroundColor(theme.colors.contentDefault)
+
+                                        Text(subtitle.localized())
+                                            .font(fonts.1)
+                                            .foregroundColor(theme.colors.contentDefault)
+                                    }
+                                }
+                            }
+                    } else {
+                        content.navigationTitle(LocalizedStringKey(title))
+                    }
                 }
-                #endif
+            } else {
+                content.navigationTitle(LocalizedStringKey(title))
             }
+        }
+        .navigationBarTitleDisplayMode(hasLargeTitle ? .large : .inline)
+        .onAppear {
+#if canImport(UIKit) && !os(watchOS)
+            DispatchQueue.main.asyncAfter(deadline: deadline) {
+                UIAccessibility.post(notification: .screenChanged, argument: title)
+            }
+#endif
+        }
+        #endif
     }
+
+    // MARK: Font helpers
+    #if !os(macOS)
+    private var fonts: (title: Font, subtitle: Font)? {
+        guard let fontFamily = theme.fontFamily else {
+            return nil
+        }
+
+        let titleFontName = kApplePostScriptFontNames[orKey: PSFNMK(fontFamily, Font.Weight.medium)]
+
+        guard let uiTitleFont = UIFont(name: titleFontName, size: 17) else {
+            return nil
+        }
+
+        guard let uiSubtitleFont = UIFont(name: titleFontName, size: 12) else {
+            return nil
+        }
+
+        return (Font(uiTitleFont), Font(uiSubtitleFont))
+    }
+    #endif
 }
 
 extension View {

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
@@ -27,8 +27,7 @@ private enum AccessibilityDelay: Double {
 
 extension View {
 
-    /// Adds a modifier to the current `View` so as to define a navigation title using the current `title`
-    /// and also send a notification for accessibility layers for a change of screen when appeared.
+    /// Adds a modifier to the current `View` so as to define a navigation title and subtitle (under this title) using the current `title` and optional `subtitle`. It also send a notification for accessibility layers for a change of screen when appeared.
     ///
     /// ```swift
     ///      SomeView().oudsNavigationTitle("your title key")
@@ -36,16 +35,19 @@ extension View {
     ///
     /// - Parameters
     ///     - title: The navigation title
-    ///     - subtitle: An optional subtitle for iOS > 26 only
+    ///     - subtitle: An optional subtitle displayed under the title. For iOS >= 26 native api is used.
+    ///     For previous version of iOS, a `ToolbarItem` with a placement  `.principal` is used to display `title` and `subtitle`. If `hasLargeTitle`is `true`, the subtitle is ignored.
+    ///     - hasLargeTitle: Flag to activate the large title. Default is `false`.
     ///
     /// - Returns View: The view with a new modifier
-    public func oudsNavigationTitle(_ title: String, subtitle: String? = nil) -> some View {
+    public func oudsNavigationTitle(_ title: String, subtitle: String? = nil, hasLargeTitle: Bool = false) -> some View {
         #if canImport(UIKit)
         modifier(AccessibleNavigationTitleModifier(title: title,
                                                    subtitle: subtitle,
+                                                   hasLargeTitle: hasLargeTitle,
                                                    deadline: .now() + AccessibilityDelay.accessibleTitleNotificationDelay.rawValue))
         #else
-        modifier(AccessibleNavigationTitleModifier(title: title, subtitle: subtitle))
+        modifier(AccessibleNavigationTitleModifier(title: title, subtitle: subtitle, hasLargeTitle: hasLargeTitle))
         #endif
     }
 

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
@@ -28,18 +28,18 @@ private enum AccessibilityDelay: Double {
 extension View {
 
     /// Adds a modifier to the current `View` so as to define a navigation title and subtitle (under this title) using the current
-    /// `title` and optional `subtitle`. It also send a notification for accessibility layers for a change of screen when appeared.
+    /// `title` and optional `subtitle`. It also sends a notification to accessibility layers for a screen change when it appears.
     ///
     /// ```swift
     ///      SomeView().oudsNavigationTitle("your title key")
     /// ```
     ///
-    /// - Parameters
-    ///     - title: The navigation title
-    ///     - subtitle: An optional subtitle displayed under the title. For iOS >= 26 native api is used.
-    ///     For previous version of iOS, a `ToolbarItem` with a placement  `.principal` is used to display
-    ///     `title` and `subtitle`. If `hasLargeTitle`is `true`, the subtitle is ignored.
-    ///     - hasLargeTitle: Flag to activate the large title. Default is `false`.
+    /// - Parameters:
+    ///    - title: The navigation title
+    ///    - subtitle: An optional subtitle displayed under the title. For iOS >= 26 the native API is used.
+    ///       For previous versions of iOS, a `ToolbarItem` with placement `.principal` is used to display `title` and `subtitle`.
+    ///       If `hasLargeTitle` is `true`, the subtitle is ignored.
+    ///    - hasLargeTitle: Flag to activate the large title. Default is `false`.
     ///
     /// - Returns View: The view with a new modifier
     public func oudsNavigationTitle(_ title: String, subtitle: String? = nil, hasLargeTitle: Bool = false) -> some View {

--- a/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
+++ b/OUDS/Core/Components/Sources/_/Public/ViewModifiers/AccessibleModifiers/View+extensions.swift
@@ -27,7 +27,8 @@ private enum AccessibilityDelay: Double {
 
 extension View {
 
-    /// Adds a modifier to the current `View` so as to define a navigation title and subtitle (under this title) using the current `title` and optional `subtitle`. It also send a notification for accessibility layers for a change of screen when appeared.
+    /// Adds a modifier to the current `View` so as to define a navigation title and subtitle (under this title) using the current
+    /// `title` and optional `subtitle`. It also send a notification for accessibility layers for a change of screen when appeared.
     ///
     /// ```swift
     ///      SomeView().oudsNavigationTitle("your title key")
@@ -36,7 +37,8 @@ extension View {
     /// - Parameters
     ///     - title: The navigation title
     ///     - subtitle: An optional subtitle displayed under the title. For iOS >= 26 native api is used.
-    ///     For previous version of iOS, a `ToolbarItem` with a placement  `.principal` is used to display `title` and `subtitle`. If `hasLargeTitle`is `true`, the subtitle is ignored.
+    ///     For previous version of iOS, a `ToolbarItem` with a placement  `.principal` is used to display
+    ///     `title` and `subtitle`. If `hasLargeTitle`is `true`, the subtitle is ignored.
     ///     - hasLargeTitle: Flag to activate the large title. Default is `false`.
     ///
     /// - Returns View: The view with a new modifier

--- a/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
+++ b/OUDS/Core/ThemesContract/Sources/TokenatorConstants.swift
@@ -131,8 +131,8 @@ public enum OUDSVersions {
     public static let componentTabBarVersion = "1.0.0"
     /// Version of the Figma specifications for the toolbar bottom components (1.0.0)
     public static let componentToolBarBottomVersion = "1.0.0"
-    /// Version of the Figma specifications for the toolbar top components (1.0.0)
-    public static let componentToolBarTopVersion = "1.0.0"
+    /// Version of the Figma specifications for the toolbar top components (1.1.0)
+    public static let componentToolBarTopVersion = "1.1.0"
 
     // MARK: - Components versions - Tag
 


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

Orange-OpenSource/ouds-ios#1696

### Description

<!-- Describe your changes in detail -->

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [ ] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [x] Design review has been done
- [ ] Accessibility review has been done
- [ ] Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
