### PR TITLE
[#1708] For `progress indicator` components update animations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Animations for `progress indicator` components (Orange-OpenSource/ouds-ios#1708)
 - Update icons to v2.3.0 (Orange-OpenSource/ouds-ios#1432)
 - `progress indicator` components to version 1.2.0 (Orange-OpenSource/ouds-ios#1674)
 - `password input` component to version 1.3.1 (Orange-OpenSource/ouds-ios#1526)

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorIndeterminateView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorIndeterminateView.swift
@@ -102,7 +102,6 @@ struct CircularProgressIndicatorIndeterminateView: View {
     let trackColor: Color
     let strokeCap: CGLineCap
     let gapSize: OUDSProgressIndicatorGapSize
-    let hasTrack: Bool
     let size: CGFloat
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorIndeterminateView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorIndeterminateView.swift
@@ -22,18 +22,35 @@ import SwiftUI
 
 /// Animates the foreground arc of an indeterminate ``OUDSCircularProgressIndicator``.
 ///
-/// The animation reproduces the **Android Material 3** indeterminate circular progress specification by combining
-/// three time-based animations simultaneously:
+/// The animation reproduces the **Material** indeterminate circular progress specification, as
+/// implemented identically by Material Web, Material Components Android and Flutter's
+/// `CircularProgressIndicator` (all three share the very same motion values, originating from the
+/// Android `progress_indeterminate_rotation_material.xml` reference). The active arc:
 ///
-/// 1. A **global rotation** of `360°` in `6 s` (linear, repeat forever).
-/// 2. An **additional rotation** of `90°` performed in `500 ms`, then resting for `1 s`
-///    (cycle of `1.5 s`, repeat forever). The rotation is accumulated across cycles to avoid a
-///    visual jump at the end of each cycle.
-/// 3. An **indicator sweep** that grows and shrinks between `5 %` and `90 %` of the full circle,
-///    with an easeInOut-like autoreversing curve.
+/// - continuously rotates **clockwise**, with no stop and no change of direction;
+/// - alternates between a **grow** phase (its trailing end advances while its leading end stays
+///   fixed, making the arc longer) and a **shrink** phase (its leading end advances and catches up
+///   with the trailing end, making the arc shorter), repeating forever: `short → grow → long →
+///   shrink → short → …`.
 ///
-/// The rendering itself is delegated to ``CircularProgressCanvas`` and computed from the current
-/// wall-clock time provided by ``TimelineView(.animation)``. This approach:
+/// This is obtained by combining four time-based values, all derived from a repeating **"tooth"**
+/// of `1333 ms`:
+///
+/// - `head` grows from `0` to `1` (eased with `fastOutSlowIn`) during the first half of the tooth,
+///   then holds at `1` during the second half;
+/// - `tail` holds at `0` during the first half of the tooth, then grows from `0` to `1` (eased)
+///   during the second half;
+/// - the visible sweep is `max((head - tail) * 270°, epsilon)`: it grows while only `head` moves,
+///   then shrinks while only `tail` moves — exactly the "grow / shrink" alternation described
+///   above, with no discontinuity since both phases meet at `sweep ≈ epsilon`;
+/// - `offset` is a raw (non-eased) sawtooth of the same `1333 ms` period, used as an additional
+///   `90°` "kick" applied to the arc start angle; combined with the `270°` swept by `tail`, the
+///   `-360°` jump produced when the tooth resets is a full turn and therefore invisible;
+/// - a slower, independent raw sawtooth of `2222 ms` (`rotation`) adds a continuous base rotation
+///   of `360°` per period, so the arc never stops advancing even while `head`/`tail` are idle.
+///
+/// The rendering itself is delegated to ``CircularProgressCanvasView`` and computed from the
+/// current wall-clock time provided by ``TimelineView(.animation)``. This approach:
 ///
 /// - avoids any ``GeometryReader`` or `@State`-driven invalidation that could propagate a layout
 ///   invalidation up to the parent (which caused a glitch in ``NavigationStack`` toolbars);
@@ -46,35 +63,35 @@ import SwiftUI
 /// by ``OUDSButton``.
 struct CircularProgressIndicatorIndeterminateView: View {
 
-    // MARK: - Android Material 3 animation constants
+    // MARK: - Material animation constants
 
-    /// Global rotation period (full 360° turn), in seconds.
-    static let globalRotationPeriod: TimeInterval = 6.0
+    /// Duration of one "tooth" (head + tail cycle), in seconds. Matches the reference
+    /// implementations' `1333 ms`.
+    static let toothDuration: TimeInterval = 1.333
 
-    /// Total duration of one additional rotation cycle (animation + hold), in seconds.
-    static let additionalRotationCycle: TimeInterval = 1.5
+    /// Duration of one base-rotation sawtooth, in seconds. Matches the reference
+    /// implementations' `2222 ms`.
+    static let rotationDuration: TimeInterval = 2.222
 
-    /// Duration of the additional rotation animation phase (before the hold), in seconds.
-    static let additionalRotationAnimDuration: TimeInterval = 0.5
+    /// Maximum sweep of the foreground arc, in degrees. Matches the reference implementations'
+    /// `3 / 2 * π` radians (i.e. `270°`, three quarters of a full turn).
+    static let maxSweepDegrees: Double = 270.0
 
-    /// Angle covered by one additional rotation cycle, in degrees.
-    static let additionalRotationTarget: Double = 90.0
+    /// Minimum sweep of the foreground arc, in degrees, used as a floor so the arc never fully
+    /// disappears (a `0°` arc would not be drawn at all).
+    static let minSweepDegrees: Double = 0.06
 
-    /// Half-period of the sweep animation (grow phase or shrink phase), in seconds.
-    /// The full cycle (grow + shrink) is therefore `2 * progressHalfCycle`.
-    static let progressHalfCycle: TimeInterval = 1.5
+    /// Additional rotation "kick" applied once per tooth, in degrees. Combined with
+    /// ``maxSweepDegrees``, the `-360°` jump produced when the tooth resets becomes a full turn
+    /// and is therefore invisible.
+    static let kickDegrees: Double = 90.0
 
-    /// Minimum sweep of the indeterminate indicator, in `[0, 1]`.
-    static let progressMin: CGFloat = 0.05
-
-    /// Maximum sweep of the indeterminate indicator when the track is displayed, in `[0, 1]`.
-    /// Matches Compose Material 3's `CircularIndeterminateMaxProgress = 0.75f`, which keeps a
-    /// visible portion of the track at the peak of the sweep respiration.
-    static let progressMax: CGFloat = 0.75
-
-    /// Maximum sweep of the indeterminate indicator when NO track is displayed, in `[0, 1]`.
-    /// Since there is no track to hide, the foreground can grow closer to a full circle.
-    static let progressMaxWithoutTrack: CGFloat = 0.90
+    /// Control points of the `fastOutSlowIn` cubic-bezier easing (`cubic-bezier(0.4, 0, 0.2, 1)`)
+    /// used to ease the `head` and `tail` values within a tooth.
+    private static let fastOutSlowInX1 = 0.4
+    private static let fastOutSlowInY1 = 0.0
+    private static let fastOutSlowInX2 = 0.2
+    private static let fastOutSlowInY2 = 1.0
 
     /// Sweep used when animations are disabled (accessibility / low power).
     static let staticSweep: CGFloat = 0.7
@@ -110,8 +127,8 @@ struct CircularProgressIndicatorIndeterminateView: View {
                     foregroundColor: foregroundColor,
                     trackColor: trackColor,
                     strokeCap: strokeCap,
-                    sweep: sweep(at: time),
-                    rotation: totalRotation(at: time),
+                    sweep: sweepFraction(at: time),
+                    rotation: arcStartDegrees(at: time),
                     gapSize: gapSize,
                     size: size)
             }
@@ -120,53 +137,71 @@ struct CircularProgressIndicatorIndeterminateView: View {
 
     // MARK: - Time-based animations
 
-    /// Global rotation angle at time `t`, in degrees. Loops from `0°` to `360°` every ``globalRotationPeriod``.
-    private func globalRotation(at time: TimeInterval) -> Double {
-        let phase = time.truncatingRemainder(dividingBy: Self.globalRotationPeriod)
-        return (phase / Self.globalRotationPeriod) * 360.0
+    /// Progress within the current tooth, in `[0, 1)`. The tooth repeats every ``toothDuration``.
+    private static func toothPhase(at time: TimeInterval) -> Double {
+        let phase = time.truncatingRemainder(dividingBy: toothDuration)
+        return phase / toothDuration
     }
 
-    /// Additional rotation angle at time `t`, in degrees.
+    /// Progress within the current base-rotation sawtooth, in `[0, 1)`. Repeats every
+    /// ``rotationDuration``, independently from the tooth.
+    private static func rotationPhase(at time: TimeInterval) -> Double {
+        let phase = time.truncatingRemainder(dividingBy: rotationDuration)
+        return phase / rotationDuration
+    }
+
+    /// `head` value at time `t`, in `[0, 1]`: eases from `0` to `1` during the first half of the
+    /// tooth (the arc's leading end advances, the arc grows), then holds at `1`.
+    private func head(at time: TimeInterval) -> Double {
+        let phase = Self.toothPhase(at: time)
+        guard phase < 0.5 else { return 1.0 }
+        return Self.fastOutSlowIn(phase / 0.5)
+    }
+
+    /// `tail` value at time `t`, in `[0, 1]`: holds at `0` during the first half of the tooth, then
+    /// eases from `0` to `1` during the second half (the arc's trailing end catches up, the arc
+    /// shrinks).
+    private func tail(at time: TimeInterval) -> Double {
+        let phase = Self.toothPhase(at: time)
+        guard phase >= 0.5 else { return 0.0 }
+        return Self.fastOutSlowIn((phase - 0.5) / 0.5)
+    }
+
+    /// Raw (non-eased) sawtooth used as the additional rotation "kick", in `[0, 1)`.
+    private func offset(at time: TimeInterval) -> Double {
+        Self.toothPhase(at: time)
+    }
+
+    /// Raw (non-eased) sawtooth used as the continuous base rotation, in `[0, 1)`.
+    private func rotation(at time: TimeInterval) -> Double {
+        Self.rotationPhase(at: time)
+    }
+
+    /// Sweep of the foreground arc at time `t`, as a fraction of the full circle in `[0, 1]`.
+    private func sweepFraction(at time: TimeInterval) -> CGFloat {
+        let sweepDegrees = max((head(at: time) - tail(at: time)) * Self.maxSweepDegrees, Self.minSweepDegrees)
+        return CGFloat(sweepDegrees / 360.0)
+    }
+
+    /// Start angle of the foreground arc at time `t`, in degrees.
     ///
-    /// The angle is accumulated across cycles (each cycle adds ``additionalRotationTarget``) so that
-    /// the total rotation never jumps back to `0°` — the animation stays visually smooth.
-    /// Within a cycle:
-    /// - during the first ``additionalRotationAnimDuration`` seconds, the rotation grows linearly from
-    ///   the previous plateau to plateau + ``additionalRotationTarget``;
-    /// - during the remaining time, the rotation stays constant (hold / pause).
-    private func additionalRotation(at time: TimeInterval) -> Double {
-        let completedCycles = floor(time / Self.additionalRotationCycle)
-        let phase = time - completedCycles * Self.additionalRotationCycle
-        let base = completedCycles * Self.additionalRotationTarget
-
-        if phase < Self.additionalRotationAnimDuration {
-            let ratio = phase / Self.additionalRotationAnimDuration
-            return base + Self.additionalRotationTarget * ratio
-        } else {
-            return base + Self.additionalRotationTarget
-        }
+    /// Combines: a `-90°` offset so the arc starts at the top (12 o'clock) at `t = 0`, the `tail`
+    /// sweep (so the start angle moves forward as the arc shrinks), the continuous base rotation,
+    /// and the additional rotation kick.
+    private func arcStartDegrees(at time: TimeInterval) -> Double {
+        -90.0
+            + tail(at: time) * Self.maxSweepDegrees
+            + rotation(at: time) * 360.0
+            + offset(at: time) * Self.kickDegrees
     }
 
-    /// Total rotation at time `t`, in degrees: sum of global rotation and additional rotation, offset by
-    /// `-90°` so that the arc starts at the top of the circle (12 o'clock position) at `t = 0`.
-    private func totalRotation(at time: TimeInterval) -> Double {
-        globalRotation(at: time) + additionalRotation(at: time) - 90.0
-    }
-
-    /// Sweep at time `t`, in `[progressMin, maxSweep]` where `maxSweep` depends on ``hasTrack``.
-    ///
-    /// The value oscillates smoothly between ``progressMin`` and either ``progressMax`` (when
-    /// the track is displayed, keeping it visible at the peak) or ``progressMaxWithoutTrack``
-    /// (when there is no track to hide, allowing a larger foreground). The easing uses a cosine
-    /// curve which approximates Material 3's `EasingEmphasizedCubic` for an autoreversing
-    /// infinite animation. The full oscillation period is `2 * progressHalfCycle`.
-    private func sweep(at time: TimeInterval) -> CGFloat {
-        let fullCycle = 2.0 * Self.progressHalfCycle
-        let phase = time.truncatingRemainder(dividingBy: fullCycle) / fullCycle // 0..1
-        // (1 - cos(2π * phase)) / 2 produces a smooth 0 -> 1 -> 0 oscillation.
-        let eased = CGFloat((1.0 - cos(phase * 2.0 * .pi)) / 2.0)
-        let maxSweep = hasTrack ? Self.progressMax : Self.progressMaxWithoutTrack
-        return Self.progressMin + (maxSweep - Self.progressMin) * eased
+    /// Evaluates the `fastOutSlowIn` cubic-bezier easing (`cubic-bezier(0.4, 0, 0.2, 1)`) at `x`.
+    private static func fastOutSlowIn(_ x: Double) -> Double {
+        ProgressIndicatorCubicBezierEasing.value(x,
+                                                 x1: fastOutSlowInX1,
+                                                 y1: fastOutSlowInY1,
+                                                 x2: fastOutSlowInX2,
+                                                 y2: fastOutSlowInY2)
     }
 }
 

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/CircularProgressIndicator/CircularProgressIndicatorView.swift
@@ -56,7 +56,6 @@ struct CircularProgressIndicatorView: View {
                         trackColor: trackColor,
                         strokeCap: strokeCap,
                         gapSize: configuration.gapSize,
-                        hasTrack: configuration.track,
                         size: scaledDefaultSize)
                 }
             }

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressBarCanvasView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressBarCanvasView.swift
@@ -38,7 +38,11 @@ import SwiftUI
 ///   5. Track after line 2: `[0, secondTail − gap]` if `secondTail > gap`.
 ///
 ///   Since two of these segments are colored and the gaps are simply not drawn (transparent
-///   container background), the effect is a caterpillar-like race between two lines.
+///   container background), the effect is a caterpillar-like race between two lines. Each `gap`
+///   above is not a fixed value: it is ramped down smoothly to `0` as the adjacent fraction
+///   approaches an edge of the track (see
+///   ``effectiveTrackGapFraction(currentValue:gapFraction:)``), so the visible spacing never jumps
+///   abruptly when a line's head or tail crosses `0` or `1`.
 ///
 /// The optional stop indicator is drawn as a **overlay** on the right edge in determinate mode
 /// only — it does not reserve any space in the track, so appearing / disappearing it never
@@ -52,6 +56,12 @@ struct LinearProgressBarCanvasView: View {
 
     /// Reduced gap between the foreground bar and the track, in points.
     static let smallGapSize: CGFloat = 1.0
+
+    /// Progress value threshold below which the track gap is ramped down proportionally, in
+    /// `[0, 1]`. Matches the Material reference implementations' `TrackGapRampDownThreshold =
+    /// 0.01`. Without this ramp, the gap would jump abruptly from `0` to its nominal size as soon
+    /// as the adjacent segment's fraction crosses `0`, producing a visible discontinuity.
+    static let trackGapRampDownThreshold: CGFloat = 0.01
 
     /// Side of the stop indicator, in points, relative to the bar height. Material 3 uses a stop
     /// indicator whose size equals the track height, so it scales naturally with Dynamic Type.
@@ -191,6 +201,12 @@ struct LinearProgressBarCanvasView: View {
     }
 
     /// Draws the three track segments of the indeterminate rendering (segments 1, 3 and 5).
+    ///
+    /// The gap adjacent to each line's fraction is computed via
+    /// ``effectiveTrackGapFraction(currentValue:gapFraction:)`` instead of being added or omitted
+    /// through a binary condition: this ramps the gap smoothly from `0` to its nominal size as the
+    /// adjacent fraction grows from `0` to `1%`, avoiding the abrupt jump that would otherwise
+    /// occur exactly when a line's head or tail crosses an edge of the track.
     private func drawIndeterminateTracks(context: GraphicsContext,
                                          size: CGSize,
                                          gapFraction: CGFloat,
@@ -205,7 +221,9 @@ struct LinearProgressBarCanvasView: View {
 
         // 1. Track before line 1.
         if firstHead < 1 - gapFraction {
-            let start = firstHead > 0 ? firstHead + gapFraction : 0
+            let start = firstHead > 0
+                ? firstHead + Self.effectiveTrackGapFraction(currentValue: firstHead, gapFraction: gapFraction)
+                : 0
             fillSegment(context: context,
                         size: size,
                         startFraction: start,
@@ -215,8 +233,12 @@ struct LinearProgressBarCanvasView: View {
         }
         // 3. Track between line 1 and line 2.
         if firstTail > gapFraction {
-            let start = secondHead > 0 ? secondHead + gapFraction : 0
-            let end = firstTail < 1 ? firstTail - gapFraction : 1
+            let start = secondHead > 0
+                ? secondHead + Self.effectiveTrackGapFraction(currentValue: secondHead, gapFraction: gapFraction)
+                : 0
+            let end = firstTail < 1
+                ? firstTail - Self.effectiveTrackGapFraction(currentValue: 1 - firstTail, gapFraction: gapFraction)
+                : 1
             if end > start {
                 fillSegment(context: context,
                             size: size,
@@ -228,7 +250,9 @@ struct LinearProgressBarCanvasView: View {
         }
         // 5. Track after line 2.
         if secondTail > gapFraction {
-            let end = secondTail < 1 ? secondTail - gapFraction : 1
+            let end = secondTail < 1
+                ? secondTail - Self.effectiveTrackGapFraction(currentValue: 1 - secondTail, gapFraction: gapFraction)
+                : 1
             if end > 0 {
                 fillSegment(context: context,
                             size: size,
@@ -312,6 +336,16 @@ struct LinearProgressBarCanvasView: View {
     }
 
     // MARK: - Gap helpers
+
+    /// Computes a track gap fraction that is scaled proportionally to a given adjacent value.
+    ///
+    /// This is used for a smooth transition of the track gap's size, preventing it from appearing
+    /// or disappearing abruptly. The returned value increases linearly from `0` to the full
+    /// `gapFraction` as `currentValue` increases from `0` to ``trackGapRampDownThreshold``.
+    /// Mirrors the Material reference implementations' `getEffectiveTrackGapFraction`.
+    static func effectiveTrackGapFraction(currentValue: CGFloat, gapFraction: CGFloat) -> CGFloat {
+        gapFraction * min(max(currentValue, 0.0), trackGapRampDownThreshold) / trackGapRampDownThreshold
+    }
 
     /// Effective gap between the foreground bar and the track, in points. When ``strokeCap`` is
     /// `.round`, the round caps eat up the visible spacing, so we compensate by adding

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressIndicatorIndeterminateView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressIndicatorIndeterminateView.swift
@@ -191,27 +191,33 @@ struct LinearProgressIndicatorIndeterminateView: View {
     /// 1f at delay + duration
     /// ```
     ///
-    /// Looped through `infiniteRepeatable`. In practice:
-    /// - Before `delay`, the fraction is **`1.0`** (the value at the end of the previous cycle).
+    /// Looped through `infiniteRepeatable`. Mirrors Flutter's `Interval.transform`, which clamps
+    /// the normalized time to `[0, 1]` before evaluating the curve. In practice:
+    /// - Before `delay`, the fraction is **`0.0`** (the animation has not started yet).
     /// - Between `delay` and `delay + duration`, it interpolates from `0.0` to `1.0` with the
     ///   given cubic Bézier easing.
     /// - After `delay + duration`, the fraction stays at `1.0` until the end of the cycle.
     ///
     /// This is what produces the "caterpillar" effect: the head starts moving before the tail, so
-    /// the visible segment (`head - tail`) grows, then shrinks as the tail catches up.
+    /// the visible segment (`head - tail`) grows continuously from `0`, then shrinks continuously
+    /// back to `0` as the tail catches up — with no discontinuity at any point. Returning `1.0`
+    /// before `delay` (as if holding the previous cycle's value) would freeze the segment at
+    /// length `0` for the whole delay, then make it jump abruptly to its already-grown length as
+    /// soon as `delay` is reached — exactly the "the caterpillar suddenly appears" glitch this
+    /// fixes.
     static func fraction(phase: TimeInterval,
                          delay: TimeInterval,
                          duration: TimeInterval,
                          controlPoints: ProgressIndicatorCubicBezierEasing.ControlPoints) -> CGFloat
     {
         guard duration > 0 else { return 1.0 }
-        if phase < delay {
+        let t = min(max((phase - delay) / duration, 0.0), 1.0)
+        if t <= 0.0 {
+            return 0.0
+        } else if t >= 1.0 {
             return 1.0
-        } else if phase < delay + duration {
-            let t = (phase - delay) / duration
-            return CGFloat(ProgressIndicatorCubicBezierEasing.value(t, controlPoints))
         } else {
-            return 1.0
+            return CGFloat(ProgressIndicatorCubicBezierEasing.value(t, controlPoints))
         }
     }
 }

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressIndicatorIndeterminateView.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/LinearProgressIndicator/LinearProgressIndicatorIndeterminateView.swift
@@ -20,22 +20,26 @@ import SwiftUI
 
 /// Animates the bar of an indeterminate ``OUDSLinearProgressIndicator``.
 ///
-/// The animation reproduces the **Android Material 3** indeterminate linear progress specification
-/// as implemented in AndroidX Compose Material 3 `ProgressIndicator.kt`. Two lines follow one
-/// another across the track, each defined by two independent animations (head and tail) sharing a
-/// **1750 ms** cycle:
+/// The animation reproduces the **Material** indeterminate linear progress specification, as
+/// implemented identically by Material Web, Material Components Android and Flutter's
+/// `LinearProgressIndicator` (all three share the very same motion values, originating from the
+/// Android `progress_indeterminate_material.xml` reference). Two lines follow one another across
+/// the track, each defined by two independent animations (head and tail), each with its **own**
+/// cubic-bezier easing, sharing a **1800 ms** cycle:
 ///
-/// | Animation             | Delay   | Duration | Easing                                       |
-/// | --------------------- | ------- | -------- | -------------------------------------------- |
-/// | First bar head        |    0 ms |  1000 ms | `EasingEmphasizedAccelerate` (0.3, 0, 0.8, 0.15) |
-/// | First bar tail        |  250 ms |  1000 ms | same                                         |
-/// | Second bar head       |  650 ms |   850 ms | same                                         |
-/// | Second bar tail       |  900 ms |   850 ms | same                                         |
+/// | Animation             | Delay   | Duration | Easing (cubic-bezier)      |
+/// | --------------------- | ------- | -------- | --------------------------- |
+/// | First bar head        |    0 ms |   750 ms | `(0.2, 0, 0.8, 1)`          |
+/// | First bar tail        |  333 ms |   750 ms | `(0.4, 0, 1, 1)`            |
+/// | Second bar head       | 1000 ms |   567 ms | `(0, 0, 0.65, 1)`           |
+/// | Second bar tail       | 1267 ms |   533 ms | `(0.10, 0, 0.45, 1)`        |
 ///
-/// The Material 3 rendering is **not** just "two colored bars over a solid track": it draws five
+/// The Material rendering is **not** just "two colored bars over a solid track": it draws five
 /// segments (three track segments and two colored lines), which naturally produces the two small
 /// transparent gaps around each colored line — the visual signature of the animation. See
-/// ``LinearProgressBarCanvasView`` for the segment layout.
+/// ``LinearProgressBarCanvasView`` for the segment layout, and
+/// ``LinearProgressBarCanvasView/effectiveTrackGapFraction(currentValue:gapFraction:)`` for how
+/// the gap is ramped down near `0` to avoid a discontinuity.
 ///
 /// The head-then-tail motion (head grows first, tail follows) makes each colored bar look like a
 /// caterpillar stretching then shrinking, and the two bars appear to race each other.
@@ -48,39 +52,39 @@ import SwiftUI
 /// ``OUDSLowPowerModeObserver``).
 struct LinearProgressIndicatorIndeterminateView: View {
 
-    // MARK: - Android Material 3 animation constants
+    // MARK: - Material animation constants
 
-    /// Total duration of one animation cycle, in seconds. Matches Android Compose Material 3
-    /// `LinearAnimationDuration = 1750`.
-    static let cycleDuration: TimeInterval = 1.750
+    /// Total duration of one animation cycle, in seconds. Matches the reference implementations'
+    /// `LinearAnimationDuration = 1800`.
+    static let cycleDuration: TimeInterval = 1.800
 
     // MARK: First bar
 
-    /// Delay before the first bar's head starts moving, in seconds (Android Material 3 `FirstLineHeadDelay = 0`).
+    /// Delay before the first bar's head starts moving, in seconds (Material spec `Line1HeadDelay = 0`).
     static let firstLineHeadDelay: TimeInterval = 0.0
 
-    /// Duration of the first bar's head animation, in seconds (Android Material 3 `FirstLineHeadDuration = 1000`).
-    static let firstLineHeadDuration: TimeInterval = 1.000
+    /// Duration of the first bar's head animation, in seconds (Material spec `Line1HeadDuration = 750`).
+    static let firstLineHeadDuration: TimeInterval = 0.750
 
-    /// Delay before the first bar's tail starts moving, in seconds (Android Material 3 `FirstLineTailDelay = 250`).
-    static let firstLineTailDelay: TimeInterval = 0.250
+    /// Delay before the first bar's tail starts moving, in seconds (Material spec `Line1TailDelay = 333`).
+    static let firstLineTailDelay: TimeInterval = 0.333
 
-    /// Duration of the first bar's tail animation, in seconds (Android Material 3 `FirstLineTailDuration = 1000`).
-    static let firstLineTailDuration: TimeInterval = 1.000
+    /// Duration of the first bar's tail animation, in seconds (Material spec `Line1TailDuration = 750`).
+    static let firstLineTailDuration: TimeInterval = 0.750
 
     // MARK: Second bar
 
-    /// Delay before the second bar's head starts moving, in seconds (Android Material 3 `SecondLineHeadDelay = 650`).
-    static let secondLineHeadDelay: TimeInterval = 0.650
+    /// Delay before the second bar's head starts moving, in seconds (Material spec `Line2HeadDelay = 1000`).
+    static let secondLineHeadDelay: TimeInterval = 1.000
 
-    /// Duration of the second bar's head animation, in seconds (Android Material 3 `SecondLineHeadDuration = 850`).
-    static let secondLineHeadDuration: TimeInterval = 0.850
+    /// Duration of the second bar's head animation, in seconds (Material spec `Line2HeadDuration = 567`).
+    static let secondLineHeadDuration: TimeInterval = 0.567
 
-    /// Delay before the second bar's tail starts moving, in seconds (Android Material 3 `SecondLineTailDelay = 900`).
-    static let secondLineTailDelay: TimeInterval = 0.900
+    /// Delay before the second bar's tail starts moving, in seconds (Material spec `Line2TailDelay = 1267`).
+    static let secondLineTailDelay: TimeInterval = 1.267
 
-    /// Duration of the second bar's tail animation, in seconds (Android Material 3 `SecondLineTailDuration = 850`).
-    static let secondLineTailDuration: TimeInterval = 0.850
+    /// Duration of the second bar's tail animation, in seconds (Material spec `Line2TailDuration = 533`).
+    static let secondLineTailDuration: TimeInterval = 0.533
 
     // MARK: Fallback
 
@@ -148,22 +152,31 @@ struct LinearProgressIndicatorIndeterminateView: View {
     /// Head/tail fractions of both bars at time `t`, in seconds.
     ///
     /// The value `t` is normalized into a phase in `[0, cycleDuration)`, then each animation
-    /// (head/tail of each bar) is computed via ``fraction(phase:delay:duration:)``.
+    /// (head/tail of each bar) is computed via ``fraction(phase:delay:duration:controlPoints:)``,
+    /// each with its own cubic-bezier easing (see the type documentation table).
     func fractions(at time: TimeInterval) -> Fractions {
         let phase = time.truncatingRemainder(dividingBy: Self.cycleDuration)
 
-        let firstHead = Self.fraction(phase: phase,
-                                      delay: Self.firstLineHeadDelay,
-                                      duration: Self.firstLineHeadDuration)
-        let firstTail = Self.fraction(phase: phase,
-                                      delay: Self.firstLineTailDelay,
-                                      duration: Self.firstLineTailDuration)
-        let secondHead = Self.fraction(phase: phase,
-                                       delay: Self.secondLineHeadDelay,
-                                       duration: Self.secondLineHeadDuration)
-        let secondTail = Self.fraction(phase: phase,
-                                       delay: Self.secondLineTailDelay,
-                                       duration: Self.secondLineTailDuration)
+        let firstHead = Self.fraction(
+            phase: phase,
+            delay: Self.firstLineHeadDelay,
+            duration: Self.firstLineHeadDuration,
+            controlPoints: .init(x1: 0.2, y1: 0.0, x2: 0.8, y2: 1.0))
+        let firstTail = Self.fraction(
+            phase: phase,
+            delay: Self.firstLineTailDelay,
+            duration: Self.firstLineTailDuration,
+            controlPoints: .init(x1: 0.4, y1: 0.0, x2: 1.0, y2: 1.0))
+        let secondHead = Self.fraction(
+            phase: phase,
+            delay: Self.secondLineHeadDelay,
+            duration: Self.secondLineHeadDuration,
+            controlPoints: .init(x1: 0.0, y1: 0.0, x2: 0.65, y2: 1.0))
+        let secondTail = Self.fraction(
+            phase: phase,
+            delay: Self.secondLineTailDelay,
+            duration: Self.secondLineTailDuration,
+            controlPoints: .init(x1: 0.10, y1: 0.0, x2: 0.45, y2: 1.0))
 
         return Fractions(firstHead: firstHead,
                          firstTail: firstTail,
@@ -171,73 +184,34 @@ struct LinearProgressIndicatorIndeterminateView: View {
                          secondTail: secondTail)
     }
 
-    /// Returns the eased fraction at `phase` for an Android Compose Material 3 `keyframes` animation of the
-    /// form:
+    /// Returns the eased fraction at `phase` for a Material `keyframes` animation of the form:
     ///
     /// ```
-    /// 0f at delay using easing
+    /// 0f at delay using cubic-bezier(controlPoints)
     /// 1f at delay + duration
     /// ```
     ///
-    /// Mooped through `infiniteRepeatable`. In practice:
+    /// Looped through `infiniteRepeatable`. In practice:
     /// - Before `delay`, the fraction is **`1.0`** (the value at the end of the previous cycle).
     /// - Between `delay` and `delay + duration`, it interpolates from `0.0` to `1.0` with the
-    ///   `EasingEmphasizedAccelerate` cubic Bézier.
+    ///   given cubic Bézier easing.
     /// - After `delay + duration`, the fraction stays at `1.0` until the end of the cycle.
     ///
     /// This is what produces the "caterpillar" effect: the head starts moving before the tail, so
     /// the visible segment (`head - tail`) grows, then shrinks as the tail catches up.
-    static func fraction(phase: TimeInterval, delay: TimeInterval, duration: TimeInterval) -> CGFloat {
+    static func fraction(phase: TimeInterval,
+                         delay: TimeInterval,
+                         duration: TimeInterval,
+                         controlPoints: ProgressIndicatorCubicBezierEasing.ControlPoints) -> CGFloat
+    {
         guard duration > 0 else { return 1.0 }
         if phase < delay {
             return 1.0
         } else if phase < delay + duration {
             let t = (phase - delay) / duration
-            return CGFloat(easingEmphasizedAccelerate(t))
+            return CGFloat(ProgressIndicatorCubicBezierEasing.value(t, controlPoints))
         } else {
             return 1.0
         }
-    }
-
-    // MARK: - Easing
-
-    /// Approximates Android Material 3's `EasingEmphasizedAccelerateCubicBezier` (`cubic-bezier(0.3, 0, 0.8, 0.15)`).
-    ///
-    /// Implemented as an iterative bisection on the parametric Bézier `x(t)` to find the parameter
-    /// matching the input `x`, then evaluated as `y(t)`. The number of bisections is fixed and
-    /// small (16) to stay fast — the resulting precision is well below one pixel.
-    static func easingEmphasizedAccelerate(_ x: Double) -> Double {
-        // Control points of the cubic Bezier (P0 = (0, 0), P3 = (1, 1)).
-        let x1 = 0.3
-        let x2 = 0.8
-        let y1 = 0.0
-        let y2 = 0.15
-
-        // Special cases at boundaries.
-        if x <= 0.0 { return 0.0 }
-        if x >= 1.0 { return 1.0 }
-
-        // Solve for t such that bezierX(t) == x, using bisection.
-        var lower = 0.0
-        var upper = 1.0
-        var t = x
-        for _ in 0 ..< 16 {
-            let currentX = bezier(t, x1, x2)
-            if currentX < x {
-                lower = t
-            } else {
-                upper = t
-            }
-            t = (lower + upper) / 2.0
-        }
-        return bezier(t, y1, y2)
-    }
-
-    /// Evaluates a 1D cubic Bezier at `t` with control points `(0, c1, c2, 1)`.
-    private static func bezier(_ t: Double, _ c1: Double, _ c2: Double) -> Double {
-        let oneMinusT = 1.0 - t
-        return 3.0 * oneMinusT * oneMinusT * t * c1
-            + 3.0 * oneMinusT * t * t * c2
-            + t * t * t
     }
 }

--- a/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/ProgressIndicatorCubicBezierEasing.swift
+++ b/OUDS/Core/Components/Sources/Indicators/ProgressIndicator/Internal/ProgressIndicatorCubicBezierEasing.swift
@@ -1,0 +1,76 @@
+//
+// Software Name: OUDS iOS
+// SPDX-FileCopyrightText: Copyright (c) Orange SA
+// SPDX-License-Identifier: MIT
+//
+// This software is distributed under the MIT license,
+// the text of which is available at https://opensource.org/license/MIT/
+// or see the "LICENSE" file for more details.
+//
+// Authors: See CONTRIBUTORS.txt
+// Software description: A SwiftUI components library with code examples for Orange Unified Design System
+//
+
+import Foundation
+
+/*
+ ━━━━━★. *･｡ﾟ✧⁺ Magic stuff
+ */
+
+/// Generic cubic-bezier easing evaluator, shared by the indeterminate animations of
+/// ``OUDSCircularProgressIndicator`` and ``OUDSLinearProgressIndicator``.
+///
+/// Reproduces the CSS/Android/Flutter `cubic-bezier(x1, y1, x2, y2)` timing function: given
+/// control points `P0 = (0, 0)`, `P1 = (x1, y1)`, `P2 = (x2, y2)`, `P3 = (1, 1)`, it solves for the
+/// Bézier parameter `t` such that `bezierX(t) == x`, then returns `bezierY(t)`.
+enum ProgressIndicatorCubicBezierEasing {
+
+    /// Control points `(x1, y1, x2, y2)` of a cubic-bezier easing, grouped together to keep call
+    /// sites with several curves (e.g. the four indeterminate linear animations) below the
+    /// maximum parameter count.
+    struct ControlPoints {
+        let x1: Double
+        let y1: Double
+        let x2: Double
+        let y2: Double
+    }
+
+    /// Evaluates the cubic-bezier `controlPoints` easing at `x`, in `[0, 1]`.
+    static func value(_ x: Double, _ controlPoints: ControlPoints) -> Double {
+        value(x, x1: controlPoints.x1, y1: controlPoints.y1, x2: controlPoints.x2, y2: controlPoints.y2)
+    }
+
+    /// Evaluates the cubic-bezier `(x1, y1, x2, y2)` easing at `x`, in `[0, 1]`.
+    ///
+    /// Implemented as an iterative bisection on the parametric Bézier `x(t)` to find the parameter
+    /// matching the input `x`, then evaluated as `y(t)`. The number of bisections is fixed and
+    /// small (16) to stay fast — the resulting precision is well below one pixel.
+    static func value(_ x: Double, x1: Double, y1: Double, x2: Double, y2: Double) -> Double {
+        // Special cases at boundaries.
+        if x <= 0.0 { return 0.0 }
+        if x >= 1.0 { return 1.0 }
+
+        // Solve for t such that bezierComponent(t, x1, x2) == x, using bisection.
+        var lower = 0.0
+        var upper = 1.0
+        var t = x
+        for _ in 0 ..< 16 {
+            let currentX = bezierComponent(t, x1, x2)
+            if currentX < x {
+                lower = t
+            } else {
+                upper = t
+            }
+            t = (lower + upper) / 2.0
+        }
+        return bezierComponent(t, y1, y2)
+    }
+
+    /// Evaluates a 1D cubic Bezier at `t` with control points `(0, c1, c2, 1)`.
+    private static func bezierComponent(_ t: Double, _ c1: Double, _ c2: Double) -> Double {
+        let oneMinusT = 1.0 - t
+        return 3.0 * oneMinusT * oneMinusT * t * c1
+            + 3.0 * oneMinusT * t * t * c2
+            + t * t * t
+    }
+}

--- a/OUDS/Core/Components/Tests/Indicators/CircularProgressIndicator/CircularProgressIndicatorConstantsTests.swift
+++ b/OUDS/Core/Components/Tests/Indicators/CircularProgressIndicator/CircularProgressIndicatorConstantsTests.swift
@@ -33,74 +33,56 @@ struct CircularProgressCanvasConstantsTests {
 
 // MARK: - Animator constants
 
-/// Tests on the Material 3 animation constants defined in ``CircularProgressIndicatorAnimator``.
-/// See the Material 3 progress indicator specification for the reference values.
+/// Tests on the Material indeterminate animation constants defined in
+/// ``CircularProgressIndicatorIndeterminateView``. Values are the ones actually shipped by
+/// Material Web, Material Components Android and Flutter's `CircularProgressIndicator` (they
+/// share the very same motion values).
 struct CircularProgressAnimatorConstantsTests {
 
-    // MARK: - Global rotation
+    // MARK: - Tooth (head / tail cycle)
 
     @Test
-    func `global rotation period must be 6 seconds (M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.globalRotationPeriod == 6.0)
+    func `tooth duration must be 1_333 seconds (Material spec)`() {
+        #expect(CircularProgressIndicatorIndeterminateView.toothDuration == 1.333)
     }
 
-    // MARK: - Additional rotation
+    // MARK: - Base rotation
 
     @Test
-    func `additional rotation cycle must be 1_5 seconds (500ms animation + 1s hold, M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.additionalRotationCycle == 1.5)
+    func `rotation duration must be 2_222 seconds (Material spec)`() {
+        #expect(CircularProgressIndicatorIndeterminateView.rotationDuration == 2.222)
     }
+
+    // MARK: - Sweep
 
     @Test
-    func `additional rotation animation duration must be 500 milliseconds (M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.additionalRotationAnimDuration == 0.5)
-    }
-
-    @Test
-    func `additional rotation target must be 90 degrees per cycle (M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.additionalRotationTarget == 90.0)
-    }
-
-    @Test @MainActor
-    func `additional rotation hold duration must equal cycle minus animation duration`() {
-        // Coherence check: hold + anim = full cycle
-        let hold = CircularProgressIndicatorIndeterminateView.additionalRotationCycle
-            - CircularProgressIndicatorIndeterminateView.additionalRotationAnimDuration
-        #expect(hold == 1.0)
-    }
-
-    // MARK: - Progress sweep
-
-    @Test
-    func `progress half cycle must be 1_5 seconds (M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.progressHalfCycle == 1.5)
+    func `maximum sweep must be 270 degrees (3 over 2 pi, Material spec)`() {
+        #expect(CircularProgressIndicatorIndeterminateView.maxSweepDegrees == 270.0)
     }
 
     @Test
-    func `progress minimum sweep must be 5 percent`() {
-        #expect(CircularProgressIndicatorIndeterminateView.progressMin == 0.05)
+    func `minimum sweep must be strictly positive so the arc never fully disappears`() {
+        #expect(CircularProgressIndicatorIndeterminateView.minSweepDegrees > 0.0)
     }
 
     @Test
-    func `progress maximum sweep must be 75 percent (M3 spec)`() {
-        #expect(CircularProgressIndicatorIndeterminateView.progressMax == 0.75)
+    func `minimum sweep must be strictly less than maximum sweep`() {
+        #expect(CircularProgressIndicatorIndeterminateView.minSweepDegrees
+            < CircularProgressIndicatorIndeterminateView.maxSweepDegrees)
+    }
+
+    // MARK: - Kick
+
+    @Test
+    func `kick must be 90 degrees per tooth (Material spec)`() {
+        #expect(CircularProgressIndicatorIndeterminateView.kickDegrees == 90.0)
     }
 
     @Test
-    func `progress maximum sweep without track must be 90 percent`() {
-        #expect(CircularProgressIndicatorIndeterminateView.progressMaxWithoutTrack == 0.90)
-    }
-
-    @Test
-    func `progress maximum without track must be greater than or equal to progress maximum with track`() {
-        #expect(CircularProgressIndicatorIndeterminateView.progressMaxWithoutTrack
-            >= CircularProgressIndicatorIndeterminateView.progressMax)
-    }
-
-    @Test
-    func `progress minimum must be strictly less than progress maximum`() {
-        // Coherence check: prevent silent regression that swaps or equals bounds
-        #expect(CircularProgressIndicatorIndeterminateView.progressMin < CircularProgressIndicatorIndeterminateView.progressMax)
+    func `kick plus maximum sweep must total a full turn (invisible reset jump)`() {
+        // The -360° jump produced when the tooth resets must be a full turn to stay invisible.
+        #expect(CircularProgressIndicatorIndeterminateView.kickDegrees
+            + CircularProgressIndicatorIndeterminateView.maxSweepDegrees == 360.0)
     }
 
     // MARK: - Static (accessibility / low power) sweep
@@ -111,9 +93,8 @@ struct CircularProgressAnimatorConstantsTests {
     }
 
     @Test
-    func `static sweep must be within the animated progress range`() {
-        // Coherence: the static fallback should look consistent with what the animation produces
-        #expect(CircularProgressIndicatorIndeterminateView.staticSweep >= CircularProgressIndicatorIndeterminateView.progressMin)
-        #expect(CircularProgressIndicatorIndeterminateView.staticSweep <= CircularProgressIndicatorIndeterminateView.progressMax)
+    func `static sweep must be within [0, 1]`() {
+        #expect(CircularProgressIndicatorIndeterminateView.staticSweep >= 0.0)
+        #expect(CircularProgressIndicatorIndeterminateView.staticSweep <= 1.0)
     }
 }

--- a/OUDS/Core/Components/Tests/Indicators/LinearProgressIndicator/LinearProgressIndicatorConstantsTests.swift
+++ b/OUDS/Core/Components/Tests/Indicators/LinearProgressIndicator/LinearProgressIndicatorConstantsTests.swift
@@ -262,11 +262,12 @@ struct LinearIndeterminateEasingTests {
     }
 }
 
-// MARK: - Fraction helper (Android Compose M3 keyframes behavior)
+// MARK: - Fraction helper (Material keyframes behavior)
 
 /// Tests on ``LinearProgressIndicatorIndeterminateView/fraction(phase:delay:duration:controlPoints:)``,
-/// which must reproduce the Material `keyframes` behavior: value is `1.0` before `delay`, then
-/// eases from `0.0` to `1.0` between `delay` and `delay + duration`, then stays at `1.0`.
+/// which must reproduce Flutter's `Interval.transform` clamping behavior: value is `0.0` before
+/// `delay` (the animation has not started yet), then eases from `0.0` to `1.0` between `delay` and
+/// `delay + duration`, then stays at `1.0`.
 struct LinearIndeterminateFractionTests {
 
     private let delay: TimeInterval = 0.25
@@ -275,12 +276,12 @@ struct LinearIndeterminateFractionTests {
     private let controlPoints = ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.2, y1: 0.0, x2: 0.8, y2: 1.0)
 
     @Test @MainActor
-    func `fraction before delay must be 1_0 (previous cycle value)`() {
+    func `fraction before delay must be 0_0 (animation not started yet)`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: 0.1,
                                                                       delay: delay,
                                                                       duration: duration,
                                                                       controlPoints: controlPoints)
-        #expect(value == 1.0)
+        #expect(value == 0.0)
     }
 
     @Test @MainActor
@@ -318,5 +319,120 @@ struct LinearIndeterminateFractionTests {
                                                                       duration: 0.0,
                                                                       controlPoints: controlPoints)
         #expect(value == 1.0)
+    }
+
+    @Test @MainActor
+    func `fraction must never jump discontinuously around the delay boundary (no sudden caterpillar)`() {
+        // Regression test for the "caterpillar appears suddenly" bug: sampling finely around
+        // `delay`, consecutive values must never differ by more than what the eased curve itself
+        // can produce in one small step.
+        let step: TimeInterval = 0.001
+        var previous = LinearProgressIndicatorIndeterminateView.fraction(phase: delay - 0.05,
+                                                                         delay: delay,
+                                                                         duration: duration,
+                                                                         controlPoints: controlPoints)
+        var phase = delay - 0.05 + step
+        while phase <= delay + 0.05 {
+            let value = LinearProgressIndicatorIndeterminateView.fraction(phase: phase,
+                                                                          delay: delay,
+                                                                          duration: duration,
+                                                                          controlPoints: controlPoints)
+            #expect(abs(value - previous) < 0.05)
+            previous = value
+            phase += step
+        }
+    }
+}
+
+// MARK: - Full-cycle segment length continuity (end-to-end regression for the reported glitch)
+
+/// Regression tests reproducing the exact reported bug: "the caterpillar arrives suddenly, a
+/// second one arrives and leaves abruptly". These tests simulate a full ``cycleDuration`` at a
+/// fine time step and check that the visible length of each colored line
+/// (`max(0, head - tail)`) never jumps abruptly, and instead grows from `0`, peaks, and shrinks
+/// back to `0` continuously — matching the reference Flutter/Material behavior of a caterpillar
+/// that departs, stretches, comes back together and exits, before the next one starts.
+struct LinearIndeterminateCycleContinuityTests {
+
+    private static let firstBarControlPoints = (
+        head: ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.2, y1: 0.0, x2: 0.8, y2: 1.0),
+        tail: ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.4, y1: 0.0, x2: 1.0, y2: 1.0))
+    private static let secondBarControlPoints = (
+        head: ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.0, y1: 0.0, x2: 0.65, y2: 1.0),
+        tail: ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.10, y1: 0.0, x2: 0.45, y2: 1.0))
+
+    private static func firstBarLength(at phase: TimeInterval) -> CGFloat {
+        let head = LinearProgressIndicatorIndeterminateView.fraction(
+            phase: phase,
+            delay: LinearProgressIndicatorIndeterminateView.firstLineHeadDelay,
+            duration: LinearProgressIndicatorIndeterminateView.firstLineHeadDuration,
+            controlPoints: firstBarControlPoints.head)
+        let tail = LinearProgressIndicatorIndeterminateView.fraction(
+            phase: phase,
+            delay: LinearProgressIndicatorIndeterminateView.firstLineTailDelay,
+            duration: LinearProgressIndicatorIndeterminateView.firstLineTailDuration,
+            controlPoints: firstBarControlPoints.tail)
+        return max(0, head - tail)
+    }
+
+    private static func secondBarLength(at phase: TimeInterval) -> CGFloat {
+        let head = LinearProgressIndicatorIndeterminateView.fraction(
+            phase: phase,
+            delay: LinearProgressIndicatorIndeterminateView.secondLineHeadDelay,
+            duration: LinearProgressIndicatorIndeterminateView.secondLineHeadDuration,
+            controlPoints: secondBarControlPoints.head)
+        let tail = LinearProgressIndicatorIndeterminateView.fraction(
+            phase: phase,
+            delay: LinearProgressIndicatorIndeterminateView.secondLineTailDelay,
+            duration: LinearProgressIndicatorIndeterminateView.secondLineTailDuration,
+            controlPoints: secondBarControlPoints.tail)
+        return max(0, head - tail)
+    }
+
+    @Test @MainActor
+    func `first bar length must start at zero and grow smoothly right from the start of the cycle`() {
+        // Regression: with the fixed `fraction`, the bar is no longer invisible until `firstLineTailDelay`
+        // then popping into existence — it must already be visibly growing well before that delay.
+        let lengthAtStart = Self.firstBarLength(at: 0.0)
+        let lengthBeforeTailDelay = Self.firstBarLength(
+            at: LinearProgressIndicatorIndeterminateView.firstLineTailDelay - 0.05)
+        #expect(lengthAtStart == 0.0)
+        #expect(lengthBeforeTailDelay > 0.0)
+    }
+
+    @Test @MainActor
+    func `first bar length must never jump by more than a small bounded step across the full cycle`() {
+        let step: TimeInterval = 0.002
+        var previous = Self.firstBarLength(at: 0.0)
+        var phase: TimeInterval = step
+        while phase <= LinearProgressIndicatorIndeterminateView.cycleDuration {
+            let value = Self.firstBarLength(at: phase)
+            #expect(abs(value - previous) < 0.05)
+            previous = value
+            phase += step
+        }
+    }
+
+    @Test @MainActor
+    func `second bar length must never jump by more than a small bounded step across the full cycle`() {
+        let step: TimeInterval = 0.002
+        var previous = Self.secondBarLength(at: 0.0)
+        var phase: TimeInterval = step
+        while phase <= LinearProgressIndicatorIndeterminateView.cycleDuration {
+            let value = Self.secondBarLength(at: phase)
+            #expect(abs(value - previous) < 0.05)
+            previous = value
+            phase += step
+        }
+    }
+
+    @Test @MainActor
+    func `first bar must fully exit before fading back in on the next cycle`() {
+        // The first bar's tail finishes at firstLineTailDelay + firstLineTailDuration: from that
+        // point until the cycle wraps, the bar must be fully gone (length 0).
+        let tailEnd = LinearProgressIndicatorIndeterminateView.firstLineTailDelay
+            + LinearProgressIndicatorIndeterminateView.firstLineTailDuration
+        #expect(Self.firstBarLength(at: tailEnd) == 0.0)
+        #expect(Self.firstBarLength(at: tailEnd + 0.1) == 0.0)
     }
 }

--- a/OUDS/Core/Components/Tests/Indicators/LinearProgressIndicator/LinearProgressIndicatorConstantsTests.swift
+++ b/OUDS/Core/Components/Tests/Indicators/LinearProgressIndicator/LinearProgressIndicatorConstantsTests.swift
@@ -44,6 +44,58 @@ struct LinearProgressBarCanvasConstantsTests {
     func `small gap size must be strictly smaller than default gap size`() {
         #expect(LinearProgressBarCanvasView.smallGapSize < LinearProgressBarCanvasView.defaultGapSize)
     }
+
+    @Test
+    func `track gap ramp down threshold must be 1 percent (Material spec)`() {
+        #expect(LinearProgressBarCanvasView.trackGapRampDownThreshold == 0.01)
+    }
+}
+
+// MARK: - Track gap ramp helper (Material reference `getEffectiveTrackGapFraction`)
+
+/// Tests on ``LinearProgressBarCanvasView/effectiveTrackGapFraction(currentValue:gapFraction:)``,
+/// which must ramp the gap smoothly from `0` to its nominal size instead of jumping abruptly —
+/// this is the fix for the reported "gap discontinuity" bug.
+struct LinearProgressBarCanvasGapRampTests {
+
+    @Test
+    func `gap must be zero when the adjacent value is zero`() {
+        #expect(LinearProgressBarCanvasView.effectiveTrackGapFraction(currentValue: 0.0, gapFraction: 0.05) == 0.0)
+    }
+
+    @Test
+    func `gap must reach its nominal value at the ramp threshold`() {
+        let gapFraction: CGFloat = 0.05
+        let value = LinearProgressBarCanvasView.effectiveTrackGapFraction(
+            currentValue: LinearProgressBarCanvasView.trackGapRampDownThreshold,
+            gapFraction: gapFraction)
+        #expect(abs(value - gapFraction) < 1e-9)
+    }
+
+    @Test
+    func `gap must stay at its nominal value beyond the ramp threshold`() {
+        let gapFraction: CGFloat = 0.05
+        let value = LinearProgressBarCanvasView.effectiveTrackGapFraction(currentValue: 0.5, gapFraction: gapFraction)
+        #expect(value == gapFraction)
+    }
+
+    @Test @MainActor
+    func `gap must increase monotonically with the adjacent value up to the threshold`() {
+        let gapFraction: CGFloat = 0.05
+        var previous: CGFloat = 0.0
+        for step in 1 ... 10 {
+            let currentValue = LinearProgressBarCanvasView.trackGapRampDownThreshold * CGFloat(step) / 10.0
+            let value = LinearProgressBarCanvasView.effectiveTrackGapFraction(currentValue: currentValue,
+                                                                              gapFraction: gapFraction)
+            #expect(value >= previous)
+            previous = value
+        }
+    }
+
+    @Test
+    func `gap must never be negative for a negative adjacent value`() {
+        #expect(LinearProgressBarCanvasView.effectiveTrackGapFraction(currentValue: -1.0, gapFraction: 0.05) == 0.0)
+    }
 }
 
 // MARK: - Determinate animator constants
@@ -82,46 +134,47 @@ struct LinearDeterminateAnimatorConstantsTests {
     }
 }
 
-// MARK: - Indeterminate animator constants (AndroidX Material 3 reference)
+// MARK: - Indeterminate animator constants (Material reference)
 
-/// Tests on the Material 3 indeterminate animation constants defined in
-/// ``LinearProgressIndicatorIndeterminateView``. Values are the ones actually shipped by AndroidX
-/// Compose Material 3 `ProgressIndicator.kt`.
+/// Tests on the Material indeterminate animation constants defined in
+/// ``LinearProgressIndicatorIndeterminateView``. Values are the ones actually shipped by
+/// Material Web, Material Components Android and Flutter's `LinearProgressIndicator` (they share
+/// the very same motion values).
 struct LinearIndeterminateAnimConstantsTests {
 
     // MARK: - Cycle
 
     @Test
-    func `cycle duration must be 1_750 seconds (M3 LinearAnimationDuration)`() {
-        #expect(LinearProgressIndicatorIndeterminateView.cycleDuration == 1.750)
+    func `cycle duration must be 1_800 seconds (Material LinearAnimationDuration)`() {
+        #expect(LinearProgressIndicatorIndeterminateView.cycleDuration == 1.800)
     }
 
     // MARK: - First bar
 
     @Test
-    func `first bar head must start at 0 ms and last 1_000 ms (M3 spec)`() {
+    func `first bar head must start at 0 ms and last 750 ms (Material spec)`() {
         #expect(LinearProgressIndicatorIndeterminateView.firstLineHeadDelay == 0.0)
-        #expect(LinearProgressIndicatorIndeterminateView.firstLineHeadDuration == 1.000)
+        #expect(LinearProgressIndicatorIndeterminateView.firstLineHeadDuration == 0.750)
     }
 
     @Test
-    func `first bar tail must start at 250 ms and last 1_000 ms (M3 spec)`() {
-        #expect(LinearProgressIndicatorIndeterminateView.firstLineTailDelay == 0.250)
-        #expect(LinearProgressIndicatorIndeterminateView.firstLineTailDuration == 1.000)
+    func `first bar tail must start at 333 ms and last 750 ms (Material spec)`() {
+        #expect(LinearProgressIndicatorIndeterminateView.firstLineTailDelay == 0.333)
+        #expect(LinearProgressIndicatorIndeterminateView.firstLineTailDuration == 0.750)
     }
 
     // MARK: - Second bar
 
     @Test
-    func `second bar head must start at 650 ms and last 850 ms (M3 spec)`() {
-        #expect(LinearProgressIndicatorIndeterminateView.secondLineHeadDelay == 0.650)
-        #expect(LinearProgressIndicatorIndeterminateView.secondLineHeadDuration == 0.850)
+    func `second bar head must start at 1_000 ms and last 567 ms (Material spec)`() {
+        #expect(LinearProgressIndicatorIndeterminateView.secondLineHeadDelay == 1.000)
+        #expect(LinearProgressIndicatorIndeterminateView.secondLineHeadDuration == 0.567)
     }
 
     @Test
-    func `second bar tail must start at 900 ms and last 850 ms (M3 spec)`() {
-        #expect(LinearProgressIndicatorIndeterminateView.secondLineTailDelay == 0.900)
-        #expect(LinearProgressIndicatorIndeterminateView.secondLineTailDuration == 0.850)
+    func `second bar tail must start at 1_267 ms and last 533 ms (Material spec)`() {
+        #expect(LinearProgressIndicatorIndeterminateView.secondLineTailDelay == 1.267)
+        #expect(LinearProgressIndicatorIndeterminateView.secondLineTailDuration == 0.533)
     }
 
     // MARK: - Coherence
@@ -175,57 +228,58 @@ struct LinearIndeterminateAnimConstantsTests {
     }
 }
 
-// MARK: - Easing (EasingEmphasizedAccelerate — M3 cubic-bezier(0.3, 0, 0.8, 0.15))
+// MARK: - Easing (per-segment cubic-bezier curves, shared implementation)
 
-/// Tests on the M3 `EasingEmphasizedAccelerate` cubic-bezier easing used by all four indeterminate
-/// linear animations.
+/// Tests on ``ProgressIndicatorCubicBezierEasing``, the generic cubic-bezier evaluator used by all
+/// four indeterminate linear animations (each with its own control points, see the type
+/// documentation of ``LinearProgressIndicatorIndeterminateView``).
 struct LinearIndeterminateEasingTests {
+
+    // Uses the first bar's head control points (0.2, 0, 0.8, 1) as a representative case.
+    private static func easing(_ x: Double) -> Double {
+        ProgressIndicatorCubicBezierEasing.value(x, x1: 0.2, y1: 0.0, x2: 0.8, y2: 1.0)
+    }
 
     @Test
     func `easing at 0 must equal 0`() {
-        #expect(LinearProgressIndicatorIndeterminateView.easingEmphasizedAccelerate(0.0) == 0.0)
+        #expect(Self.easing(0.0) == 0.0)
     }
 
     @Test
     func `easing at 1 must equal 1`() {
-        #expect(LinearProgressIndicatorIndeterminateView.easingEmphasizedAccelerate(1.0) == 1.0)
+        #expect(Self.easing(1.0) == 1.0)
     }
 
     @Test @MainActor
     func `easing must be monotonically increasing`() {
-        var previous = LinearProgressIndicatorIndeterminateView.easingEmphasizedAccelerate(0.0)
+        var previous = Self.easing(0.0)
         for step in 1 ... 20 {
             let x = Double(step) / 20.0
-            let value = LinearProgressIndicatorIndeterminateView.easingEmphasizedAccelerate(x)
+            let value = Self.easing(x)
             #expect(value >= previous - 1e-6) // small numerical tolerance
             previous = value
         }
-    }
-
-    @Test @MainActor
-    func `easing must accelerate (value at 0_5 is strictly less than 0_5)`() {
-        // EasingEmphasizedAccelerate is a decelerating output curve: slow at the beginning,
-        // fast at the end. The value at t = 0.5 stays well below the diagonal (0.5).
-        let mid = LinearProgressIndicatorIndeterminateView.easingEmphasizedAccelerate(0.5)
-        #expect(mid < 0.5)
     }
 }
 
 // MARK: - Fraction helper (Android Compose M3 keyframes behavior)
 
-/// Tests on ``LinearProgressIndicatorIndeterminateView/fraction(phase:delay:duration:)``, which
-/// must reproduce the Compose `keyframes` behavior: value is `1.0` before `delay`, then eases
-/// from `0.0` to `1.0` between `delay` and `delay + duration`, then stays at `1.0`.
+/// Tests on ``LinearProgressIndicatorIndeterminateView/fraction(phase:delay:duration:controlPoints:)``,
+/// which must reproduce the Material `keyframes` behavior: value is `1.0` before `delay`, then
+/// eases from `0.0` to `1.0` between `delay` and `delay + duration`, then stays at `1.0`.
 struct LinearIndeterminateFractionTests {
 
     private let delay: TimeInterval = 0.25
     private let duration: TimeInterval = 1.0
+    // First bar head control points, used as a representative case.
+    private let controlPoints = ProgressIndicatorCubicBezierEasing.ControlPoints(x1: 0.2, y1: 0.0, x2: 0.8, y2: 1.0)
 
     @Test @MainActor
     func `fraction before delay must be 1_0 (previous cycle value)`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: 0.1,
                                                                       delay: delay,
-                                                                      duration: duration)
+                                                                      duration: duration,
+                                                                      controlPoints: controlPoints)
         #expect(value == 1.0)
     }
 
@@ -233,7 +287,8 @@ struct LinearIndeterminateFractionTests {
     func `fraction exactly at delay must start from eased 0_0`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: delay,
                                                                       delay: delay,
-                                                                      duration: duration)
+                                                                      duration: duration,
+                                                                      controlPoints: controlPoints)
         #expect(value == 0.0)
     }
 
@@ -241,7 +296,8 @@ struct LinearIndeterminateFractionTests {
     func `fraction after animation end must stay at 1_0`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: delay + duration + 0.1,
                                                                       delay: delay,
-                                                                      duration: duration)
+                                                                      duration: duration,
+                                                                      controlPoints: controlPoints)
         #expect(value == 1.0)
     }
 
@@ -249,7 +305,8 @@ struct LinearIndeterminateFractionTests {
     func `fraction in the middle of the animation must be strictly less than 1 (accelerating)`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: delay + duration / 2.0,
                                                                       delay: delay,
-                                                                      duration: duration)
+                                                                      duration: duration,
+                                                                      controlPoints: controlPoints)
         #expect(value > 0.0)
         #expect(value < 1.0)
     }
@@ -258,7 +315,8 @@ struct LinearIndeterminateFractionTests {
     func `fraction guards against zero duration`() {
         let value = LinearProgressIndicatorIndeterminateView.fraction(phase: 0.5,
                                                                       delay: 0.0,
-                                                                      duration: 0.0)
+                                                                      duration: 0.0,
+                                                                      controlPoints: controlPoints)
         #expect(value == 1.0)
     }
 }


### PR DESCRIPTION
### Related issues

<!-- Please link any related issues here. -->
#1708 

### Description

<!-- Describe your changes in detail -->
Change animations for circular and linear progress indicators

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Implement expected animations

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Refactoring (non-breaking change)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [x] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- [x] Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
