### PR TITLE
[#1721] For toolbar top component update API to expose principal placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `toast` component tokens (tokens library v2.7.0) (Orange-OpenSource/ouds-ios#1652)
 - `alert message` component tokens (tokens library v2.7.0) (Orange-OpenSource/ouds-ios#1652)
+- `principal` placement for `toolbar top` component items (Orange-OpenSource/ouds-ios#1721)
 - `subtitle` on `toolbar top` for iOS lower than 26 or with Liquid Glass disabled (Orange-OpenSource/ouds-ios#1696)
 - Support of animated images (GIF, WebP) for `list item` components (Orange-OpenSource/ouds-ios#1706)
 - Leading, trailing and bottom slots for `list item` components (Orange-OpenSource/ouds-ios#1568)

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -26,7 +26,7 @@ struct ToolBarTopModifier: ViewModifier {
     let hasLargeTitle: Bool
     let subtitle: String?
     @OUDSToolBarItemsBuilder let leadingItems: [OUDSToolBarItem]
-    @OUDSToolBarItemsBuilder let principalItems: [OUDSToolBarItem]
+    let principalItem: OUDSToolBarItem?
     @OUDSToolBarItemsBuilder let trailingItems: [OUDSToolBarItem]
 
     // MARK: - Initializer
@@ -38,14 +38,14 @@ struct ToolBarTopModifier: ViewModifier {
     ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for iOS lower than 26.
     ///   - subtitle: Optional subtitle displayed below the title, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side
-    ///   - principalItems: The items displayed in the principal (center) position
+    ///   - principalItem: The item displayed in the principal (center) position (only one item supported)
     ///   - trailingItems: The items displayed on the trailing side
     ///   - content: The content view wrapped by the toolbar.
     init(title: String,
          hasLargeTitle: Bool,
          subtitle: String? = nil,
          @OUDSToolBarItemsBuilder leadingItems: @escaping () -> [OUDSToolBarItem],
-         @OUDSToolBarItemsBuilder principalItems: @escaping () -> [OUDSToolBarItem],
+         principalItem: OUDSToolBarItem? = nil,
          @OUDSToolBarItemsBuilder trailingItems: @escaping () -> [OUDSToolBarItem])
     {
         if title.isEmpty {
@@ -59,7 +59,7 @@ struct ToolBarTopModifier: ViewModifier {
         self.hasLargeTitle = hasLargeTitle
         self.subtitle = subtitle
         self.leadingItems = leadingItems()
-        self.principalItems = principalItems()
+        self.principalItem = principalItem
         self.trailingItems = trailingItems()
     }
 
@@ -72,8 +72,10 @@ struct ToolBarTopModifier: ViewModifier {
                 ToolbarItemGroup(placement: leadingPlacement) {
                     itemsView(leadingItems)
                 }
-                ToolbarItemGroup(placement: principalPlacement) {
-                    itemsView(principalItems)
+                ToolbarItem(placement: principalPlacement) {
+                    principalItem.map { item in
+                        item.environment(\.toolbarItemLocation, .toolbarTop)
+                    }
                 }
                 ToolbarItemGroup(placement: trailingPlacement) {
                     itemsView(trailingItems)

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -26,23 +26,26 @@ struct ToolBarTopModifier: ViewModifier {
     let hasLargeTitle: Bool
     let subtitle: String?
     @OUDSToolBarItemsBuilder let leadingItems: [OUDSToolBarItem]
+    @OUDSToolBarItemsBuilder let principalItems: [OUDSToolBarItem]
     @OUDSToolBarItemsBuilder let trailingItems: [OUDSToolBarItem]
 
     // MARK: - Initializer
 
-    /// Creates a top toobar with a title, optional subtitle (iOS 26+ only), and leading / trailing items.
+    /// Creates a top toobar with a title, optional subtitle (iOS 26+ only), and leading / principal / trailing items.
     ///
     /// - Parameters:
     ///   - title: The toobar title. Prefer a non-empty string.
     ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for iOS lower than 26.
     ///   - subtitle: Optional subtitle displayed below the title, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side
+    ///   - principalItems: The items displayed in the principal (center) position
     ///   - trailingItems: The items displayed on the trailing side
     ///   - content: The content view wrapped by the toolbar.
     init(title: String,
          hasLargeTitle: Bool,
          subtitle: String? = nil,
          @OUDSToolBarItemsBuilder leadingItems: @escaping () -> [OUDSToolBarItem],
+         @OUDSToolBarItemsBuilder principalItems: @escaping () -> [OUDSToolBarItem],
          @OUDSToolBarItemsBuilder trailingItems: @escaping () -> [OUDSToolBarItem])
     {
         if title.isEmpty {
@@ -56,6 +59,7 @@ struct ToolBarTopModifier: ViewModifier {
         self.hasLargeTitle = hasLargeTitle
         self.subtitle = subtitle
         self.leadingItems = leadingItems()
+        self.principalItems = principalItems()
         self.trailingItems = trailingItems()
     }
 
@@ -67,6 +71,9 @@ struct ToolBarTopModifier: ViewModifier {
             .toolbar {
                 ToolbarItemGroup(placement: leadingPlacement) {
                     itemsView(leadingItems)
+                }
+                ToolbarItemGroup(placement: principalPlacement) {
+                    itemsView(principalItems)
                 }
                 ToolbarItemGroup(placement: trailingPlacement) {
                     itemsView(trailingItems)
@@ -86,6 +93,14 @@ struct ToolBarTopModifier: ViewModifier {
     private var leadingPlacement: ToolbarItemPlacement {
         #if os(iOS) || os(visionOS)
         return .topBarLeading
+        #else
+        return .automatic
+        #endif
+    }
+
+    private var principalPlacement: ToolbarItemPlacement {
+        #if os(iOS) || os(visionOS)
+        return .principal
         #else
         return .automatic
         #endif

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -36,9 +36,10 @@ struct ToolBarTopModifier: ViewModifier {
     /// - Parameters:
     ///   - title: The toobar title. Prefer a non-empty string.
     ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for iOS lower than 26.
-    ///   - subtitle: Optional subtitle displayed below the title, *nil* by default.
+    ///   - subtitle: Optional subtitle displayed below the title, *nil* by default. **Ignored if `principalItem` is not *nil*.**
     ///   - leadingItems: The items displayed on the leading side
-    ///   - principalItem: The item displayed in the principal (center) position (only one item supported)
+    ///   - principalItem: The item displayed in the principal (center) position (only one item supported).
+    ///     If set, the title is not displayed unless `hasLargeTitle` is `true`, and the subtitle is never displayed.
     ///   - trailingItems: The items displayed on the trailing side
     ///   - content: The content view wrapped by the toolbar.
     init(title: String,
@@ -65,22 +66,52 @@ struct ToolBarTopModifier: ViewModifier {
 
     // MARK: - Body
 
+    @ViewBuilder
     func body(content: Content) -> some View {
-        content
-            .oudsNavigationTitle(title, subtitle: subtitle, hasLargeTitle: hasLargeTitle)
-            .toolbar {
+        if let principalItem, !hasLargeTitle {
+            // Principal item without large title: no title, no subtitle, just the toolbar with the principal item.
+            content.toolbar {
                 ToolbarItemGroup(placement: leadingPlacement) {
                     itemsView(leadingItems)
                 }
                 ToolbarItem(placement: principalPlacement) {
-                    principalItem.map { item in
-                        item.environment(\.toolbarItemLocation, .toolbarTop)
-                    }
+                    principalItem.environment(\.toolbarItemLocation, .toolbarTop)
                 }
                 ToolbarItemGroup(placement: trailingPlacement) {
                     itemsView(trailingItems)
                 }
             }
+        } else if let principalItem {
+            // Principal item and large title: title is displayed (large mode), subtitle is never displayed.
+            // Note: SwiftUI's `.principal` placement only replaces the inline compact bar title, not the large title
+            // nor `.navigationSubtitle()` (iOS 26+), which would otherwise keep rendering next to/under the principal
+            // item with no visible title next to it. So the subtitle must never be forwarded here.
+            content
+                .oudsNavigationTitle(title, subtitle: nil, hasLargeTitle: hasLargeTitle)
+                .toolbar {
+                    ToolbarItemGroup(placement: leadingPlacement) {
+                        itemsView(leadingItems)
+                    }
+                    ToolbarItem(placement: principalPlacement) {
+                        principalItem.environment(\.toolbarItemLocation, .toolbarTop)
+                    }
+                    ToolbarItemGroup(placement: trailingPlacement) {
+                        itemsView(trailingItems)
+                    }
+                }
+        } else {
+            // No principal item: standard behavior, title and subtitle displayed as configured.
+            content
+                .oudsNavigationTitle(title, subtitle: subtitle, hasLargeTitle: hasLargeTitle)
+                .toolbar {
+                    ToolbarItemGroup(placement: leadingPlacement) {
+                        itemsView(leadingItems)
+                    }
+                    ToolbarItemGroup(placement: trailingPlacement) {
+                        itemsView(trailingItems)
+                    }
+                }
+        }
     }
 
     // MARK: - Helpers

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/Internal/ToolBarTopModifier.swift
@@ -31,10 +31,10 @@ struct ToolBarTopModifier: ViewModifier {
 
     // MARK: - Initializer
 
-    /// Creates a top toobar with a title, optional subtitle (iOS 26+ only), and leading / principal / trailing items.
+    /// Creates a top toolbar with a title, optional subtitle (iOS 26+ only), and leading / principal / trailing items.
     ///
     /// - Parameters:
-    ///   - title: The toobar title. Prefer a non-empty string.
+    ///   - title: The toolbar title. Prefer a non-empty string.
     ///   - hasLargeTitle: If title must be displayed in large mode. If large mode, the subtitle is not displayed for iOS lower than 26.
     ///   - subtitle: Optional subtitle displayed below the title, *nil* by default. **Ignored if `principalItem` is not *nil*.**
     ///   - leadingItems: The items displayed on the leading side

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -20,7 +20,7 @@ import SwiftUI
 // MARK: - OUDS ToolBar Item
 
 /// A strongly typed toolbar item container used inside:
-/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)`
+/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItem:trailingItems:)`
 /// - `toolBarBottom(leadingItems:trailingItems:)`
 ///
 /// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
@@ -86,7 +86,7 @@ public struct OUDSToolBarItem: View, Identifiable {
 
     /// Defines the built-in action type available for the toolbars.
     /// Those items can be used at `.topLeading`, `.principal` and `.topTrailing` positions
-    /// of a `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)`
+    /// of a `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItem:trailingItems:)`
     ///
     /// - Since: 1.4.0
     @frozen public enum ActionType {

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -20,7 +20,7 @@ import SwiftUI
 // MARK: - OUDS ToolBar Item
 
 /// A strongly typed toolbar item container used inside:
-/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
+/// - `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)`
 /// - `toolBarBottom(leadingItems:trailingItems:)`
 ///
 /// Use ``OUDSToolBarItem`` to provide custom toolbar views or predefined navigation items.
@@ -85,7 +85,8 @@ public struct OUDSToolBarItem: View, Identifiable {
     }
 
     /// Defines the built-in action type available for the toolbars.
-    /// Those items can be used at `.topLeading` and `.topTrailing` positions of a `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`
+    /// Those items can be used at `.topLeading`, `.principal` and `.topTrailing` positions
+    /// of a `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)`
     ///
     /// - Since: 1.4.0
     @frozen public enum ActionType {

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -163,7 +163,8 @@ public struct OUDSToolBarItem: View, Identifiable {
 
     // MARK: - Stored properties
 
-    private let content: Content
+    let content: Content
+
     public let id = UUID()
 
     // MARK: - Initializers

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarItem.swift
@@ -199,7 +199,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         content = .action(type: .icon(asset: icon, accessibilityLabel: accessibilityLabel, action: action), style: .default)
     }
 
-    /// Creates a toobar item with action type.
+    /// Creates a toolbar item with action type.
     ///
     /// ```swift
     ///     // A toolbar item with an "Edit" label and an associated action
@@ -214,7 +214,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         content = .action(type: type, style: .default)
     }
 
-    /// Creates a toobar item with action type and a style
+    /// Creates a toolbar item with action type and a style
     ///
     /// ```swift
     ///     OUDSToolBarItem(action: .label("Edit") { }, style: .tinted)
@@ -228,7 +228,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         content = .action(type: type, style: style)
     }
 
-    /// Creates a toobar item with icon dedicated to navigation.
+    /// Creates a toolbar item with icon dedicated to navigation.
     ///
     /// ```swift
     ///     OUDSToolBarItem(navigation: .back { /* Action */ })
@@ -239,7 +239,7 @@ public struct OUDSToolBarItem: View, Identifiable {
         content = .navigation(type: type)
     }
 
-    /// Creates a toobar item with a custom view.
+    /// Creates a toolbar item with a custom view.
     ///
     /// Use this initializer to provide any SwiftUI view, such as a `Menu`, custom button, or complex layout.
     ///

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// The top toolbar (aka *navigation bar* on iOS and iPadOS 18 and lower) sits at the top of the screen and provides contextual information
 /// and controls related to the current view.
 /// It typically displays the page title, and may include navigation actions such as "Back" or "Close" as well as supplementary actions.
-/// It can contains leading, principal (center), and trailing actions.
+/// It can contains leading, principal (center, single item only), and trailing actions.
 ///
 /// ## Appearances
 ///
@@ -69,9 +69,7 @@ import SwiftUI
 ///             leadingItems: {
 ///                 OUDSToolBarItem(navigation: .back())
 ///             },
-///             principalItems: {
-///                 OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ }
-///             },
+///             principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ },
 ///             trailingItems: {
 ///                 OUDSToolBarItem(label: "Label") { /* Action to process */ }
 ///                 OUDSToolBarItem(icon: Image(decorative: "some_image"), accessibilityLabel: "Label") { /* Action to process */ }
@@ -82,7 +80,7 @@ import SwiftUI
 /// A `View` helper can also be used to apply a SwiftUI toolbar configuration.
 ///
 /// ```swift
-///     toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)
+///     toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItem:trailingItems:)
 /// ```
 ///
 /// ## Design documentation
@@ -151,8 +149,8 @@ public struct OUDSToolBarTop: ViewModifier {
     private let subtitle: String?
     /// The items to display in leading position
     @OUDSToolBarItemsBuilder private let leadingItems: () -> [OUDSToolBarItem]
-    /// The items to display in principal (center) position
-    @OUDSToolBarItemsBuilder private let principalItems: () -> [OUDSToolBarItem]
+    /// The item to display in principal (center) position (only one item supported)
+    private let principalItem: OUDSToolBarItem?
     /// The items to display in trailing position
     @OUDSToolBarItemsBuilder private let trailingItems: () -> [OUDSToolBarItem]
 
@@ -160,15 +158,13 @@ public struct OUDSToolBarTop: ViewModifier {
 
     /// `ViewModifier` to define an OUDS top toolbar.
     ///
-    ///  You should prefer `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)` on view placed
+    ///  You should prefer `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItem:trailingItems:)` on view placed
     ///  inside `NavigationView` or`NavigationStack`.
     ///
     /// ```swift
     ///     OUDSToolBarTop(title: "Home") {
     ///         OUDSToolBarItem(navigation: .back { })
-    ///     } principalItems: {
-    ///         OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { }
-    ///     } trailingItems: {
+    ///     } principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { } trailingItems: {
     ///         OUDSToolBarItem(label: "Done") { }
     ///     }
     /// ```
@@ -178,20 +174,20 @@ public struct OUDSToolBarTop: ViewModifier {
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed
     ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
-    ///   - principalItems: The items displayed in the principal (center) position, *empty* by default.
+    ///   - principalItem: The item displayed in the principal (center) position, *nil* by default. Only one item is supported.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     public init(title: String,
                 hasLargeTitle: Bool = false,
                 subtitle: String? = nil,
                 leadingItems: @escaping () -> [OUDSToolBarItem] = { [] },
-                principalItems: @escaping () -> [OUDSToolBarItem] = { [] },
+                principalItem: OUDSToolBarItem? = nil,
                 trailingItems: @escaping () -> [OUDSToolBarItem] = { [] })
     {
         self.title = title
         self.hasLargeTitle = hasLargeTitle
         self.subtitle = subtitle
         self.leadingItems = leadingItems
-        self.principalItems = principalItems
+        self.principalItem = principalItem
         self.trailingItems = trailingItems
     }
 
@@ -202,7 +198,7 @@ public struct OUDSToolBarTop: ViewModifier {
                            hasLargeTitle: hasLargeTitle,
                            subtitle: subtitle,
                            leadingItems: leadingItems,
-                           principalItems: principalItems,
+                           principalItem: principalItem,
                            trailingItems: trailingItems)
     }
 }
@@ -223,21 +219,21 @@ extension View {
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed for iOS < 26.
     ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
-    ///   - principalItems: The items displayed in the principal (center) position, *empty* by default.
+    ///   - principalItem: The item displayed in the principal (center) position, *nil* by default. Only one item is supported.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     @available(iOS 15, visionOS 1, *)
     public func toolBarTop(_ title: String,
                            hasLargeTitle: Bool = false,
                            subtitle: String? = nil,
                            @OUDSToolBarItemsBuilder leadingItems: @escaping () -> [OUDSToolBarItem] = { [] },
-                           @OUDSToolBarItemsBuilder principalItems: @escaping () -> [OUDSToolBarItem] = { [] },
+                           principalItem: OUDSToolBarItem? = nil,
                            @OUDSToolBarItemsBuilder trailingItems: @escaping () -> [OUDSToolBarItem] = { [] }) -> some View
     {
         modifier(ToolBarTopModifier(title: title,
                                     hasLargeTitle: hasLargeTitle,
                                     subtitle: subtitle,
                                     leadingItems: leadingItems,
-                                    principalItems: principalItems,
+                                    principalItem: principalItem,
                                     trailingItems: trailingItems))
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -21,7 +21,7 @@ import SwiftUI
 /// The top toolbar (aka *navigation bar* on iOS and iPadOS 18 and lower) sits at the top of the screen and provides contextual information
 /// and controls related to the current view.
 /// It typically displays the page title, and may include navigation actions such as "Back" or "Close" as well as supplementary actions.
-/// It can contains leading, principal (center, single item only), and trailing actions.
+/// It can contain leading, principal (center, single item only), and trailing actions.
 ///
 /// **Warning**: If an item is placed in principal position, the subtitle is never displayed (whatever `hasLargeTitle` is), because
 /// SwiftUI's `.principal` placement only replaces the inline compact bar title, not `.navigationSubtitle()` (iOS 26+), which would
@@ -169,7 +169,9 @@ public struct OUDSToolBarTop: ViewModifier {
     /// ```swift
     ///     OUDSToolBarTop(title: "Home") {
     ///         OUDSToolBarItem(navigation: .back { })
-    ///     } principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { } trailingItems: {
+    ///     },
+    ///     principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { },
+    ///     trailingItems: {
     ///         OUDSToolBarItem(label: "Done") { }
     ///     }
     /// ```

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -20,10 +20,8 @@ import SwiftUI
 
 /// The top toolbar (aka *navigation bar* on iOS and iPadOS 18 and lower) sits at the top of the screen and provides contextual information
 /// and controls related to the current view.
-/// It typically displays the page title, and may include navigation actions such as “Back” or "Close" as well as supplementary actions.
-/// It can contains leading and trailing actions.
-///
-/// `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)`  View helper applies a SwiftUI toolbar configuration.
+/// It typically displays the page title, and may include navigation actions such as "Back" or "Close" as well as supplementary actions.
+/// It can contains leading, principal (center), and trailing actions.
 ///
 /// ## Appearances
 ///
@@ -71,11 +69,20 @@ import SwiftUI
 ///             leadingItems: {
 ///                 OUDSToolBarItem(navigation: .back())
 ///             },
+///             principalItems: {
+///                 OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ }
+///             },
 ///             trailingItems: {
 ///                 OUDSToolBarItem(label: "Label") { /* Action to process */ }
 ///                 OUDSToolBarItem(icon: Image(decorative: "some_image"), accessibilityLabel: "Label") { /* Action to process */ }
 ///             }
 ///         )
+/// ```
+///
+/// A `View` helper can also be used to apply a SwiftUI toolbar configuration.
+///
+/// ```swift
+///     toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)
 /// ```
 ///
 /// ## Design documentation
@@ -144,6 +151,8 @@ public struct OUDSToolBarTop: ViewModifier {
     private let subtitle: String?
     /// The items to display in leading position
     @OUDSToolBarItemsBuilder private let leadingItems: () -> [OUDSToolBarItem]
+    /// The items to display in principal (center) position
+    @OUDSToolBarItemsBuilder private let principalItems: () -> [OUDSToolBarItem]
     /// The items to display in trailing position
     @OUDSToolBarItemsBuilder private let trailingItems: () -> [OUDSToolBarItem]
 
@@ -151,12 +160,14 @@ public struct OUDSToolBarTop: ViewModifier {
 
     /// `ViewModifier` to define an OUDS top toolbar.
     ///
-    ///  You should prefer `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:trailingItems:)` on view placed
+    ///  You should prefer `toolBarTop(_:hasLargeTitle:subtitle:leadingItems:principalItems:trailingItems:)` on view placed
     ///  inside `NavigationView` or`NavigationStack`.
     ///
     /// ```swift
     ///     OUDSToolBarTop(title: "Home") {
     ///         OUDSToolBarItem(navigation: .back { })
+    ///     } principalItems: {
+    ///         OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { }
     ///     } trailingItems: {
     ///         OUDSToolBarItem(label: "Done") { }
     ///     }
@@ -167,17 +178,20 @@ public struct OUDSToolBarTop: ViewModifier {
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed
     ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
+    ///   - principalItems: The items displayed in the principal (center) position, *empty* by default.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     public init(title: String,
                 hasLargeTitle: Bool = false,
                 subtitle: String? = nil,
                 leadingItems: @escaping () -> [OUDSToolBarItem] = { [] },
+                principalItems: @escaping () -> [OUDSToolBarItem] = { [] },
                 trailingItems: @escaping () -> [OUDSToolBarItem] = { [] })
     {
         self.title = title
         self.hasLargeTitle = hasLargeTitle
         self.subtitle = subtitle
         self.leadingItems = leadingItems
+        self.principalItems = principalItems
         self.trailingItems = trailingItems
     }
 
@@ -188,6 +202,7 @@ public struct OUDSToolBarTop: ViewModifier {
                            hasLargeTitle: hasLargeTitle,
                            subtitle: subtitle,
                            leadingItems: leadingItems,
+                           principalItems: principalItems,
                            trailingItems: trailingItems)
     }
 }
@@ -196,7 +211,7 @@ public struct OUDSToolBarTop: ViewModifier {
 
 extension View {
 
-    /// Creates a top toolbar with a title, optional subtitle (for iOS 26+), leading and trailing items.
+    /// Creates a top toolbar with a title, optional subtitle (for iOS 26+), leading, principal and trailing items.
     ///
     /// The view which contains this *top toolbar* must be placed inside a `NavigationView` or `NavigationStack`,
     /// otherwise th top toolbar won't appear..
@@ -208,18 +223,21 @@ extension View {
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed for iOS < 26.
     ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
+    ///   - principalItems: The items displayed in the principal (center) position, *empty* by default.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     @available(iOS 15, visionOS 1, *)
     public func toolBarTop(_ title: String,
                            hasLargeTitle: Bool = false,
                            subtitle: String? = nil,
                            @OUDSToolBarItemsBuilder leadingItems: @escaping () -> [OUDSToolBarItem] = { [] },
+                           @OUDSToolBarItemsBuilder principalItems: @escaping () -> [OUDSToolBarItem] = { [] },
                            @OUDSToolBarItemsBuilder trailingItems: @escaping () -> [OUDSToolBarItem] = { [] }) -> some View
     {
         modifier(ToolBarTopModifier(title: title,
                                     hasLargeTitle: hasLargeTitle,
                                     subtitle: subtitle,
                                     leadingItems: leadingItems,
+                                    principalItems: principalItems,
                                     trailingItems: trailingItems))
     }
 }

--- a/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
+++ b/OUDS/Core/Components/Sources/Navigations/ToolBar/OUDSToolBarTop.swift
@@ -23,6 +23,11 @@ import SwiftUI
 /// It typically displays the page title, and may include navigation actions such as "Back" or "Close" as well as supplementary actions.
 /// It can contains leading, principal (center, single item only), and trailing actions.
 ///
+/// **Warning**: If an item is placed in principal position, the subtitle is never displayed (whatever `hasLargeTitle` is), because
+/// SwiftUI's `.principal` placement only replaces the inline compact bar title, not `.navigationSubtitle()` (iOS 26+), which would
+/// otherwise keep rendering next to the item with no visible title next to it. The title itself is displayed only if `hasLargeTitle`
+/// is `true` (in that case it appears below the bar, in large title mode, not inside it).
+///
 /// ## Appearances
 ///
 /// With Liquid Glass / iOS 26+ the OS will change the rendering of the toolbar items depending to the context:
@@ -172,9 +177,10 @@ public struct OUDSToolBarTop: ViewModifier {
     /// - Parameters:
     ///   - title: The toolbar title. Prefer a non-empty string.
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed
-    ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
+    ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default. **Never displayed if `principalItem` is not *nil*.**
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
     ///   - principalItem: The item displayed in the principal (center) position, *nil* by default. Only one item is supported.
+    ///     If set, the *title* is displayed only if `hasLargeTitle` is `true`, and the *subtitle* is never displayed.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     public init(title: String,
                 hasLargeTitle: Bool = false,
@@ -214,12 +220,18 @@ extension View {
     ///
     /// There must be only one *top toolbar*.
     ///
+    /// **Warning**: If an item is placed in principal position, the subtitle is never displayed (whatever `hasLargeTitle` is), because
+    /// SwiftUI's `.principal` placement only replaces the inline compact bar title, not `.navigationSubtitle()` (iOS 26+), which would
+    /// otherwise keep rendering next to the item with no visible title next to it. The title itself is displayed only if `hasLargeTitle`
+    /// is `true` (in that case it appears below the bar, in large title mode, not inside it).
+    ///
     /// - Parameters:
     ///   - title: The toolbar title. Prefer a non-empty string.
     ///   - hasLargeTitle: If *title* must be displayed in large mode or not, *false* by default. If large mode, the *subtitle* is not displayed for iOS < 26.
-    ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default.
+    ///   - subtitle: Optional *subtitle* displayed below the *title* if iOS 26+, *nil* by default. **Never displayed if `principalItem` is not *nil*.**
     ///   - leadingItems: The items displayed on the leading side, *empty* by default.
     ///   - principalItem: The item displayed in the principal (center) position, *nil* by default. Only one item is supported.
+    ///     If set, the *title* is displayed only if `hasLargeTitle` is `true`, and the *subtitle* is never displayed.
     ///   - trailingItems: The items displayed on the trailing side, *empty* by default.
     @available(iOS 15, visionOS 1, *)
     public func toolBarTop(_ title: String,

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -424,9 +424,7 @@ NavigationStack {
                         // Back button — system dismiss is automatic, no closure needed
                         OUDSToolBarItem(navigation: .back())
                     },
-                    principalItems: {
-                        OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ }
-                    },
+                    principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ },
                     trailingItems: {
                         OUDSToolBarItem(label: "Label") { /* Action to process */ }
                         OUDSToolBarItem(icon: Image(decorative: "some_image"), accessibilityLabel: "Label") { /* Action to process */ }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -424,6 +424,9 @@ NavigationStack {
                         // Back button — system dismiss is automatic, no closure needed
                         OUDSToolBarItem(navigation: .back())
                     },
+                    principalItems: {
+                        OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { /* Action to process */ }
+                    },
                     trailingItems: {
                         OUDSToolBarItem(label: "Label") { /* Action to process */ }
                         OUDSToolBarItem(icon: Image(decorative: "some_image"), accessibilityLabel: "Label") { /* Action to process */ }

--- a/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
+++ b/OUDS/Core/Components/Sources/_OUDSComponents.docc/Navigations.md
@@ -415,6 +415,11 @@ There are different style depending to Liquid Glass (iOS 26+) or not (iOS 18 and
     }
 }
 
+> **Principal item**: at most one item can be placed in the principal (center) position with `principalItem:`. When a `principalItem`
+> is set, the subtitle is **never** displayed (whatever `hasLargeTitle` is), because SwiftUI's `.principal` placement only replaces
+> the inline compact bar title, not `.navigationSubtitle()` (iOS 26+), which would otherwise keep floating with no visible title next
+> to it. The title itself is displayed only if `hasLargeTitle` is `true`, in which case it appears below the bar (large title mode).
+
 ```swift
 // Apply once on the root NavigationStack to style the system navigation bar
 NavigationStack {
@@ -431,6 +436,17 @@ NavigationStack {
                     })
 }
 .oudsNavigationBarAppearance() // required — apply on the NavigationStack, not on the child view
+
+// Principal item + hasLargeTitle: title is displayed below the bar (large mode), subtitle is never displayed
+SomeView()
+    .toolBarTop("Title",
+                hasLargeTitle: true,
+                subtitle: "This subtitle will never be shown because a principalItem is set",
+                principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { })
+
+// Principal item without hasLargeTitle: neither title nor subtitle are displayed
+SomeView()
+    .toolBarTop("Title", principalItem: OUDSToolBarItem(icon: Image(decorative: "search"), accessibilityLabel: "Search") { })
 
 // Close button — .close takes NO closure, dismiss is handled automatically
 SomeView()

--- a/skills/ouds-ios-components-navigations/SKILL.md
+++ b/skills/ouds-ios-components-navigations/SKILL.md
@@ -52,6 +52,9 @@ OUDSTabBar {
 - Call `.oudsNavigationBarAppearance()` once on the root `NavigationStack`.
 - On iOS ≤ 18: add `.accentColor(theme.colors.contentDefault)` on root view for the back chevron.
 - `subtitle` rendered on iOS 26+ only; ignored when `hasLargeTitle: true`.
+- `principalItem` (at most one item, center position): when set, `subtitle` is **never** displayed (whatever `hasLargeTitle` is —
+  `.principal` only replaces the inline bar title, not `.navigationSubtitle()` on iOS 26+); `title` is displayed only if
+  `hasLargeTitle: true` (shown below the bar, large mode — never inside the bar next to `principalItem`).
 
 **Setup (bottom toolbar):**
 - Never combine with `OUDSTabBar` on the same screen.
@@ -73,6 +76,15 @@ NavigationStack {
                 OUDSToolBarItem(icon: Image("ic_settings"), accessibilityLabel: "Settings") {}
             })
 }
+
+// Top — principalItem + hasLargeTitle: title shown below the bar (large mode), subtitle never shown
+ContentView()
+    .toolBarTop("Title", hasLargeTitle: true, subtitle: "Never shown",
+        principalItem: OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") {})
+
+// Top — principalItem without hasLargeTitle: neither title nor subtitle shown
+ContentView()
+    .toolBarTop("Title", principalItem: OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") {})
 
 // Top — large title + subtitle (subtitle iOS 26+ only)
 ContentView().toolBarTop("Title", hasLargeTitle: true, subtitle: "Sub")

--- a/skills/ouds-ios-components-navigations/SKILL.md
+++ b/skills/ouds-ios-components-navigations/SKILL.md
@@ -68,6 +68,9 @@ NavigationStack {
     ContentView()
         .toolBarTop("Title",
             leadingItems: { OUDSToolBarItem(navigation: .back()) },
+            principalItems: {
+                OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") {}
+            },
             trailingItems: {
                 OUDSToolBarItem(icon: Image("ic_settings"), accessibilityLabel: "Settings") {}
             })
@@ -116,7 +119,11 @@ if #available(iOS 26, *) {
 OUDSToolBarItem { Menu("More") { Button("Option 1") {} } }
 
 // Conditional (result-builder syntax)
-.toolBarTop("Title", trailingItems: {
+.toolBarTop("Title", principalItems: {
+    if showSearch {
+        OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") { showSearch = false }
+    }
+}, trailingItems: {
     if isEditing {
         OUDSToolBarItem(label: "Done") { isEditing = false }
     } else {

--- a/skills/ouds-ios-components-navigations/SKILL.md
+++ b/skills/ouds-ios-components-navigations/SKILL.md
@@ -68,9 +68,7 @@ NavigationStack {
     ContentView()
         .toolBarTop("Title",
             leadingItems: { OUDSToolBarItem(navigation: .back()) },
-            principalItems: {
-                OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") {}
-            },
+            principalItem: OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") {},
             trailingItems: {
                 OUDSToolBarItem(icon: Image("ic_settings"), accessibilityLabel: "Settings") {}
             })
@@ -119,11 +117,7 @@ if #available(iOS 26, *) {
 OUDSToolBarItem { Menu("More") { Button("Option 1") {} } }
 
 // Conditional (result-builder syntax)
-.toolBarTop("Title", principalItems: {
-    if showSearch {
-        OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") { showSearch = false }
-    }
-}, trailingItems: {
+.toolBarTop("Title", principalItem: showSearch ? OUDSToolBarItem(icon: Image("ic_search"), accessibilityLabel: "Search") { showSearch = false } : nil, trailingItems: {
     if isEditing {
         OUDSToolBarItem(label: "Done") { isEditing = false }
     } else {


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1721 

### Description

<!-- Describe your changes in detail -->
Update API to define toolbar item to place in `principal` location

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->
Let isers add their own view in principal location of toolbar

### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- New feature (non-breaking change which adds functionality)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- [x] My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [x] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
