### PR TITLE
[#1744] Erratic focus flickering between fields when typing in `PIN code input` component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Erratic focus flickering between fields when typing in `PIN code input` component (Orange-OpenSource/ouds-ios#1744)
 - Vocalization of accessibility trait for `navigation list item` component (Orange-OpenSource/ouds-ios#1718)
 - Vocalization of `warning` and `negative` statuses of `progress indicators` components (Orange-OpenSource/ouds-ios#1697)
 - Vocalization of `progress indicators` components (Orange-OpenSource/ouds-ios#1698)

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
@@ -39,18 +39,9 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
     let index: Int
     let a11yLabel: String
     let a11yValue: String
-    /// Whether this field is the one currently expected to be the first responder.
-    ///
-    /// SwiftUI's `@FocusState` does not always reliably drive `becomeFirstResponder()` on a
-    /// `UITextField` hosted through `UIViewRepresentable`, especially when the focus change is
-    /// programmatic (e.g. autofocus on appear, or moving to the next digit after a keystroke).
-    ///
-    /// This flag lets `updateUIView` explicitly call `becomeFirstResponder()` on the underlying
-    /// `UITextField` when it should be focused. We deliberately do NOT call
-    /// `resignFirstResponder()` when this flag is `false`: on iOS/FKA the focus loss is driven by
-    /// the user (Tab, tap on another view…) and forcing `resignFirstResponder()` here would fight
-    /// against the system.
     let isFocused: Bool
+    let shouldResignFocus: Bool
+    let onFocusChanged: (Bool) -> Void
     let onBackspace: () -> Void
     let onTextInserted: (String) -> Void
 
@@ -64,6 +55,7 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         let textField = BackspaceTextField()
 
         textField.delegate = context.coordinator
+        context.coordinator.onFocusChanged = onFocusChanged
         textField.keyboardType = .numberPad
         textField.textAlignment = .center
         textField.onTextInserted = onTextInserted
@@ -95,6 +87,7 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         // Always refresh callbacks in case the closures captured new values after a SwiftUI re-render
         uiView.onBackspace = onBackspace
         uiView.onTextInserted = onTextInserted
+        context.coordinator.onFocusChanged = onFocusChanged
 
         // Only update the displayed text if it actually changed, to avoid unnecessary UIKit updates
         if uiView.text != displayText {
@@ -106,29 +99,14 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         uiView.accessibilityLabel = a11yLabel
         uiView.accessibilityValue = a11yValue
 
-        // Explicit first responder acquisition.
-        //
-        // Required because SwiftUI's `@FocusState` bound via `.focused($focusedIndex, equals:)`
-        // does not always relay focus changes down to a `UITextField` hosted inside a
-        // `UIViewRepresentable`. This is particularly noticeable for:
-        // - the initial autofocus on appear,
-        // - the auto-advance to the next digit after a keystroke,
-        // - the auto-recede to the previous digit after a backspace.
-        //
-        // We do NOT force `resignFirstResponder()` on `isFocused == false`: focus loss is driven
-        // by the user (Tab in Full Keyboard Access, tap on another view…) and forcing resignation
-        // would fight against the system.
-        //
-        // The call is synchronous (not dispatched to a later run loop turn): `becomeFirstResponder()`
-        // is a plain UIKit call, it does not mutate any SwiftUI state, so there is no "Modifying
-        // state during view update" concern here. Deferring it with `DispatchQueue.main.async`
-        // used to queue up several stale closures (one per SwiftUI re-render happening in the same
-        // update cycle) whose `!uiView.isFirstResponder` check was only valid at scheduling time;
-        // once several of them piled up for different fields, they could run out of order and make
-        // the focus visibly bounce between fields before settling. Calling it synchronously removes
-        // that race entirely: `updateUIView` always reflects the current desired focus state.
+        uiView.shouldBeFocused = isFocused
         if isFocused, !uiView.isFirstResponder {
-            _ = uiView.becomeFirstResponder()
+            DispatchQueue.main.async { [weak uiView] in
+                guard let uiView, uiView.shouldBeFocused, !uiView.isFirstResponder else { return }
+                _ = uiView.becomeFirstResponder()
+            }
+        } else if shouldResignFocus, uiView.isFirstResponder {
+            _ = uiView.resignFirstResponder()
         }
     }
 
@@ -146,6 +124,7 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
 
         @Binding var text: String
         let index: Int
+        var onFocusChanged: ((Bool) -> Void)?
 
         init(text: Binding<String>, index: Int) {
             _text = text
@@ -153,6 +132,14 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         }
 
         deinit {}
+
+        func textFieldDidBeginEditing(_ textField: UITextField) {
+            onFocusChanged?(true)
+        }
+
+        func textFieldDidEndEditing(_ textField: UITextField) {
+            onFocusChanged?(false)
+        }
 
         /// Called when the text field's text is about to change.
         ///
@@ -204,6 +191,9 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
 /// together after a short silence (50ms), allowing the parent to handle them as a complete code.
 @MainActor
 final class BackspaceTextField: UITextField {
+
+    /// The latest focus requested by SwiftUI. Deferred focus work checks this value before running.
+    var shouldBeFocused = false
 
     /// Callback triggered when the backspace key is pressed.
     var onBackspace: (() -> Void)?

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInput+Backspace.swift
@@ -119,11 +119,16 @@ struct BackspaceDetectingTextField: UIViewRepresentable {
         // by the user (Tab in Full Keyboard Access, tap on another view…) and forcing resignation
         // would fight against the system.
         //
-        // Dispatch async to avoid mutating focus during a SwiftUI layout pass.
+        // The call is synchronous (not dispatched to a later run loop turn): `becomeFirstResponder()`
+        // is a plain UIKit call, it does not mutate any SwiftUI state, so there is no "Modifying
+        // state during view update" concern here. Deferring it with `DispatchQueue.main.async`
+        // used to queue up several stale closures (one per SwiftUI re-render happening in the same
+        // update cycle) whose `!uiView.isFirstResponder` check was only valid at scheduling time;
+        // once several of them piled up for different fields, they could run out of order and make
+        // the focus visibly bounce between fields before settling. Calling it synchronously removes
+        // that race entirely: `updateUIView` always reflects the current desired focus state.
         if isFocused, !uiView.isFirstResponder {
-            DispatchQueue.main.async {
-                _ = uiView.becomeFirstResponder()
-            }
+            _ = uiView.becomeFirstResponder()
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -41,20 +41,6 @@ struct PinCodeInputContainer: View {
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
-    // MARK: - Black magic
-
-    // These properties prevent double backspace processing by tracking which field was cleared and when.
-    // When a backspace occurs, we mark the field index and timestamp, then skip onChange events
-    // for that field within 100ms to avoid processing the same backspace twice.
-    // \("˚☐˚)/ ⊹₊⟡⋆
-
-    // swiftlint:disable implicit_optional_initialization
-    /// Tracks which field index was last cleared by a backspace operation
-    @State private var lastBackspaceIndex: Int? = nil
-    /// Tracks when the last backspace operation occurred (used for debouncing)
-    @State private var lastBackspaceTime: Date = .distantPast
-    // swiftlint:enable implicit_optional_initialization
-
     // MARK: - Initializer
 
     init(_ value: Binding<String>,
@@ -239,86 +225,10 @@ struct PinCodeInputContainer: View {
             .focused($focusedIndex, equals: index)
             .padding(.vertical, theme.textInput.spacePaddingBlockDefault)
             .padding(.horizontal, theme.textInput.spacePaddingInlineDefault)
-        #if os(visionOS)
-            .onChange(of: digits[index]) { _, newValue in
-                let timeSinceLastBackspace = Date().timeIntervalSince(lastBackspaceTime)
-                if lastBackspaceIndex == index, timeSinceLastBackspace < 0.1 {
-                    return
-                }
-                handleDigitChange(at: index, newValue: newValue)
-            }
-        #else
-            .onChange(of: digits[index]) { newValue in
-                let timeSinceLastBackspace = Date().timeIntervalSince(lastBackspaceTime)
-                if lastBackspaceIndex == index, timeSinceLastBackspace < 0.1 {
-                    return
-                }
-                handleDigitChange(at: index, newValue: newValue)
-            }
-        #endif
         #else
         // NOTE: Source code must be compilable on macOS to build the doc...
         EmptyView()
         #endif
-    }
-
-    /// To handle the written data:
-    /// 1. Filters the input to only allow digits (0-9)
-    /// 2. If more than one digit is received (e.g. autofill), distributes them across fields
-    /// 3. Moves focus to the next field when a single digit is entered
-    /// 4. Updates the final value binding when all fields are filled
-    ///
-    /// - Parameters:
-    ///    - index: The index of the field
-    ///    - newValue: The new value written in the field
-    private func handleDigitChange(at index: Int, newValue: String) { //  \("˚☐˚)/ ⊹₊⟡⋆
-        let filtered = newValue.filter(\.isNumber)
-
-        // Autofill / paste case: more than one digit received
-        if filtered.count > 1 {
-            let available = length.rawValue - index
-            let toDistribute = filtered.prefix(available)
-
-            for (offset, char) in toDistribute.enumerated() {
-                digits[index + offset] = String(char)
-            }
-
-            let joined = digits.joined()
-            if joined.count == length.rawValue, !digits.contains("") {
-                value = joined
-                focusedIndex = nil
-            } else {
-                value = ""
-                let nextIndex = index + toDistribute.count
-                focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
-            }
-            return
-        }
-
-        // Normal typing: single digit
-        let single = String(filtered.prefix(1))
-
-        // If filtering changed the value, update and return (triggers onChange again)
-        if single != newValue {
-            digits[index] = single
-            return
-        }
-
-        if single.count == 1 {
-            digits[index] = single
-
-            let joined = digits.joined()
-            if joined.count == length.rawValue, !digits.contains("") {
-                value = joined
-                focusedIndex = nil
-            } else if index < length.rawValue - 1 {
-                focusedIndex = index + 1
-                value = ""
-                announceFocusChanged(forInputAt: index + 1)
-            } else {
-                value = ""
-            }
-        }
     }
 
     /// To handle the backspace button, i.e. the keyboard feature to go back and remove
@@ -336,19 +246,15 @@ struct PinCodeInputContainer: View {
         let wasEmpty = digits[index].isEmpty
 
         DispatchQueue.main.async {
-            lastBackspaceTime = Date()
-
             if wasEmpty {
                 if index > 0 {
                     let previousIndex = index - 1
-                    lastBackspaceIndex = previousIndex
                     digits[previousIndex] = ""
                     value = ""
                     focusedIndex = previousIndex
                     announceFocusChanged(forInputAt: previousIndex)
                 }
             } else {
-                lastBackspaceIndex = index
                 digits[index] = ""
                 value = ""
                 focusedIndex = index
@@ -380,6 +286,7 @@ struct PinCodeInputContainer: View {
             value = ""
             let nextIndex = index + toDistribute.count
             focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
+            announceFocusChanged(forInputAt: focusedIndex ?? nextIndex)
         }
     }
 

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/Internal/PinCodeInputContainer.swift
@@ -32,7 +32,7 @@ struct PinCodeInputContainer: View {
     private let autofocus: Bool
 
     /// To manage the focus between all fields
-    @FocusState private var focusedIndex: Int?
+    @State private var focusedIndex: Int?
     /// The digits written one by one by the user before being exposed through `value`
     @State private var digits: [String]
 
@@ -214,21 +214,32 @@ struct PinCodeInputContainer: View {
             a11yLabel: accessibilityLabel(for: index),
             a11yValue: accessibilityValue(for: index),
             isFocused: focusedIndex == index,
+            shouldResignFocus: focusedIndex == nil,
+            onFocusChanged: { isFocused in
+                handleFocusChange(isFocused, at: index)
+            },
             onBackspace: {
                 handleBackspace(at: index)
             },
-            onTextInserted: { inserted in // ← nouveau
+            onTextInserted: { inserted in
                 handleTextInserted(inserted, at: index)
             })
             .foregroundColor(theme.colors.contentDefault)
             .accentColor(theme.colors.contentDefault)
-            .focused($focusedIndex, equals: index)
             .padding(.vertical, theme.textInput.spacePaddingBlockDefault)
             .padding(.horizontal, theme.textInput.spacePaddingInlineDefault)
         #else
         // NOTE: Source code must be compilable on macOS to build the doc...
         EmptyView()
         #endif
+    }
+
+    private func handleFocusChange(_ isFocused: Bool, at index: Int) {
+        if isFocused {
+            focusedIndex = index
+        } else if focusedIndex == index {
+            focusedIndex = nil
+        }
     }
 
     /// To handle the backspace button, i.e. the keyboard feature to go back and remove
@@ -263,7 +274,7 @@ struct PinCodeInputContainer: View {
         }
     }
 
-    /// Manages any text insertion: one figit (normal typing) or several (autofill, keyboard suggestions, copy/paste).
+    /// Manages any text insertion: one digit (normal typing) or several (autofill, keyboard suggestions, copy/paste).
     ///
     /// - Parameters:
     ///   - text: The chain of digits inserted (filtered, only figures)
@@ -276,11 +287,8 @@ struct PinCodeInputContainer: View {
             digits[index + offset] = String(char)
         }
 
-        let joined = digits.joined()
-        let allFilled = joined.count == length.rawValue && !digits.contains("")
-
-        if allFilled {
-            value = joined
+        if let completedValue = Self.completedValue(from: digits, length: length.rawValue) {
+            value = completedValue
             focusedIndex = nil
         } else {
             value = ""
@@ -288,6 +296,12 @@ struct PinCodeInputContainer: View {
             focusedIndex = nextIndex < length.rawValue ? nextIndex : length.rawValue - 1
             announceFocusChanged(forInputAt: focusedIndex ?? nextIndex)
         }
+    }
+
+    static func completedValue(from digits: [String], length: Int) -> String? {
+        let activeDigits = digits.prefix(length)
+        guard activeDigits.count == length, activeDigits.allSatisfy({ !$0.isEmpty }) else { return nil }
+        return activeDigits.joined()
     }
 
     private func announceFocusChanged(forInputAt index: Int) {

--- a/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
+++ b/OUDS/Core/Components/Sources/Controls/PinCodeInput/OUDSPinCodeInput.swift
@@ -298,6 +298,7 @@ public struct OUDSPinCodeInput: View {
         VStack(alignment: .leading, spacing: theme.spaces.fixedNone) {
             VStack(alignment: .leading, spacing: theme.spaces.fixedNone) {
                 PinCodeInputContainer(_value, length: length, isError: status != .enabled, isOutlined: isOutlined, autofocus: autofocus)
+                    .id(length)
 
                 PinCodeHelperErrorTextContainer(helperText: helperText, status: status)
             }

--- a/OUDS/Core/Components/Tests/Controls/PinCodeInput/OUDSPinCodeInputTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/PinCodeInput/OUDSPinCodeInputTests.swift
@@ -14,8 +14,10 @@
 #if !os(watchOS) && !os(macOS)
 @testable import OUDSComponents
 import Testing
+import UIKit
 
 /// Tests some API for `OUDSPinCodeInput`
+@MainActor
 struct OUDSPinCodeInputTests {
 
     /// Test the raw values for the length of the component
@@ -29,6 +31,50 @@ struct OUDSPinCodeInputTests {
     @Test func `pin code input predefined symbols`() {
         #expect(OUDSPinCodeInput.obfuscationCharacter == "●")
         #expect(OUDSPinCodeInput.placeholderCharacter == "-")
+    }
+
+    @Test func `text field delegate reports focus changes`() {
+        let coordinator = BackspaceDetectingTextField.Coordinator(text: .constant(""), index: 0)
+        var focusChanges: [Bool] = []
+        coordinator.onFocusChanged = { focusChanges.append($0) }
+        let textField = UITextField()
+
+        coordinator.textFieldDidBeginEditing(textField)
+        coordinator.textFieldDidEndEditing(textField)
+
+        #expect(focusChanges == [true, false])
+    }
+
+    @Test func `backspace triggers one callback`() {
+        let textField = BackspaceTextField()
+        var backspaceCount = 0
+        textField.onBackspace = { backspaceCount += 1 }
+
+        textField.deleteBackward()
+
+        #expect(backspaceCount == 1)
+    }
+
+    @Test func `pasted digits are forwarded together`() async throws {
+        let textField = BackspaceTextField()
+        var insertedText = ""
+        textField.onTextInserted = { insertedText = $0 }
+
+        textField.accumulate(digit: "123456")
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        #expect(insertedText == "123456")
+    }
+
+    @Test func `completed value only uses active digits`() {
+        #expect(PinCodeInputContainer.completedValue(from: ["1", "2", "3", "4"], length: 4) == "1234")
+        #expect(PinCodeInputContainer.completedValue(from: ["1", "2", "3", "4", "5", "6"], length: 6) == "123456")
+        #expect(PinCodeInputContainer.completedValue(from: ["1", "2", "3", "4", "5", "6", "7", "8"], length: 8) == "12345678")
+        #expect(PinCodeInputContainer.completedValue(from: ["1", "2", "3", "4", "", ""], length: 4) == "1234")
+    }
+
+    @Test func `incomplete value is not exposed`() {
+        #expect(PinCodeInputContainer.completedValue(from: ["1", "2", "3", ""], length: 4) == nil)
     }
 }
 #endif

--- a/OUDS/Core/Components/Tests/Controls/PinCodeInput/OUDSPinCodeInputTests.swift
+++ b/OUDS/Core/Components/Tests/Controls/PinCodeInput/OUDSPinCodeInputTests.swift
@@ -11,7 +11,7 @@
 // Software description: A SwiftUI components library with code examples for Orange Unified Design System
 //
 
-#if !os(watchOS) && !os(macOS)
+#if !os(watchOS) && !os(tvOS) && !os(macOS)
 @testable import OUDSComponents
 import Testing
 import UIKit


### PR DESCRIPTION
_Note: Please transform `- [ ]` into `- (NA)` in the description when things are not applicable_

### Related issues

<!-- Please link any related issues here. -->
#1744

### Description

<!-- Describe your changes in detail -->
Review management of focus and binding between fields

### Motivation & Context

<!-- Why is this change required? What problem does it solve? -->

 ### Types of change

<!-- What types of changes do your code introduce? -->
<!-- Please remove the unused items in the list -->

- Bug fix (non-breaking which fixes an issue)

### Previews

<!-- Please add screenshots or videos showing your evolutions -->

### Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Note that any checkboxes not optional must be ticked by an 'x' (or '(NA)') and our [branch ruleset](https://github.com/marketplace/task-list-completed) may block any merge if some mandatory boxes remain empty -->
<!-- Your branch used to submit the evolutions must be prefixed by the issue number like 666-add-some-feature -->

#### Contribution

- [x] I have read the [contributing guidelines](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CONTRIBUTING.md)

#### Accessibility

- [x] My change follows accessibility good practices

#### Design

- (NA) My change respects the design guidelines of _Orange Unified Design System_

#### Development

- [x] My change follows the [developer guide](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/DEVELOP.md)
- [x] I checked my changes do not add new SwiftLint warnings
- [ ] <!-- OPTIONAL --> I have added unit tests to cover my changes _(optional)_

#### Documentation

- [x] My change introduces changes to the documentation and/or I have updated the documentation accordingly

### Checklist (for Core Team only)

- [x] The evolution have been tested and the project builds for iPhones and iPads
- [ ] Code review has been done by reviewers according to [CODEOWNERS file](https://github.com/Orange-OpenSource/ouds-ios/blob/develop/.github/CODEOWNERS)
- (NA) Design review has been done
- (NA) Accessibility review has been done
- (NA) Q/A team has tested the evolution
- [x] Documentation has been updated if relevant
- [x] Internal files have been updated if relevant (like CONTRIBUTING, DEVELOP, THIRD_PARTY, CONTRIBUTORS, NOTICE)
- [x] CHANGELOG has been updated respecting [keep a changelog rules](https://keepachangelog.com/en/1.0.0/) and reference the issues
- [ ] <!-- OPTIONAL --> [The wiki](https://github.com/Orange-OpenSource/ouds-ios/wiki) has been updated if needed _(optional)_
